### PR TITLE
qa_utils: warm each arch before timed measurement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules
 ) #location for custom "Modules"
 
+include(CMakeDependentOption)
 include(VolkBuildTypes)
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
@@ -152,29 +153,6 @@ if(VOLK_CPU_FEATURES)
     endif()
 else()
     message(STATUS "Building Volk without cpu_features")
-endif()
-
-# fmt - required for qa_utils table printing
-# For static builds, always use FetchContent to ensure we get a static library
-if(NOT ENABLE_STATIC_LIBS)
-    find_package(fmt QUIET)
-endif()
-if(NOT fmt_FOUND)
-    if(ENABLE_STATIC_LIBS)
-        message(STATUS "Static build: using FetchContent to build fmt as static library ...")
-    else()
-        message(STATUS "fmt package not found. Using FetchContent to download ...")
-    endif()
-    include(FetchContent)
-    FetchContent_Declare(
-        fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 10.2.1
-        GIT_SHALLOW TRUE)
-    set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
-    set(BUILD_SHARED_LIBS OFF)
-    FetchContent_MakeAvailable(fmt)
-    set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 endif()
 
 # Python
@@ -348,9 +326,46 @@ endif()
 message(STATUS "  Modify using: -DENABLE_TESTING=ON/OFF")
 
 ########################################################################
+# Utility apps (rely on an OS being present instead of a bare-metal target)
+########################################################################
+option(ENABLE_UTILITY_APPS "Enable utility apps" ON)
+if(ENABLE_UTILITY_APPS)
+    message(STATUS "Utility apps are enabled.")
+else()
+    message(STATUS "Utility apps are disabled.")
+endif()
+
+# fmt - required for qa_utils table printing (tests and utility apps)
+# For static builds, always use FetchContent to ensure we get a static library
+if(ENABLE_TESTING OR ENABLE_UTILITY_APPS)
+    if(NOT ENABLE_STATIC_LIBS)
+        find_package(fmt QUIET)
+    endif()
+    if(NOT fmt_FOUND)
+        if(ENABLE_STATIC_LIBS)
+            message(
+                STATUS "Static build: using FetchContent to build fmt as static library ...")
+        else()
+            message(STATUS "fmt package not found. Using FetchContent to download ...")
+        endif()
+        include(FetchContent)
+        FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG 12.1.0
+            GIT_SHALLOW TRUE)
+        set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+        set(BUILD_SHARED_LIBS OFF)
+        FetchContent_MakeAvailable(fmt)
+        set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
+    endif()
+endif()
+
+########################################################################
 # Option to enable post-build profiling using volk_profile, off by default
 ########################################################################
-option(ENABLE_PROFILING "Launch system profiler after build" OFF)
+cmake_dependent_option(ENABLE_PROFILING "Launch system profiler after build" OFF
+                       "ENABLE_UTILITY_APPS" OFF)
 if(ENABLE_PROFILING)
     if(DEFINED VOLK_CONFIGPATH)
         get_filename_component(VOLK_CONFIGPATH ${VOLK_CONFIGPATH} ABSOLUTE)
@@ -384,9 +399,12 @@ add_subdirectory(lib)
 add_subdirectory(tests)
 
 ########################################################################
-# And the utility apps
+# Utility apps
 ########################################################################
-add_subdirectory(apps)
+if(ENABLE_UTILITY_APPS)
+    add_subdirectory(apps)
+endif()
+
 option(ENABLE_MODTOOL "Enable volk_modtool python utility" True)
 if(ENABLE_MODTOOL)
     add_subdirectory(python/volk_modtool)

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -1088,43 +1088,50 @@ bool run_volk_tests(volk_func_desc_t desc,
         g_warmup_done = true;
     }
 
