### PR TITLE
volk_profile: add -T / --trials flag for variability estimation

### DIFF
--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -36,6 +36,14 @@ std::vector<std::string> kernel_patterns;
 void set_substr(std::string val) { kernel_patterns.push_back(val); }
 bool update_mode = false;
 void set_update(bool val) { update_mode = val; }
+void set_trials(int val)
+{
+    if (val < 1) {
+        std::cerr << "volk_profile: --trials must be at least 1\n";
+        std::exit(1);
+    }
+    test_params.set_trials((unsigned int)val);
+}
 bool dry_run = false;
 void set_dryrun(bool val) { dry_run = val; }
 std::string json_filename("");
@@ -56,6 +64,12 @@ int main(int argc, char* argv[])
         option_t("vlen", "v", "Set the default vector length for tests", set_vlen));
     profile_options.add((option_t(
         "iter", "i", "Set the default number of test iterations per kernel", set_iter)));
+    profile_options.add(
+        (option_t("trials",
+                  "T",
+                  "Run the timed loop N times per kernel and report median + MAD "
+                  "(default 1; 10-30 recommended for a stable MAD estimate)",
+                  set_trials)));
     profile_options.add((option_t("tests-substr",
                                   "R",
                                   "Run tests matching substring (can be repeated)",

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -18,6 +18,7 @@
 #include <stdint.h>    // for uint16_t, uint64_t
 #include <sys/time.h>  // for CLOCKS_PER_SEC
 #include <sys/types.h> // for int16_t, int32_t
+#include <algorithm>   // for std::sort, std::minmax_element
 #include <chrono>
 #include <cmath>    // for sqrt, fabs, abs
 #include <cstring>  // for memcpy, memset
@@ -37,6 +38,33 @@ static bool g_warmup_done = false;
 double volk_test_get_warmup_ms() { return g_warmup_ms; }
 void volk_test_set_warmup_ms(double ms) { g_warmup_ms = ms; }
 void volk_test_reset_warmup() { g_warmup_done = false; }
+
+static double compute_median(std::vector<double> v)
+{
+    std::sort(v.begin(), v.end());
+    const size_t n = v.size();
+    if (n == 0) {
+        return 0.0;
+    }
+    if (n % 2 == 1) {
+        return v[n / 2];
+    }
+    return 0.5 * (v[n / 2 - 1] + v[n / 2]);
+}
+
+static double compute_mad(const std::vector<double>& v, double median)
+{
+    if (v.size() < 2) {
+        return 0.0;
+    }
+    std::vector<double> deviations;
+    deviations.reserve(v.size());
+    for (double x : v) {
+        deviations.push_back(std::fabs(x - median));
+    }
+    // 1.4826 scales MAD to a consistent estimator of σ under normality
+    return 1.4826 * compute_median(std::move(deviations));
+}
 
 template <typename T>
 void random_floats(void* buf, unsigned int n, std::default_random_engine& rnd_engine)
@@ -774,7 +802,8 @@ bool run_volk_tests(volk_func_desc_t desc,
                           test_params.absolute_mode(),
                           test_params.benchmark_mode(),
                           test_params.float_edge_cases(),
-                          test_params.complex_edge_cases());
+                          test_params.complex_edge_cases(),
+                          test_params.trials());
 }
 
 bool run_volk_tests(volk_func_desc_t desc,
@@ -789,7 +818,8 @@ bool run_volk_tests(volk_func_desc_t desc,
                     bool absolute_mode,
                     bool benchmark_mode,
                     const std::vector<float>& float_edge_cases,
-                    const std::vector<lv_32fc_t>& complex_edge_cases)
+                    const std::vector<lv_32fc_t>& complex_edge_cases,
+                    unsigned int trials)
 {
     // Initialize this entry in results vector
     results->push_back(volk_test_results_t());
@@ -1212,13 +1242,23 @@ bool run_volk_tests(volk_func_desc_t desc,
     reset_test_buffers();
 
     // Timed measurement pass.
-    for (size_t i = 0; i < arch_list.size(); i++) {
-        start = std::chrono::system_clock::now();
-        run_one_arch(i, iter);
-        end = std::chrono::system_clock::now();
+    std::vector<double> profile_mads(arch_list.size(), 0.0);
 
-        std::chrono::duration<double> elapsed_seconds = end - start;
-        double arch_time = 1000.0 * elapsed_seconds.count();
+    for (size_t i = 0; i < arch_list.size(); i++) {
+        std::vector<double> arch_samples;
+        arch_samples.reserve(trials);
+
+        for (unsigned int t = 0; t < trials; t++) {
+            start = std::chrono::system_clock::now();
+            run_one_arch(i, iter);
+            end = std::chrono::system_clock::now();
+
+            std::chrono::duration<double> elapsed_seconds = end - start;
+            arch_samples.push_back(1000.0 * elapsed_seconds.count());
+        }
+
+        double arch_time = compute_median(arch_samples);
+        profile_mads[i] = compute_mad(arch_samples, arch_time);
 
         volk_test_time_t result;
         result.name = arch_list[i];
@@ -1468,6 +1508,7 @@ bool run_volk_tests(volk_func_desc_t desc,
     constexpr int w_tput = 14;
     constexpr int w_speedup = 8;
     constexpr int w_err = 10;
+    constexpr int w_mad = 6;
 
     // Column header depends on error mode
     // Integer outputs always use absolute comparison, so show "max_abs" for them
@@ -1489,31 +1530,61 @@ bool run_volk_tests(volk_func_desc_t desc,
         return fmt::format("{:.1f} MB/s", mbps);
     };
 
-    // Print table header
-    fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} |\n",
-               "arch",
-               w_arch,
-               "time",
-               w_time,
-               "throughput",
-               w_tput,
-               "speedup",
-               w_speedup,
-               err_col,
-               w_err);
-    fmt::print("{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+\n",
-               "",
-               w_arch,
-               "",
-               w_time,
-               "",
-               w_tput,
-               "",
-               w_speedup,
-               "",
-               w_err);
+    // Print table header — Mode B adds a MAD% column and renames "time" to "median".
+    if (trials > 1) {
+        fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} |\n",
+                   "arch",
+                   w_arch,
+                   "median",
+                   w_time,
+                   "MAD%",
+                   w_mad,
+                   "throughput",
+                   w_tput,
+                   "speedup",
+                   w_speedup,
+                   err_col,
+                   w_err);
+        fmt::print("{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+\n",
+                   "",
+                   w_arch,
+                   "",
+                   w_time,
+                   "",
+                   w_mad,
+                   "",
+                   w_tput,
+                   "",
+                   w_speedup,
+                   "",
+                   w_err);
+    } else {
+        fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} |\n",
+                   "arch",
+                   w_arch,
+                   "time",
+                   w_time,
+                   "throughput",
+                   w_tput,
+                   "speedup",
+                   w_speedup,
+                   err_col,
+                   w_err);
+        fmt::print("{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+\n",
+                   "",
+                   w_arch,
+                   "",
+                   w_time,
+                   "",
+                   w_tput,
+                   "",
+                   w_speedup,
+                   "",
+                   w_err);
+    }
 
