### PR TITLE
volk_rank_archs: widen impl_deps to uint64_t, fix name matching

### DIFF
--- a/lib/volk_rank_archs.c
+++ b/lib/volk_rank_archs.c
@@ -8,6 +8,7 @@
  */
 
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,22 +23,32 @@ int volk_get_index(const char* impl_names[], // list of implementations by name
 {
     unsigned int i;
     for (i = 0; i < n_impls; i++) {
-        if (!strncmp(impl_names[i], impl_name, 20)) {
+        if (!strcmp(impl_names[i], impl_name)) {
             return i;
         }
     }
-    // TODO return -1;
-    // something terrible should happen here
-    fprintf(stderr, "Volk warning: no arch found, returning generic impl\n");
-    return volk_get_index(impl_names, n_impls, "generic"); // but we'll fake it for now
+    // requested impl not found -- try falling back to "generic"
+    if (strcmp(impl_name, "generic") != 0) {
+        fprintf(stderr,
+                "Volk warning: arch '%s' not found, returning generic impl\n",
+                impl_name);
+        for (i = 0; i < n_impls; i++) {
+            if (!strcmp(impl_names[i], "generic")) {
+                return i;
+            }
+        }
+    }
+    // neither requested impl nor "generic" found -- return first available
+    fprintf(stderr, "Volk warning: no generic impl found, returning index 0\n");
+    return 0;
 }
 
-int volk_rank_archs(const char* kern_name,    // name of the kernel to rank
-                    const char* impl_names[], // list of implementations by name
-                    const int* impl_deps,     // requirement mask per implementation
-                    const bool* alignment,    // alignment status of each implementation
-                    size_t n_impls,           // number of implementations available
-                    const bool align          // if false, filter aligned implementations
+int volk_rank_archs(const char* kern_name,       // name of the kernel to rank
+                    const char* impl_names[],    // list of implementations by name
+                    const uint64_t* impl_deps,   // requirement mask per implementation
+                    const bool* alignment,       // alignment status of each implementation
+                    size_t n_impls,              // number of implementations available
+                    const bool align             // if false, filter aligned implementations
 )
 {
     size_t i;
@@ -78,10 +89,10 @@ int volk_rank_archs(const char* kern_name,    // name of the kernel to rank
     // return the best index with the largest deps
     size_t best_index_a = 0;
     size_t best_index_u = 0;
-    int best_value_a = -1;
-    int best_value_u = -1;
+    int64_t best_value_a = -1;
+    int64_t best_value_u = -1;
     for (i = 0; i < n_impls; i++) {
-        const signed val = impl_deps[i];
+        const int64_t val = (int64_t)impl_deps[i];
         if (alignment[i] && val > best_value_a) {
             best_index_a = i;
             best_value_a = val;

--- a/lib/volk_rank_archs.h
+++ b/lib/volk_rank_archs.h
@@ -11,6 +11,7 @@
 #define INCLUDED_VOLK_RANK_ARCHS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus
@@ -22,12 +23,12 @@ int volk_get_index(const char* impl_names[], // list of implementations by name
                    const char* impl_name     // the implementation name to find
 );
 
-int volk_rank_archs(const char* kern_name,    // name of the kernel to rank
-                    const char* impl_names[], // list of implementations by name
-                    const int* impl_deps,     // requirement mask per implementation
-                    const bool* alignment,    // alignment status of each implementation
-                    size_t n_impls,           // number of implementations available
-                    const bool align          // if false, filter aligned implementations
+int volk_rank_archs(const char* kern_name,       // name of the kernel to rank
+                    const char* impl_names[],    // list of implementations by name
+                    const uint64_t* impl_deps,   // requirement mask per implementation
+                    const bool* alignment,       // alignment status of each implementation
+                    size_t n_impls,              // number of implementations available
+                    const bool align             // if false, filter aligned implementations
 );
 
 #ifdef __cplusplus

--- a/tmpl/volk.tmpl.c
+++ b/tmpl/volk.tmpl.c
@@ -29,7 +29,7 @@ struct volk_machine *get_machine(void)
   if(machine != NULL)
     return machine;
   else {
-    unsigned int max_score = 0;
+    uint64_t max_score = 0;
     unsigned int i;
     struct volk_machine *max_machine = NULL;
     for(i=0; i<n_volk_machines; i++) {
@@ -71,7 +71,7 @@ const char* volk_get_machine(void)
   if(machine != NULL)
     return machine->name;
   else {
-    unsigned int max_score = 0;
+    uint64_t max_score = 0;
     unsigned int i;
     struct volk_machine *max_machine = NULL;
     for(i=0; i<n_volk_machines; i++) {
@@ -133,7 +133,7 @@ static inline void __init_${kern.name}(void)
 {
     const char *name = get_machine()->${kern.name}_name;
     const char **impl_names = get_machine()->${kern.name}_impl_names;
-    const int *impl_deps = get_machine()->${kern.name}_impl_deps;
+    const uint64_t *impl_deps = get_machine()->${kern.name}_impl_deps;
     const bool *alignment = get_machine()->${kern.name}_impl_alignment;
     const size_t n_impls = get_machine()->${kern.name}_n_impls;
     const size_t index_a = volk_rank_archs(name, impl_names, impl_deps, alignment, n_impls, true/*aligned*/);
@@ -188,7 +188,7 @@ void ${kern.name}_manual(${kern.arglist_full}, const char* impl_name)
 
 volk_func_desc_t ${kern.name}_get_func_desc(void) {
     const char **impl_names = get_machine()->${kern.name}_impl_names;
-    const int *impl_deps = get_machine()->${kern.name}_impl_deps;
+    const uint64_t *impl_deps = get_machine()->${kern.name}_impl_deps;
     const bool *alignment = get_machine()->${kern.name}_impl_alignment;
     const size_t n_impls = get_machine()->${kern.name}_n_impls;
     volk_func_desc_t desc = {

--- a/tmpl/volk.tmpl.h
+++ b/tmpl/volk.tmpl.h
@@ -25,7 +25,7 @@ __VOLK_DECL_BEGIN
 typedef struct volk_func_desc
 {
     const char **impl_names;
-    const int *impl_deps;
+    const uint64_t *impl_deps;
     const bool *impl_alignment;
     size_t n_impls;
 } volk_func_desc_t;

--- a/tmpl/volk_cpu.tmpl.c
+++ b/tmpl/volk_cpu.tmpl.c
@@ -96,11 +96,11 @@ void volk_cpu_init() {
     set_float_rounding();
 }
 
-unsigned int volk_get_lvarch() {
-    unsigned int retval = 0;
+uint64_t volk_get_lvarch() {
+    uint64_t retval = 0;
     volk_cpu_init();
     %for arch in archs:
-    retval += volk_cpu.has_${arch.name}() << LV_${arch.name.upper()};
+    retval += (uint64_t)volk_cpu.has_${arch.name}() << LV_${arch.name.upper()};
     %endfor
     return retval;
 }

--- a/tmpl/volk_cpu.tmpl.h
+++ b/tmpl/volk_cpu.tmpl.h
@@ -23,7 +23,7 @@ struct VOLK_CPU {
 extern struct VOLK_CPU volk_cpu;
 
 void volk_cpu_init ();
-unsigned int volk_get_lvarch ();
+uint64_t volk_get_lvarch ();
 
 __VOLK_DECL_END
 

--- a/tmpl/volk_machine_xxx.tmpl.c
+++ b/tmpl/volk_machine_xxx.tmpl.c
@@ -27,7 +27,7 @@
 %endfor
 
 struct volk_machine volk_machine_${this_machine.name} = {
-<% make_arch_have_list = (' | '.join(['(1 << LV_%s)'%a.name.upper() for a in this_machine.archs])) %>    ${make_arch_have_list},
+<% make_arch_have_list = (' | '.join(['(UINT64_C(1) << LV_%s)'%a.name.upper() for a in this_machine.archs])) %>    ${make_arch_have_list},
 <% this_machine_name = "\""+this_machine.name+"\"" %>    ${this_machine_name},
     ${this_machine.alignment},
 ##//list all kernels
@@ -38,7 +38,7 @@ struct volk_machine volk_machine_${this_machine.name} = {
 ##//list of kernel implementations by name
 <% make_impl_name_list = "{"+', '.join(['"%s"'%i.name for i in impls])+"}" %>    ${make_impl_name_list},
 ##//list of arch dependencies per implementation
-<% make_impl_deps_list = "{"+', '.join([' | '.join(['(1 << LV_%s)'%d.upper() for d in i.deps]) for i in impls])+"}" %>    ${make_impl_deps_list},
+<% make_impl_deps_list = "{"+', '.join([' | '.join(['(UINT64_C(1) << LV_%s)'%d.upper() for d in i.deps]) for i in impls])+"}" %>    ${make_impl_deps_list},
 ##//alignment required? for each implementation
 <% make_impl_align_list = "{"+', '.join(['true' if i.is_aligned else 'false' for i in impls])+"}" %>    ${make_impl_align_list},
 ##//pointer to each implementation

--- a/tmpl/volk_machines.tmpl.h
+++ b/tmpl/volk_machines.tmpl.h
@@ -19,13 +19,13 @@
 __VOLK_DECL_BEGIN
 
 struct volk_machine {
-    const unsigned int caps; //capabilities (i.e., archs compiled into this machine, in the volk_get_lvarch format)
+    const uint64_t caps; //capabilities (i.e., archs compiled into this machine, in the volk_get_lvarch format)
     const char *name;
     const size_t alignment; //the maximum byte alignment required for functions in this library
     %for kern in kernels:
     const char *${kern.name}_name;
     const char *${kern.name}_impl_names[<%len_archs=len(archs)%>${len_archs}];
-    const int ${kern.name}_impl_deps[${len_archs}];
+    const uint64_t ${kern.name}_impl_deps[${len_archs}];
     const bool ${kern.name}_impl_alignment[${len_archs}];
     const ${kern.pname} ${kern.name}_impls[${len_archs}];
     const size_t ${kern.name}_n_impls;


### PR DESCRIPTION
The architecture dispatcher uses `int` (32-bit signed) for implementation
dependency bitmasks. With 28 architectures defined and indices 0-27, only
3 spare bits remain before signed overflow. `volk_get_index` truncates
implementation names at 20 characters via `strncmp` and recurses
infinitely when an implementation is not found.

Widen `impl_deps` from `int` to `uint64_t` in `volk_rank_archs` and all
codegen templates. Widen `volk_get_lvarch` return type and `volk_machine`
caps field to match. Use `UINT64_C(1)` for ISA flag shifts. Replace
`strncmp` with `strcmp` for exact name matching. Replace the recursive
fallback in `volk_get_index` with a bounded linear search for "generic",
then index 0.

**ABI note:** Two public API types change:
- `volk_func_desc_t.impl_deps` (`const int*` to `const uint64_t*`) in
  `volk.h`. The `get_func_desc()` functions that expose this struct are
  already `__attribute__((deprecated))`.
- `volk_get_lvarch()` return type (`unsigned int` to `uint64_t`) in
  `volk_cpu.h`. This function is public and not deprecated. Downstream
  code storing the result in `unsigned int` will silently truncate on
  systems with >32 ISA flags. This change should coincide with a
  version bump.

Fixes https://github.com/mtibbits/volk/issues/16
Related: https://github.com/gnuradio/volk/issues/516