### PR TITLE
volk_modtool: prune VCS and __pycache__ from walk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules
 ) #location for custom "Modules"
 
+include(CMakeDependentOption)
 include(VolkBuildTypes)
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
@@ -152,29 +153,6 @@ if(VOLK_CPU_FEATURES)
     endif()
 else()
     message(STATUS "Building Volk without cpu_features")
-endif()
-
-# fmt - required for qa_utils table printing
-# For static builds, always use FetchContent to ensure we get a static library
-if(NOT ENABLE_STATIC_LIBS)
-    find_package(fmt QUIET)
-endif()
-if(NOT fmt_FOUND)
-    if(ENABLE_STATIC_LIBS)
-        message(STATUS "Static build: using FetchContent to build fmt as static library ...")
-    else()
-        message(STATUS "fmt package not found. Using FetchContent to download ...")
-    endif()
-    include(FetchContent)
-    FetchContent_Declare(
-        fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 10.2.1
-        GIT_SHALLOW TRUE)
-    set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
-    set(BUILD_SHARED_LIBS OFF)
-    FetchContent_MakeAvailable(fmt)
-    set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 endif()
 
 # Python
@@ -348,9 +326,46 @@ endif()
 message(STATUS "  Modify using: -DENABLE_TESTING=ON/OFF")
 
 ########################################################################
+# Utility apps (rely on an OS being present instead of a bare-metal target)
+########################################################################
+option(ENABLE_UTILITY_APPS "Enable utility apps" ON)
+if(ENABLE_UTILITY_APPS)
+    message(STATUS "Utility apps are enabled.")
+else()
+    message(STATUS "Utility apps are disabled.")
+endif()
+
+# fmt - required for qa_utils table printing (tests and utility apps)
+# For static builds, always use FetchContent to ensure we get a static library
+if(ENABLE_TESTING OR ENABLE_UTILITY_APPS)
+    if(NOT ENABLE_STATIC_LIBS)
+        find_package(fmt QUIET)
+    endif()
+    if(NOT fmt_FOUND)
+        if(ENABLE_STATIC_LIBS)
+            message(
+                STATUS "Static build: using FetchContent to build fmt as static library ...")
+        else()
+            message(STATUS "fmt package not found. Using FetchContent to download ...")
+        endif()
+        include(FetchContent)
+        FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG 12.1.0
+            GIT_SHALLOW TRUE)
+        set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+        set(BUILD_SHARED_LIBS OFF)
+        FetchContent_MakeAvailable(fmt)
+        set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
+    endif()
+endif()
+
+########################################################################
 # Option to enable post-build profiling using volk_profile, off by default
 ########################################################################
-option(ENABLE_PROFILING "Launch system profiler after build" OFF)
+cmake_dependent_option(ENABLE_PROFILING "Launch system profiler after build" OFF
+                       "ENABLE_UTILITY_APPS" OFF)
 if(ENABLE_PROFILING)
     if(DEFINED VOLK_CONFIGPATH)
         get_filename_component(VOLK_CONFIGPATH ${VOLK_CONFIGPATH} ABSOLUTE)
@@ -384,9 +399,12 @@ add_subdirectory(lib)
 add_subdirectory(tests)
 
 ########################################################################
-# And the utility apps
+# Utility apps
 ########################################################################
-add_subdirectory(apps)
+if(ENABLE_UTILITY_APPS)
+    add_subdirectory(apps)
+endif()
+
 option(ENABLE_MODTOOL "Enable volk_modtool python utility" True)
 if(ENABLE_MODTOOL)
     add_subdirectory(python/volk_modtool)

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -10,6 +10,7 @@
 
 import os
 import re
+import sys
 import glob
 
 
@@ -87,13 +88,22 @@ class volk_modtool(object):
         need_ifdef_updates = ["constant.h", "volk_complex.h", "volk_malloc.h", "volk_prefs.h",
                               "volk_common.h", "volk_cpu.tmpl.h", "volk_config_fixed.tmpl.h",
                               "volk_typedefs.h", "volk.tmpl.h"]
+        # skip VCS metadata and Python bytecode caches so we don't try
+        # to read .git/index, *.pyc, etc. as UTF-8 text
+        skip_dirs = {'.git', '.hg', '.svn', '__pycache__'}
         for root, dirnames, filenames in os.walk(self.my_dict['base']):
+            dirnames[:] = [d for d in dirnames if d not in skip_dirs]
             for name in filenames:
                 t_table = [re.search(a, name) for a in current_kernel_names]
                 t_table = set(t_table)
                 if (t_table == set([None])) or (name == "volk_32f_null_32f.h"):
                     infile = os.path.join(root, name)
-                    instring = open(infile, 'r').read()
+                    try:
+                        instring = open(infile, 'r').read()
+                    except UnicodeDecodeError:
+                        print("volk_modtool: skipping non-UTF-8 file %s" % infile,
+                              file=sys.stderr)
+                        continue
                     outstring = re.sub(self.volk, 'volk_' + self.my_dict['name'], instring)
                     # Update the header ifdef guards only where needed
                     if name in need_ifdef_updates:


### PR DESCRIPTION
`volk_modtool make_module_skeleton()` walks every file under `base/`
and reads each as UTF-8 text. The first binary file it encounters in
`.git/` (typically `.git/index`) crashes the tool with
`UnicodeDecodeError`. The reporter's tree was a normal git clone, so
the crash reproduces from a fresh checkout.

Per jdemel's comment on the issue ("the correct fix here is to ignore
`.git` entirely"), prune `.git` (and the other common VCS metadata
directories `.hg` and `.svn`) from `os.walk`'s `dirnames` in place.
Also prune `__pycache__`: `volk_modtool` is shipped with VOLK itself,
which is a Python project, so every checkout grows `__pycache__/*.pyc`
the moment any module is imported, and without pruning the backstop
below would warn about every one of them on every run.

Add a `UnicodeDecodeError` guard around the per-file read as a
backstop for any other binary file under `base/` (e.g. an image asset
under `docs/`, a stray `.so`) and warn to `stderr` so the user can
see which files were skipped.

Verified on a clean clone of `gnuradio/volk` containing both `.git/`
and an existing CMake build directory: `make_module_skeleton()`
completes successfully, no `__pycache__` warnings, and the backstop
loudly reports the build directory binaries it encounters (a separate
pre-existing issue, not addressed here).

Fixes https://github.com/gnuradio/volk/issues/406