-    // Print each architecture row
+    // Print each architecture row — per-row computation is shared; only
+    // the fmt::print call differs (Mode B inserts the MAD% column).
     for (size_t i = 0; i < arch_list.size(); i++) {
         double time_seconds = profile_times[i] / 1000.0;
         double throughput_mbps = total_mb / time_seconds;
@@ -1532,18 +1603,39 @@ bool run_volk_tests(volk_func_desc_t desc,
         std::string win_str =
             (arch_list[i] == best_arch_a || arch_list[i] == best_arch_u) ? " *" : "";
 
-        fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} |{}\n",
-                   arch_list[i],
-                   w_arch,
-                   time_str,
-                   w_time,
-                   tput_str,
-                   w_tput,
-                   speedup_str,
-                   w_speedup,
-                   err_str,
-                   w_err,
-                   win_str);
+        if (trials > 1) {
+            std::string mad_str =
+                (profile_times[i] > 0.0)
+                    ? fmt::format("{:.1f}%", 100.0 * profile_mads[i] / profile_times[i])
+                    : std::string("-");
+            fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} |{}\n",
+                       arch_list[i],
+                       w_arch,
+                       time_str,
+                       w_time,
+                       mad_str,
+                       w_mad,
+                       tput_str,
+                       w_tput,
+                       speedup_str,
+                       w_speedup,
+                       err_str,
+                       w_err,
+                       win_str);
+        } else {
+            fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} |{}\n",
+                       arch_list[i],
+                       w_arch,
+                       time_str,
+                       w_time,
+                       tput_str,
+                       w_tput,
+                       speedup_str,
+                       w_speedup,
+                       err_str,
+                       w_err,
+                       win_str);
+        }
     }
 
     // Print best arch summary (left-aligned, ":" at arch column width)
