### PR TITLE
volk_option_helpers: validate arguments before consuming argv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules
 ) #location for custom "Modules"
 
+include(CMakeDependentOption)
 include(VolkBuildTypes)
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
@@ -152,29 +153,6 @@ if(VOLK_CPU_FEATURES)
     endif()
 else()
     message(STATUS "Building Volk without cpu_features")
-endif()
-
-# fmt - required for qa_utils table printing
-# For static builds, always use FetchContent to ensure we get a static library
-if(NOT ENABLE_STATIC_LIBS)
-    find_package(fmt QUIET)
-endif()
-if(NOT fmt_FOUND)
-    if(ENABLE_STATIC_LIBS)
-        message(STATUS "Static build: using FetchContent to build fmt as static library ...")
-    else()
-        message(STATUS "fmt package not found. Using FetchContent to download ...")
-    endif()
-    include(FetchContent)
-    FetchContent_Declare(
-        fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 10.2.1
-        GIT_SHALLOW TRUE)
-    set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
-    set(BUILD_SHARED_LIBS OFF)
-    FetchContent_MakeAvailable(fmt)
-    set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 endif()
 
 # Python
@@ -348,9 +326,46 @@ endif()
 message(STATUS "  Modify using: -DENABLE_TESTING=ON/OFF")
 
 ########################################################################
+# Utility apps (rely on an OS being present instead of a bare-metal target)
+########################################################################
+option(ENABLE_UTILITY_APPS "Enable utility apps" ON)
+if(ENABLE_UTILITY_APPS)
+    message(STATUS "Utility apps are enabled.")
+else()
+    message(STATUS "Utility apps are disabled.")
+endif()
+
+# fmt - required for qa_utils table printing (tests and utility apps)
+# For static builds, always use FetchContent to ensure we get a static library
+if(ENABLE_TESTING OR ENABLE_UTILITY_APPS)
+    if(NOT ENABLE_STATIC_LIBS)
+        find_package(fmt QUIET)
+    endif()
+    if(NOT fmt_FOUND)
+        if(ENABLE_STATIC_LIBS)
+            message(
+                STATUS "Static build: using FetchContent to build fmt as static library ...")
+        else()
+            message(STATUS "fmt package not found. Using FetchContent to download ...")
+        endif()
+        include(FetchContent)
+        FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG 12.1.0
+            GIT_SHALLOW TRUE)
+        set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+        set(BUILD_SHARED_LIBS OFF)
+        FetchContent_MakeAvailable(fmt)
+        set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
+    endif()
+endif()
+
+########################################################################
 # Option to enable post-build profiling using volk_profile, off by default
 ########################################################################
-option(ENABLE_PROFILING "Launch system profiler after build" OFF)
+cmake_dependent_option(ENABLE_PROFILING "Launch system profiler after build" OFF
+                       "ENABLE_UTILITY_APPS" OFF)
 if(ENABLE_PROFILING)
     if(DEFINED VOLK_CONFIGPATH)
         get_filename_component(VOLK_CONFIGPATH ${VOLK_CONFIGPATH} ABSOLUTE)
@@ -384,9 +399,12 @@ add_subdirectory(lib)
 add_subdirectory(tests)
 
 ########################################################################
-# And the utility apps
+# Utility apps
 ########################################################################
-add_subdirectory(apps)
+if(ENABLE_UTILITY_APPS)
+    add_subdirectory(apps)
+endif()
+
 option(ENABLE_MODTOOL "Enable volk_modtool python utility" True)
 if(ENABLE_MODTOOL)
     add_subdirectory(python/volk_modtool)

--- a/apps/volk_option_helpers.cc
+++ b/apps/volk_option_helpers.cc
@@ -11,6 +11,7 @@
 #include "volk_option_helpers.h"
 
 #include <limits.h>  // IWYU pragma: keep
+#include <cerrno>    // IWYU pragma: keep
 #include <cstdlib>   // IWYU pragma: keep
 #include <cstring>   // IWYU pragma: keep
 #include <exception> // for exception
