### PR TITLE
volk_profile: add --trial-csv flag for per-trial timing export

### DIFF
--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -49,6 +49,8 @@ bool dry_run = false;
 void set_dryrun(bool val) { dry_run = val; }
 std::string json_filename("");
 void set_json(std::string val) { json_filename = val; }
+std::string trial_csv_path("");
+void set_trial_csv_path(std::string val) { trial_csv_path = val; }
 std::string volk_config_path("");
 void set_volk_config(std::string val) { volk_config_path = val; }
 void set_warmup(int val) { volk_test_set_warmup_ms((double)val); }
@@ -90,6 +92,11 @@ int main(int argc, char* argv[])
                   set_dryrun)));
     profile_options.add((option_t(
         "json", "j", "Write results to JSON file named as argument value", set_json)));
+    profile_options.add(option_t("trial-csv",
+                                 "",
+                                 "Write per-trial timings to FILE "
+                                 "(creates or truncates; existing content is lost)",
+                                 set_trial_csv_path));
     profile_options.add(
         (option_t("path", "p", "Specify the volk_config path", set_volk_config)));
     profile_options.add(
@@ -111,6 +118,17 @@ int main(int argc, char* argv[])
 
     if (json_filename != "") {
         json_file.open(json_filename.c_str());
+    }
+
+    std::ofstream csv_file;
+    if (!trial_csv_path.empty()) {
+        csv_file.open(trial_csv_path);
+        if (!csv_file.is_open()) {
+            std::cerr << "error: cannot open --trial-csv target '" << trial_csv_path
+                      << "'\n";
+            return 1;
+        }
+        csv_file << "kernel,arch,trial,time_ms\n";
     }
 
     if (volk_config_path != "") {
@@ -163,7 +181,8 @@ int main(int argc, char* argv[])
                                test_case.name(),
                                test_case.test_parameters(),
                                &results,
-                               test_case.puppet_master_name());
+                               test_case.puppet_master_name(),
+                               csv_file.is_open() ? &csv_file : nullptr);
             } catch (std::string& error) {
                 std::cerr << "Caught Exception in 'run_volk_tests': " << error
                           << std::endl;

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -23,6 +23,7 @@
 #include <cmath>    // for sqrt, fabs, abs
 #include <cstring>  // for memcpy, memset
 #include <ctime>    // for clock
+#include <fstream>  // for std::ofstream (csv_out)
 #include <iostream> // for cerr
 #include <limits>   // for numeric_limits
 #include <map>      // for map, map<>::mappe...
@@ -30,6 +31,7 @@
 #include <vector> // for vector, _Bit_refe...
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 // Warmup time for CPU frequency scaling (ms)
 static double g_warmup_ms = 2000.0;
@@ -788,7 +790,8 @@ bool run_volk_tests(volk_func_desc_t desc,
                     std::string name,
                     volk_test_params_t test_params,
                     std::vector<volk_test_results_t>* results,
-                    std::string puppet_master_name)
+                    std::string puppet_master_name,
+                    std::ofstream* csv_out)
 {
     return run_volk_tests(desc,
                           manual_func,
@@ -804,7 +807,8 @@ bool run_volk_tests(volk_func_desc_t desc,
                           test_params.float_edge_cases(),
                           test_params.complex_edge_cases(),
                           test_params.trials(),
-                          test_params.with_minmax());
+                          test_params.with_minmax(),
+                          csv_out);
 }
 
 bool run_volk_tests(volk_func_desc_t desc,
@@ -821,7 +825,8 @@ bool run_volk_tests(volk_func_desc_t desc,
                     const std::vector<float>& float_edge_cases,
                     const std::vector<lv_32fc_t>& complex_edge_cases,
                     unsigned int trials,
-                    bool with_minmax)
+                    bool with_minmax,
+                    std::ofstream* csv_out)
 {
     // Initialize this entry in results vector
     results->push_back(volk_test_results_t());
@@ -1276,6 +1281,18 @@ bool run_volk_tests(volk_func_desc_t desc,
         results->back().results[result.name] = result;
 
         profile_times.push_back(arch_time);
+
+        // Write per-trial CSV rows if csv_out is active
+        if (csv_out) {
+            for (unsigned int t = 0; t < trials; t++) {
+                fmt::print(*csv_out,
+                           "{},{},{},{:.6g}\n",
+                           name,
+                           arch_list[i],
+                           t,
+                           arch_samples[t]);
+            }
+        }
     }
 
     // and now compare each output to the generic output

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -13,6 +13,7 @@
 #include <stdbool.h>   // for bool, false
 #include <volk/volk.h> // for volk_func_desc_t
 #include <cstdlib>     // for NULL
+#include <iosfwd>      // for std::ofstream (forward decl)
 #include <map>         // for map
 #include <string>      // for string, basic_string
 #include <vector>      // for vector
@@ -194,7 +195,8 @@ bool run_volk_tests(volk_func_desc_t,
                     std::string,
                     volk_test_params_t,
                     std::vector<volk_test_results_t>* results = NULL,
-                    std::string puppet_master_name = "NULL");
+                    std::string puppet_master_name = "NULL",
+                    std::ofstream* csv_out = nullptr);
 
 bool run_volk_tests(
     volk_func_desc_t,
@@ -211,7 +213,8 @@ bool run_volk_tests(
     const std::vector<float>& float_edge_cases = std::vector<float>(),
     const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>(),
     unsigned int trials = 1,
-    bool with_minmax = false);
+    bool with_minmax = false,
+    std::ofstream* csv_out = nullptr);
 
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \


### PR DESCRIPTION
Depends on #22, #26, #35, #36

---

## volk_profile: add --trial-csv flag for per-trial timing export

### Summary

Add `--trial-csv FILE` to `volk_profile` for exporting raw per-trial
timing data to CSV. One row per (kernel, arch, trial) with the
wall-clock sample from `arch_samples`.

- Independent of `-T`: at `-T 1` produces one row per (kernel, arch);
  at `-T 30` produces 30 rows per (kernel, arch)
- Default is off -- no file opened, no I/O cost
- Header: `kernel,arch,trial,time_ms`
- Stacked on #32 (`--with-minmax`); both flags are orthogonal

### Files changed (3 files, +45 -6)

| File | Change |
|------|--------|
| `lib/qa_utils.h` | `#include <iosfwd>`, add `std::ofstream* csv_out = nullptr` to both `run_volk_tests` overloads |
| `lib/qa_utils.cc` | `#include <fstream>`, `#include <fmt/ostream.h>`, forward `csv_out` through both overloads, CSV-write block after `profile_times.push_back` |
| `apps/volk_profile.cc` | `trial_csv_path` global + callback, `--trial-csv` option registration, `std::ofstream` open + `is_open()` check + header write, pass pointer at call site |

### What this does NOT change

- Table writer (no Mode A/B/C changes)
- Selection logic, JSON output, saved config
- `volk_test_params_t`
- `VOLK_PROFILE` / `VOLK_PUPPET_PROFILE` macros (new param defaults to `nullptr`)

### Test plan

- [x] `--trial-csv trials.csv` produces correct header + row count
- [x] `-T 10 --trial-csv` produces arches x 10 rows
- [x] Python CSV validation (fieldnames, positive times, valid trial indices)
- [x] No side effects without the flag
- [x] `ctest -j$(nproc)` -- 254/254 pass
- [x] `git clang-format` -- no changes needed
- [x] cppcheck, cpplint, clang-tidy, scan-build -- no novel findings
- [x] IWYU -- clean
- [x] ASan+UBSan -- clean exit, valid output
- [x] TSan -- clean exit, valid output

Related: https://github.com/mtibbits/volk/issues/33