-    // Reset all test buffers after warmup
-    for (size_t i = 0; i < arch_list.size(); i++) {
-        for (size_t j = 0; j < outputsig.size(); j++) {
-            memset(test_data[i][j],
-                   0,
-                   vlen * outputsig[j].size * (outputsig[j].is_complex ? 2 : 1));
+    // Zero output buffers and reload input buffers from the original data
+    // for every arch. Used between warmup and timed runs.
+    auto reset_test_buffers = [&]() {
+        for (size_t i = 0; i < arch_list.size(); i++) {
+            for (size_t j = 0; j < outputsig.size(); j++) {
+                memset(test_data[i][j],
+                       0,
+                       vlen * outputsig[j].size * (outputsig[j].is_complex ? 2 : 1));
+            }
+            for (size_t j = 0; j < inputsig.size(); j++) {
+                memcpy(test_data[i][outputsig.size() + j],
+                       inbuffs[j],
+                       vlen * inputsig[j].size * (inputsig[j].is_complex ? 2 : 1));
+            }
         }
-        // Reload input buffers from original data
-        for (size_t j = 0; j < inputsig.size(); j++) {
-            memcpy(test_data[i][outputsig.size() + j],
-                   inbuffs[j],
-                   vlen * inputsig[j].size * (inputsig[j].is_complex ? 2 : 1));
-        }
-    }
+    };
 
-    for (size_t i = 0; i < arch_list.size(); i++) {
-        start = std::chrono::system_clock::now();
+    // Reset all test buffers after the global CPU-frequency warmup.
+    reset_test_buffers();
 
+    // Dispatch one timed run of arch index `i` with `n_iter` iterations.
+    auto run_one_arch = [&](size_t i, unsigned int n_iter) {
         switch (both_sigs.size()) {
         case 1:
             if (inputsc.size() == 0) {
-                run_cast_test1(
-                    (volk_fn_1arg)(manual_func), test_data[i], vlen, iter, arch_list[i]);
+                run_cast_test1((volk_fn_1arg)(manual_func),
+                               test_data[i],
+                               vlen,
+                               n_iter,
+                               arch_list[i]);
             } else if (inputsc.size() == 1 && inputsc[0].is_float) {
                 if (inputsc[0].is_complex) {
                     run_cast_test1_s32fc((volk_fn_1arg_s32fc)(manual_func),
                                          test_data[i],
                                          scalar,
                                          vlen,
-                                         iter,
+                                         n_iter,
                                          arch_list[i]);
                 } else {
                     run_cast_test1_s32f((volk_fn_1arg_s32f)(manual_func),
                                         test_data[i],
                                         scalar.real(),
                                         vlen,
-                                        iter,
+                                        n_iter,
                                         arch_list[i]);
                 }
             } else
@@ -1132,22 +1139,25 @@ bool run_volk_tests(volk_func_desc_t desc,
             break;
         case 2:
             if (inputsc.size() == 0) {
-                run_cast_test2(
-                    (volk_fn_2arg)(manual_func), test_data[i], vlen, iter, arch_list[i]);
+                run_cast_test2((volk_fn_2arg)(manual_func),
+                               test_data[i],
+                               vlen,
+                               n_iter,
+                               arch_list[i]);
             } else if (inputsc.size() == 1 && inputsc[0].is_float) {
                 if (inputsc[0].is_complex) {
                     run_cast_test2_s32fc((volk_fn_2arg_s32fc)(manual_func),
                                          test_data[i],
                                          scalar,
                                          vlen,
-                                         iter,
+                                         n_iter,
                                          arch_list[i]);
                 } else {
                     run_cast_test2_s32f((volk_fn_2arg_s32f)(manual_func),
                                         test_data[i],
                                         scalar.real(),
                                         vlen,
-                                        iter,
+                                        n_iter,
                                         arch_list[i]);
                 }
             } else
@@ -1155,22 +1165,25 @@ bool run_volk_tests(volk_func_desc_t desc,
             break;
         case 3:
             if (inputsc.size() == 0) {
-                run_cast_test3(
-                    (volk_fn_3arg)(manual_func), test_data[i], vlen, iter, arch_list[i]);
+                run_cast_test3((volk_fn_3arg)(manual_func),
+                               test_data[i],
+                               vlen,
+                               n_iter,
+                               arch_list[i]);
             } else if (inputsc.size() == 1 && inputsc[0].is_float) {
                 if (inputsc[0].is_complex) {
                     run_cast_test3_s32fc((volk_fn_3arg_s32fc)(manual_func),
                                          test_data[i],
                                          scalar,
                                          vlen,
-                                         iter,
+                                         n_iter,
                                          arch_list[i]);
                 } else {
                     run_cast_test3_s32f((volk_fn_3arg_s32f)(manual_func),
                                         test_data[i],
                                         scalar.real(),
                                         vlen,
-                                        iter,
+                                        n_iter,
                                         arch_list[i]);
                 }
             } else
@@ -1178,14 +1191,32 @@ bool run_volk_tests(volk_func_desc_t desc,
             break;
         case 4:
             run_cast_test4(
-                (volk_fn_4arg)(manual_func), test_data[i], vlen, iter, arch_list[i]);
+                (volk_fn_4arg)(manual_func), test_data[i], vlen, n_iter, arch_list[i]);
             break;
         default:
             throw "no function handler for this signature";
             break;
         }
+    };
 
+    // Per-arch warmup pass: run each arch once with iter=1 so ORC JIT
+    // compilation, instruction caches, and branch predictors are warm
+    // before the timed measurement. The generic arch is intentionally
+    // included even though g_warmup_done covers it; the cost is one
+    // extra single-iteration call. Fixes gnuradio/volk#203.
+    for (size_t i = 0; i < arch_list.size(); i++) {
+        run_one_arch(i, 1);
+    }
+
+    // Reset all test buffers after the per-arch warmup pass.
+    reset_test_buffers();
+
+    // Timed measurement pass.
+    for (size_t i = 0; i < arch_list.size(); i++) {
+        start = std::chrono::system_clock::now();
+        run_one_arch(i, iter);
         end = std::chrono::system_clock::now();
+
         std::chrono::duration<double> elapsed_seconds = end - start;
         double arch_time = 1000.0 * elapsed_seconds.count();
 


### PR DESCRIPTION
ORC kernels JIT-compile on first invocation. The current per-arch
timing loop measures each architecture once with `iter` iterations,
so an ORC kernel's measured time includes its compilation overhead
(often >1 second). The existing warmup only runs the `"generic"`
implementation, so non-generic archs (including ORC) are never warmed.

Extract the per-arch dispatch into a `run_one_arch` lambda and the
buffer reset into a `reset_test_buffers` lambda. Replace the single
timed loop with three explicit steps:

1. Warmup pass — run each arch once with `iter=1` so ORC JIT
   compilation, instruction caches, and branch predictors are warm
2. Reset all test buffers
3. Timed pass — time each arch with the original `iter` and record

The lambda extraction also lets the existing post-CPU-warmup buffer
reset reuse the same helper, eliminating the duplication that would
otherwise exist between the two reset call sites.

Per jdemel's comment on the issue: "our profiling should just make
one or several calls to the benchmarked function before the actual
measurements."

Verified on `volk_16u_byteswappuppet_16u`: `u_orc` time drops from
>1 second to ~14ms, comparable to other architectures. Non-ORC
kernels see no measurable change in their reported timings.

Fixes https://github.com/gnuradio/volk/issues/203