### PR TITLE
volk_profile: add --with-minmax flag for per-arch min/max columns

### DIFF
--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -29,6 +29,7 @@ namespace fs = std::filesystem;
 volk_test_params_t test_params(1e-6f, 327.f, 131071, 1987, false, "");
 
 void set_benchmark(bool val) { test_params.set_benchmark(val); }
+void set_with_minmax(bool val) { test_params.set_with_minmax(val); }
 void set_tolerance(float val) { test_params.set_tol(val); }
 void set_vlen(int val) { test_params.set_vlen((unsigned int)val); }
 void set_iter(int val) { test_params.set_iter((unsigned int)val); }
@@ -58,6 +59,12 @@ int main(int argc, char* argv[])
     option_list profile_options("volk_profile");
     profile_options.add(
         option_t("benchmark", "b", "Run all kernels (benchmark mode)", set_benchmark));
+    profile_options.add(
+        option_t("with-minmax",
+                 "",
+                 "Add per-arch min and max columns to the -T results table "
+                 "(requires -T >= 2)",
+                 set_with_minmax));
     profile_options.add(
         option_t("tol", "t", "Set the default tolerance for all tests", set_tolerance));
     profile_options.add(

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -803,7 +803,8 @@ bool run_volk_tests(volk_func_desc_t desc,
                           test_params.benchmark_mode(),
                           test_params.float_edge_cases(),
                           test_params.complex_edge_cases(),
-                          test_params.trials());
+                          test_params.trials(),
+                          test_params.with_minmax());
 }
 
 bool run_volk_tests(volk_func_desc_t desc,
@@ -819,7 +820,8 @@ bool run_volk_tests(volk_func_desc_t desc,
                     bool benchmark_mode,
                     const std::vector<float>& float_edge_cases,
                     const std::vector<lv_32fc_t>& complex_edge_cases,
-                    unsigned int trials)
+                    unsigned int trials,
+                    bool with_minmax)
 {
     // Initialize this entry in results vector
     results->push_back(volk_test_results_t());
@@ -1243,6 +1245,8 @@ bool run_volk_tests(volk_func_desc_t desc,
 
     // Timed measurement pass.
     std::vector<double> profile_mads(arch_list.size(), 0.0);
+    std::vector<double> profile_mins(arch_list.size(), 0.0);
+    std::vector<double> profile_maxes(arch_list.size(), 0.0);
 
     for (size_t i = 0; i < arch_list.size(); i++) {
         std::vector<double> arch_samples;
@@ -1259,6 +1263,10 @@ bool run_volk_tests(volk_func_desc_t desc,
 
         double arch_time = compute_median(arch_samples);
         profile_mads[i] = compute_mad(arch_samples, arch_time);
+        auto [min_it, max_it] =
+            std::minmax_element(arch_samples.begin(), arch_samples.end());
+        profile_mins[i] = *min_it;
+        profile_maxes[i] = *max_it;
 
         volk_test_time_t result;
         result.name = arch_list[i];
@@ -1530,8 +1538,45 @@ bool run_volk_tests(volk_func_desc_t desc,
         return fmt::format("{:.1f} MB/s", mbps);
     };
 
-    // Print table header — Mode B adds a MAD% column and renames "time" to "median".
-    if (trials > 1) {
+    // Print table header — Mode A, B, or C.
+    if (trials > 1 && with_minmax) {
+        fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} "
+                   "| {:>{}} | {:>{}} | {:>{}} |\n",
+                   "arch",
+                   w_arch,
+                   "median",
+                   w_time,
+                   "MAD%",
+                   w_mad,
+                   "min",
+                   w_time,
+                   "max",
+                   w_time,
+                   "throughput",
+                   w_tput,
+                   "speedup",
+                   w_speedup,
+                   err_col,
+                   w_err);
+        fmt::print("{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}"
+                   "-+-{:-<{}}-+-{:-<{}}-+-{:-<{}}-+\n",
+                   "",
+                   w_arch,
+                   "",
+                   w_time,
+                   "",
+                   w_mad,
+                   "",
+                   w_time,
+                   "",
+                   w_time,
+                   "",
+                   w_tput,
+                   "",
+                   w_speedup,
+                   "",
+                   w_err);
+    } else if (trials > 1) {
         fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} |\n",
                    "arch",
                    w_arch,
@@ -1603,7 +1648,33 @@ bool run_volk_tests(volk_func_desc_t desc,
         std::string win_str =
             (arch_list[i] == best_arch_a || arch_list[i] == best_arch_u) ? " *" : "";
 
-        if (trials > 1) {
+        if (trials > 1 && with_minmax) {
+            std::string mad_str =
+                (profile_times[i] > 0.0)
+                    ? fmt::format("{:.1f}%", 100.0 * profile_mads[i] / profile_times[i])
+                    : std::string("-");
+            std::string min_str = format_time(profile_mins[i]);
+            std::string max_str = format_time(profile_maxes[i]);
+            fmt::print("{:<{}} | {:>{}} | {:>{}} | {:>{}} | {:>{}} "
+                       "| {:>{}} | {:>{}} | {:>{}} |{}\n",
+                       arch_list[i],
+                       w_arch,
+                       time_str,
+                       w_time,
+                       mad_str,
+                       w_mad,
+                       min_str,
+                       w_time,
+                       max_str,
+                       w_time,
+                       tput_str,
+                       w_tput,
+                       speedup_str,
+                       w_speedup,
+                       err_str,
+                       w_err,
+                       win_str);
+        } else if (trials > 1) {
             std::string mad_str =
                 (profile_times[i] > 0.0)
                     ? fmt::format("{:.1f}%", 100.0 * profile_mads[i] / profile_times[i])
@@ -1662,7 +1733,9 @@ bool run_volk_tests(volk_func_desc_t desc,
                           tol_f);
     }
 
-    if (trials > 1) {
+    if (trials > 1 && with_minmax) {
+        fmt::print("{:-<131}\n", "");
+    } else if (trials > 1) {
         fmt::print("{:-<97}\n", "");
     } else {
         fmt::print("{:-<88}\n", "");

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -67,6 +67,7 @@ private:
     unsigned int _vlen;
     unsigned int _iter;
     unsigned int _trials = 1;
+    bool _with_minmax = false;
     bool _benchmark_mode;
     bool _absolute_mode;
     std::string _kernel_regex;
@@ -94,6 +95,7 @@ public:
     void set_vlen(unsigned int vlen) { _vlen = vlen; };
     void set_iter(unsigned int iter) { _iter = iter; };
     void set_trials(unsigned int trials) { _trials = trials; };
+    void set_with_minmax(bool val) { _with_minmax = val; };
     void set_benchmark(bool benchmark) { _benchmark_mode = benchmark; };
     void set_regex(std::string regex) { _kernel_regex = regex; };
     void add_float_edge_cases(const std::vector<float>& edge_cases)
@@ -110,6 +112,7 @@ public:
     unsigned int vlen() { return _vlen; };
     unsigned int iter() { return _iter; };
     unsigned int trials() { return _trials; };
+    bool with_minmax() { return _with_minmax; };
     bool benchmark_mode() { return _benchmark_mode; };
     bool absolute_mode() { return _absolute_mode; };
     std::string kernel_regex() { return _kernel_regex; };
@@ -207,7 +210,8 @@ bool run_volk_tests(
     bool benchmark_mode = false,
     const std::vector<float>& float_edge_cases = std::vector<float>(),
     const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>(),
-    unsigned int trials = 1);
+    unsigned int trials = 1,
+    bool with_minmax = false);
 
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \


### PR DESCRIPTION
Depends on #22, #26, #35

---

## Summary

When `trials > 1` and `--with-minmax` is passed, `volk_profile` inserts
`min` and `max` columns between `MAD%` and `throughput` in the per-kernel
results table. The columns show the extreme values of the per-arch trial
sample vector, surfacing rare-outlier distributions that `median + MAD%`
can hide.

The flag is long-form only (no short letter), opt-in, and a silent no-op
when `trials == 1`. Mode A and Mode B output are unchanged.

## What changed

```
apps/volk_profile.cc |  7 +++++++
lib/qa_utils.cc      | 91 ++++++++++++++++++++++++++++++++++++++++++++++------
lib/qa_utils.h       |  6 +++++-
3 files changed, 91 insertions(+), 7 deletions(-)
```

- `lib/qa_utils.h`: new `_with_minmax` field, setter, getter, and
  `bool with_minmax = false` parameter on the second `run_volk_tests`
  overload.
- `lib/qa_utils.cc`: thread `with_minmax` through both overloads; add
  `profile_mins` / `profile_maxes` vectors populated via
  `std::minmax_element`; add Mode C header, per-row, and trailing-rule
  branches gated on `trials > 1 && with_minmax`. Mode A and Mode B
  code paths are untouched.
- `apps/volk_profile.cc`: `set_with_minmax` callback and
  `option_t("with-minmax", "", ...)` registration (long-form only).

## Verification

**Mode C output** (`-T 5 --with-minmax -R volk_32f_x2_add_32f`):

```
arch                       |         median |   MAD% |            min |            max |     throughput |  speedup |    max_rel |
---------------------------+----------------+--------+----------------+----------------+----------------+----------+------------+
generic                    |       42.93 ms |   0.5% |       42.78 ms |       44.32 ms |   72803.5 MB/s |        - |          - |
u_avx512f                  |       43.19 ms |   0.5% |       43.02 ms |       43.37 ms |   72358.3 MB/s |    0.99x |    0.0e+00 |
u_avx                      |       40.61 ms |   0.1% |       40.51 ms |       40.70 ms |   76954.4 MB/s |    1.06x |    0.0e+00 | *
```

**Regression tested:**

- Mode A (`--dry-run`, no flags): unchanged from baseline
- Mode B (`-T 5 --dry-run`): unchanged from baseline
- Silent no-op (`--with-minmax --dry-run`, no `-T`): Mode A unchanged
- `--help`: shows `--with-minmax` with `(requires -T >= 2)`
- `min ≤ median ≤ max` invariant: holds on all rows
- Trailing rule: 131 dashes in Mode C
- `ctest`: 254/254 pass
- `clang-format`: zero violations on changed lines (`git clang-format`)
- Static analysis (cppcheck, scan-build, cpplint, flawfinder): zero
  new findings
- Sanitizers (ASan+UBSan, TSan): no new failures

## Fixes

https://github.com/mtibbits/volk/issues/32