@@ -1570,7 +1662,11 @@ bool run_volk_tests(volk_func_desc_t desc,
                           tol_f);
     }
 
-    fmt::print("{:-<88}\n", "");
+    if (trials > 1) {
+        fmt::print("{:-<97}\n", "");
+    } else {
+        fmt::print("{:-<88}\n", "");
+    }
 
     if (puppet_master_name == "NULL") {
         results->back().config_name = name;

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -66,6 +66,7 @@ private:
     lv_32fc_t _scalar;
     unsigned int _vlen;
     unsigned int _iter;
+    unsigned int _trials = 1;
     bool _benchmark_mode;
     bool _absolute_mode;
     std::string _kernel_regex;
@@ -92,6 +93,7 @@ public:
     void set_scalar(lv_32fc_t scalar) { _scalar = scalar; };
     void set_vlen(unsigned int vlen) { _vlen = vlen; };
     void set_iter(unsigned int iter) { _iter = iter; };
+    void set_trials(unsigned int trials) { _trials = trials; };
     void set_benchmark(bool benchmark) { _benchmark_mode = benchmark; };
     void set_regex(std::string regex) { _kernel_regex = regex; };
     void add_float_edge_cases(const std::vector<float>& edge_cases)
@@ -107,6 +109,7 @@ public:
     lv_32fc_t scalar() { return _scalar; };
     unsigned int vlen() { return _vlen; };
     unsigned int iter() { return _iter; };
+    unsigned int trials() { return _trials; };
     bool benchmark_mode() { return _benchmark_mode; };
     bool absolute_mode() { return _absolute_mode; };
     std::string kernel_regex() { return _kernel_regex; };
@@ -203,7 +206,8 @@ bool run_volk_tests(
     bool absolute_mode = false,
     bool benchmark_mode = false,
     const std::vector<float>& float_edge_cases = std::vector<float>(),
-    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
+    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>(),
+    unsigned int trials = 1);
 
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \


### PR DESCRIPTION
Depends on #22

---

Add a `-T <N>` / `--trials <N>` flag to `volk_profile` that runs the
existing per-arch timed loop N times and reports median + MAD% (scaled median
absolute deviation — 1.4826 × MAD, the consistent σ estimator under
normality; see `compute_mad` in `lib/qa_utils.cc` — as a percentage of
the median) in the results table.
Default is `-T 1`, which produces output identical to the current build
— users who don't pass `-T` see no change.

At `-T >= 2` the `time` column is renamed `median` and a `MAD%` column
is inserted to its right. Selection logic still picks the lowest
median. No changes to `-i` semantics, JSON output, or the saved
`volk_config` format.

The dispatch switch at qa_utils.cc gains one indent level from the
new trial loop; `git diff -w` confirms the switch body is otherwise
unchanged.

Tested: 254 ctests pass; mode A output verified identical to unpatched
build via `diff -u`; mode B visually verified at `-T 10` and `-T 20`;
argument validation verified for `-T 0`, `-T -1`, `-T garbage`.

Related: https://github.com/mtibbits/volk/issues/25
