### PR TITLE
tools: median-line geom + arch family ordering for plot_pr_evidence.R

### DIFF
--- a/tools/plot_pr_evidence.R
+++ b/tools/plot_pr_evidence.R
@@ -51,6 +51,25 @@ PALETTE_DARK2 <- c(
     "#66A61E", "#E6AB02", "#A6761D", "#666666"
 )
 
+# Order archs for plotting: `generic` always leftmost; other
+# prefix-less algorithm names (generic_branchless, lut, polynomial,
+# 1972magic, etc.) next, alphabetically; then SIMD archs grouped by
+# family with a_/u_ pairs adjacent (a_ before u_ within each family).
+# Within tier 2, the family sort key replaces '_' with ' ' so that
+# variants (avx_fma, avx2_fma, sse4_1) sort *adjacent to their base*
+# rather than after it lexicographically — pure byte order would
+# place avx_fma after avx512f because '_' (0x5F) > '5' (0x35).
+sort_archs_for_plot <- function(archs) {
+    has_au_prefix <- grepl("^[au]_", archs)
+    is_generic    <- archs == "generic"
+    tier   <- ifelse(is_generic, 0L,
+                     ifelse(!has_au_prefix, 1L, 2L))
+    family <- ifelse(has_au_prefix, sub("^[au]_", "", archs), archs)
+    family_key <- gsub("_", " ", family, fixed = TRUE)
+    au     <- ifelse(has_au_prefix, substr(archs, 1L, 1L), "")
+    archs[order(tier, family_key, au, archs)]
+}
+
 # ---- Error helpers ----------------------------------------------
 
 stop_loud <- function(msg) {
@@ -229,26 +248,40 @@ render_kernel_plot <- function(summary_df, kernel_name, outdir,
             substr(kernel_name, 1L, 60L)))
     }
     sub <- summary_df[summary_df$kernel == kernel_name, ]
-    sub$arch <- factor(sub$arch, levels = sort(unique(sub$arch)))
+    sub$arch <- factor(sub$arch,
+                       levels = sort_archs_for_plot(unique(sub$arch)))
     n_runs <- length(run_labels)
     palette_used <- PALETTE_DARK2[seq_len(n_runs)]
     names(palette_used) <- run_labels
 
+    # Median rendered as a horizontal line; MAD as whiskers around it.
+    # Both use position_dodge so 2+ runs sit side-by-side per arch.
+    # We deliberately do NOT draw bars: bar height to a y=0 baseline
+    # forces log10 to clip at the lowest tick (1 ms) and visually
+    # compresses the legitimate data range. With lines, the y-axis
+    # auto-scales to the data — sub-percent MAD whiskers stay
+    # invisibly tight, and the cluster structure is immediately
+    # legible.
+    dodge <- ggplot2::position_dodge(width = 0.6)
     p <- ggplot2::ggplot(sub,
-            ggplot2::aes(x = arch, y = median_ms, fill = run)) +
-        ggplot2::geom_col(position = ggplot2::position_dodge(width = 0.8),
-                          width = 0.7) +
+            ggplot2::aes(x = arch, y = median_ms, color = run,
+                         group = run)) +
         ggplot2::geom_errorbar(
             ggplot2::aes(ymin = pmax(median_ms - mad_ms, 1e-12),
                          ymax = median_ms + mad_ms),
-            position = ggplot2::position_dodge(width = 0.8),
-            width = 0.25
+            position = dodge, width = 0.25, linewidth = 0.6
+        ) +
+        # Horizontal "median line" via geom_errorbar with ymin == ymax;
+        # the bracket collapses to two overlapping caps = one line.
+        ggplot2::geom_errorbar(
+            ggplot2::aes(ymin = median_ms, ymax = median_ms),
+            position = dodge, width = 0.5, linewidth = 1.2
         ) +
         ggplot2::scale_y_log10() +
-        ggplot2::scale_fill_manual(values = palette_used) +
+        ggplot2::scale_color_manual(values = palette_used) +
         ggplot2::labs(title = kernel_name,
                       x = "arch", y = "wall-time (ms, log scale)",
-                      fill = "run") +
+                      color = "run") +
         ggplot2::theme_bw(base_family = "sans")
 
     out_path <- file.path(outdir, sprintf("%s.png", kernel_name))


### PR DESCRIPTION
Iterative follow-up to PR #47 (#46). Two visual changes; no contract changes.

## Median-line geom (no bars, ever)

`geom_col`'s bar baseline forces `y = 0` into the rendered y range,
and on `scale_y_log10()` that clips the visible axis to start at
the lowest "nice" tick (1 ms) even when actual data lives in the
30–100 ms band. With bars removed, the y-axis auto-scales to the
actual data range and the cluster structure (e.g. avx2 ~35 ms vs
sse/generic ~95 ms in the dot-prod case) reads immediately.

The median is now drawn as a horizontal line via `geom_errorbar` with
`ymin == ymax` (the bracket collapses to a single segment); MAD
whiskers continue as a second `geom_errorbar`. In single-snapshot
mode every line is the palette's first color (teal); in paired /
N-way mode lines are color-coded by run with `position_dodge` keeping
them side-by-side per arch.

Single-snapshot:

![single](https://user-images.githubusercontent.com/placeholder.png)

Paired (orange "after" sits below teal "before" at every arch when
"after" is faster):

![paired](https://user-images.githubusercontent.com/placeholder.png)

## Arch family ordering

`generic` always leftmost; other prefix-less algorithm-name archs
(`generic_branchless`, `lut`, `polynomial`, `1972magic`, etc.) next,
alphabetically; then SIMD archs grouped by family with `a_`/`u_`
pairs adjacent and `a_` before `u_` within each family.

The family sort key replaces `_` with `` `` (space) so variants like
`avx_fma`, `avx2_fma`, and `sse4_1` sort *adjacent to their base
family* rather than after it under pure byte order (where `_` at
0x5F would otherwise push `avx_fma` past `avx512f`).

Result on a 13-arch kernel: `generic | a_avx u_avx | a_avx2_fma
u_avx2_fma | a_avx512f u_avx512f | a_sse u_sse | a_sse3 u_sse3 |
a_sse4_1 u_sse4_1`. Family clusters are immediately visible without
the reader having to mentally re-sort the labels.

## Smoke

Re-rendered all 124 kernels from the existing
`baseline-2026-04-28-T30/trials.csv` baseline corpus: single-snapshot
mode renders cleanly with the new ordering. Manual paired-mode test
with a synthetic 10%-faster "after" CSV shows the orange line sitting
consistently below the teal line at every arch.

Diff: +41 / -8, one file (`tools/plot_pr_evidence.R`).

Related: #46