@@ -108,12 +109,14 @@ void option_list::add(option_t opt) { d_internal_list.push_back(opt); }
 void option_list::parse(int argc, char** argv)
 {
     for (int arg_number = 0; arg_number < argc; ++arg_number) {
+        bool matched = false;
         for (std::vector<option_t>::iterator this_option = d_internal_list.begin();
              this_option != d_internal_list.end();
              this_option++) {
             int int_val = INT_MIN;
             if (this_option->longform == std::string(argv[arg_number]) ||
                 this_option->shortform == std::string(argv[arg_number])) {
+                matched = true;
 
                 if (d_present_options.count(this_option->longform) == 0) {
                     d_present_options.insert(
@@ -127,62 +130,86 @@ void option_list::parse(int argc, char** argv)
                     break;
                 case INT_CALLBACK:
                     try {
-                        int_val = atoi(argv[++arg_number]);
-                        ((void (*)(int))this_option->callback)(int_val);
+                        if (arg_number + 1 >= argc) {
+                            std::cerr << "Error: option '" << argv[arg_number]
+                                      << "' requires a value" << std::endl;
+                            exit(1);
+                        }
+                        {
+                            char* endptr = nullptr;
+                            errno = 0;
+                            long long_val = strtol(argv[++arg_number], &endptr, 10);
+                            if (endptr == argv[arg_number] || *endptr != '\0' ||
+                                errno == ERANGE || long_val < INT_MIN ||
+                                long_val > INT_MAX) {
+                                std::cerr << "Error: option '" << argv[arg_number - 1]
+                                          << "' requires a numeric value, got '"
+                                          << argv[arg_number] << "'" << std::endl;
+                                exit(1);
+                            }
+                            int_val = (int)long_val;
+                            ((void (*)(int))this_option->callback)(int_val);
+                        }
                     } catch (std::exception& exc) {
-                        std::cout << "An int option can only receive a number"
+                        std::cerr << "An int option can only receive a number"
                                   << std::endl;
                         throw std::exception();
                     };
                     break;
                 case FLOAT_CALLBACK:
                     try {
-                        double double_val = atof(argv[++arg_number]);
-                        ((void (*)(float))this_option->callback)(double_val);
+                        if (arg_number + 1 >= argc) {
+                            std::cerr << "Error: option '" << argv[arg_number]
+                                      << "' requires a value" << std::endl;
+                            exit(1);
+                        }
+                        {
+                            char* endptr = nullptr;
+                            double double_val = strtod(argv[++arg_number], &endptr);
+                            if (endptr == argv[arg_number] || *endptr != '\0') {
+                                std::cerr << "Error: option '" << argv[arg_number - 1]
+                                          << "' requires a numeric value, got '"
+                                          << argv[arg_number] << "'" << std::endl;
+                                exit(1);
+                            }
+                            ((void (*)(float))this_option->callback)(double_val);
+                        }
                     } catch (std::exception& exc) {
-                        std::cout << "A float option can only receive a number"
+                        std::cerr << "A float option can only receive a number"
                                   << std::endl;
                         throw std::exception();
                     };
                     break;
                 case BOOL_CALLBACK:
-                    try {
-                        if (arg_number == (argc - 1)) { // this is the last arg
+                    if (arg_number == (argc - 1)) {
+                        int_val = 1;
+                    } else {
+                        const char* next_arg = argv[arg_number + 1];
+                        if (strncmp(next_arg, "-", 1) == 0) {
                             int_val = 1;
-                        } else { // sneak a look at the next arg since it's present
-                            char* next_arg = argv[arg_number + 1];
-                            if ((strncmp(next_arg, "-", 1) == 0) ||
-                                (strncmp(next_arg, "--", 2) == 0)) {
-                                // the next arg is actually an arg, the bool is just
-                                // present, set to true
-                                int_val = 1;
-                            } else if (strncmp(next_arg, "true", 4) == 0) {
-                                int_val = 1;
-                            } else if (strncmp(next_arg, "false", 5) == 0) {
-                                int_val = 0;
-                            } else {
-                                // we got a number or a string.
-                                // convert it to a number and depend on the catch to
-                                // report an error condition
-                                int_val = (bool)atoi(argv[++arg_number]);
-                            }
+                        } else if (strncmp(next_arg, "true", 4) == 0) {
+                            int_val = 1;
+                            ++arg_number;
+                        } else if (strncmp(next_arg, "false", 5) == 0) {
+                            int_val = 0;
+                            ++arg_number;
+                        } else if (next_arg[0] >= '0' && next_arg[0] <= '9') {
+                            int_val = (bool)atoi(argv[++arg_number]);
+                        } else {
+                            int_val = 1;
                         }
-                    } catch (std::exception& e) {
-                        int_val = INT_MIN;
-                    };
-                    if (int_val == INT_MIN) {
-                        std::cout
-                            << "option: '" << argv[arg_number - 1]
-                            << "' -> received an unknown value. Boolean "
-                               "options should receive one of '0', '1', 'true', 'false'."
-                            << std::endl;
-                        throw std::exception();
-                    } else if (int_val) {
+                    }
+                    if (int_val) {
                         ((void (*)(bool))this_option->callback)(int_val);
                     }
                     break;
                 case STRING_CALLBACK:
                     try {
+                        if (arg_number + 1 >= argc) {
+                            std::cerr << "Error: option '" << argv[arg_number]
+                                      << "' requires a value" << std::endl;
+                            exit(1);
+                        }
                         ((void (*)(std::string))this_option->callback)(
                             argv[++arg_number]);
                     } catch (std::exception& exc) {
@@ -197,8 +224,13 @@ void option_list::parse(int argc, char** argv)
         }
         if (std::string("--help") == std::string(argv[arg_number]) ||
             std::string("-h") == std::string(argv[arg_number])) {
+            matched = true;
             d_present_options.insert(std::pair<std::string, int>("--help", 1));
             help();
+        }
+        if (!matched && arg_number > 0 && argv[arg_number][0] == '-') {
+            std::cerr << "Warning: unrecognized option '" << argv[arg_number] << "'"
+                      << std::endl;
         }
     }
 }


### PR DESCRIPTION
The argument parser in `volk_option_helpers.cc` crashes when any
value-taking flag (`-t`, `-v`, `-i`, `-w`, `-R`, `-j`, `-p`) is the
last argument — `argv[++arg_number]` reads past the end of `argv`.
Non-numeric strings for numeric flags are silently accepted (`atoi`
returns 0), and unrecognized flags are silently ignored.

Add bounds checks before consuming the next `argv` element. Replace
`atoi`/`atof` with `strtol`/`strtod` to detect non-numeric input.
Warn on unrecognized flags (warning, not error — preserves forward
compatibility with scripts using flags from newer versions). Simplify
`BOOL_CALLBACK` by removing the dead `try`/`catch` and `INT_MIN`
sentinel.

Range validation for semantically invalid values (negative vlen, zero
iterations) is tracked separately in fork #13 — different file,
different concern.

Fixes https://github.com/mtibbits/volk/issues/12