### PR TITLE
docs: exclude non-public directories from Doxygen documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules
 ) #location for custom "Modules"
 
+include(CMakeDependentOption)
 include(VolkBuildTypes)
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
@@ -152,29 +153,6 @@ if(VOLK_CPU_FEATURES)
     endif()
 else()
     message(STATUS "Building Volk without cpu_features")
-endif()
-
-# fmt - required for qa_utils table printing
-# For static builds, always use FetchContent to ensure we get a static library
-if(NOT ENABLE_STATIC_LIBS)
-    find_package(fmt QUIET)
-endif()
-if(NOT fmt_FOUND)
-    if(ENABLE_STATIC_LIBS)
-        message(STATUS "Static build: using FetchContent to build fmt as static library ...")
-    else()
-        message(STATUS "fmt package not found. Using FetchContent to download ...")
-    endif()
-    include(FetchContent)
-    FetchContent_Declare(
-        fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 10.2.1
-        GIT_SHALLOW TRUE)
-    set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
-    set(BUILD_SHARED_LIBS OFF)
-    FetchContent_MakeAvailable(fmt)
-    set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 endif()
 
 # Python
@@ -348,9 +326,46 @@ endif()
 message(STATUS "  Modify using: -DENABLE_TESTING=ON/OFF")
 
 ########################################################################
+# Utility apps (rely on an OS being present instead of a bare-metal target)
+########################################################################
+option(ENABLE_UTILITY_APPS "Enable utility apps" ON)
+if(ENABLE_UTILITY_APPS)
+    message(STATUS "Utility apps are enabled.")
+else()
+    message(STATUS "Utility apps are disabled.")
+endif()
+
+# fmt - required for qa_utils table printing (tests and utility apps)
+# For static builds, always use FetchContent to ensure we get a static library
+if(ENABLE_TESTING OR ENABLE_UTILITY_APPS)
+    if(NOT ENABLE_STATIC_LIBS)
+        find_package(fmt QUIET)
+    endif()
+    if(NOT fmt_FOUND)
+        if(ENABLE_STATIC_LIBS)
+            message(
+                STATUS "Static build: using FetchContent to build fmt as static library ...")
+        else()
+            message(STATUS "fmt package not found. Using FetchContent to download ...")
+        endif()
+        include(FetchContent)
+        FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG 12.1.0
+            GIT_SHALLOW TRUE)
+        set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+        set(BUILD_SHARED_LIBS OFF)
+        FetchContent_MakeAvailable(fmt)
+        set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
+    endif()
+endif()
+
+########################################################################
 # Option to enable post-build profiling using volk_profile, off by default
 ########################################################################
-option(ENABLE_PROFILING "Launch system profiler after build" OFF)
+cmake_dependent_option(ENABLE_PROFILING "Launch system profiler after build" OFF
+                       "ENABLE_UTILITY_APPS" OFF)
 if(ENABLE_PROFILING)
     if(DEFINED VOLK_CONFIGPATH)
         get_filename_component(VOLK_CONFIGPATH ${VOLK_CONFIGPATH} ABSOLUTE)
@@ -384,9 +399,12 @@ add_subdirectory(lib)
 add_subdirectory(tests)
 
 ########################################################################
-# And the utility apps
+# Utility apps
 ########################################################################
-add_subdirectory(apps)
+if(ENABLE_UTILITY_APPS)
+    add_subdirectory(apps)
+endif()
+
 option(ENABLE_MODTOOL "Enable volk_modtool python utility" True)
 if(ENABLE_MODTOOL)
     add_subdirectory(python/volk_modtool)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -953,7 +953,14 @@ EXCLUDE                = @CMAKE_BINARY_DIR@ \
                          @CMAKE_SOURCE_DIR@/cpu_features \
                          @CMAKE_SOURCE_DIR@/include/volk/sse2neon \
                          @CMAKE_SOURCE_DIR@/README.md \
-                         @CMAKE_SOURCE_DIR@/docs/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+                         @CMAKE_SOURCE_DIR@/docs/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md \
+                         @CMAKE_SOURCE_DIR@/cmake \
+                         @CMAKE_SOURCE_DIR@/apps \
+                         @CMAKE_SOURCE_DIR@/lib/qa_utils.cc \
+                         @CMAKE_SOURCE_DIR@/lib/qa_utils.h \
+                         @CMAKE_SOURCE_DIR@/lib/testqa.cc \
+                         @CMAKE_SOURCE_DIR@/tmpl \
+                         @CMAKE_SOURCE_DIR@/gen
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
## Summary

Expand the `EXCLUDE` list in `docs/Doxyfile.in` to skip directories and
files that are not part of the public library API. Complements the
`STRIP_FROM_PATH` fix in gnuradio/volk#598 — while #598 prevents
absolute paths from leaking into output, this removes files that
shouldn't be documented at all.

| Path | Contents | Why exclude |
|------|----------|-------------|
| `cmake/` | CMake modules (FindORC, VolkVersion, etc.) | Build infrastructure |
| `apps/` | CLI tools (volk_profile, volk_modtool) | Developer/build tools, not library API |
| `lib/qa_utils.cc` | Test harness utilities | Internal test infrastructure |
| `lib/qa_utils.h` | Test harness header | Internal test infrastructure |
| `lib/testqa.cc` | Test runner | Internal test infrastructure |
| `tmpl/` | Code generation templates | Build-time codegen |
| `gen/` | Code generation scripts | Build-time codegen |

Note: `lib/qa_utils.h` is included by `lib/kernel_tests.h`, so
downstream projects adding custom kernels could reference it. If
reviewers feel it should remain documented, it can be removed from the
exclusion list without affecting other entries.

## Related issues

Addresses mtibbits/volk#3

## Testing

- Built docs with `cmake --build build --target volk_doc`
- Verified `qa_utils`, `testqa`, `volk_profile`, `volk_option_helpers`, `tmpl`, and `gen` pages are no longer generated
- Verified public kernel docs (e.g., `volk_32f_x2_dot_prod_32f`) still render

## Checklist

- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in