### PR TITLE
kernels: add AVX (no-AVX2/no-FMA) tier to sin, cos, and sincos kernels

### DIFF
--- a/include/volk/volk_avx_intrinsics.h
+++ b/include/volk/volk_avx_intrinsics.h
@@ -322,4 +322,82 @@ static inline __m256 _mm256_log2_poly_avx(const __m256 x)
     return poly;
 }
 
+/*
+ * Approximate sin(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~7.3e-9
+ * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
+ *
+ * AVX-only sibling of _mm256_sin_poly_avx2 in volk_avx2_intrinsics.h.
+ * The AVX2 version uses only AVX1 intrinsics; this copy lets the AVX
+ * tier of volk_32f_sin_32f / volk_32f_sincos_32f_x2 include it without
+ * depending on the AVX2 intrinsics header.
+ */
+static inline __m256 _mm256_sin_poly_avx(const __m256 x)
+{
+    const __m256 s1 = _mm256_set1_ps(-0x1.555552p-3f);
+    const __m256 s2 = _mm256_set1_ps(+0x1.110be2p-7f);
+    const __m256 s3 = _mm256_set1_ps(-0x1.9ab22ap-13f);
+
+    const __m256 x2 = _mm256_mul_ps(x, x);
+    const __m256 x3 = _mm256_mul_ps(x2, x);
+
+    __m256 poly = _mm256_add_ps(_mm256_mul_ps(x2, s3), s2);
+    poly = _mm256_add_ps(_mm256_mul_ps(x2, poly), s1);
+    return _mm256_add_ps(_mm256_mul_ps(x3, poly), x);
+}
+
+/*
+ * Approximate cos(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~1.1e-7
+ * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
+ *
+ * AVX-only sibling of _mm256_cos_poly_avx2 in volk_avx2_intrinsics.h.
+ */
+static inline __m256 _mm256_cos_poly_avx(const __m256 x)
+{
+    const __m256 c1 = _mm256_set1_ps(-0x1.fffff4p-2f);
+    const __m256 c2 = _mm256_set1_ps(+0x1.554a46p-5f);
+    const __m256 c3 = _mm256_set1_ps(-0x1.661be2p-10f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+
+    const __m256 x2 = _mm256_mul_ps(x, x);
+
+    __m256 poly = _mm256_add_ps(_mm256_mul_ps(x2, c3), c2);
+    poly = _mm256_add_ps(_mm256_mul_ps(x2, poly), c1);
+    return _mm256_add_ps(_mm256_mul_ps(x2, poly), one);
+}
+
+/*
+ * Compute mask = (n & K) == K, returned as a 256-bit blend mask suitable
+ * for _mm256_blendv_ps (sign bit is read; 0xFFFFFFFF cast to float has
+ * the sign bit set).
+ *
+ * AVX1-only — emulates the AVX2 _mm256_and_si256 + _mm256_cmpeq_epi32
+ * sequence by splitting the 256-bit integer vector into two 128-bit
+ * halves, performing the test in SSE2, and recombining.
+ *
+ * Inputs: n_lo, n_hi are the lower and upper 128-bit halves of a 256-bit
+ *         integer vector. Callers extract once per loop iteration via
+ *         _mm256_castsi256_si128 (lo, free) and _mm256_extractf128_si256
+ *         (hi) and reuse across multiple masks.
+ *         K_128 is a 128-bit broadcast of the test mask
+ *         (e.g. _mm_set1_epi32(1) or _mm_set1_epi32(2)).
+ *
+ * Used by the AVX tiers of volk_32f_sin_32f, volk_32f_cos_32f, and
+ * volk_32f_sincos_32f_x2 for quadrant-bit tests in sin/cos
+ * reconstruction.
+ */
+static inline __m256
+_mm256_mask_bit_set_avx(const __m128i n_lo, const __m128i n_hi, const __m128i K_128)
+{
+    const __m128i mask_lo = _mm_cmpeq_epi32(_mm_and_si128(n_lo, K_128), K_128);
+    const __m128i mask_hi = _mm_cmpeq_epi32(_mm_and_si128(n_hi, K_128), K_128);
+    return _mm256_castsi256_ps(
+        _mm256_insertf128_si256(_mm256_castsi128_si256(mask_lo), mask_hi, 1));
+}
+
 #endif /* INCLUDE_VOLK_VOLK_AVX_INTRINSICS_H_ */

--- a/kernels/volk/volk_32f_cos_32f.h
+++ b/kernels/volk/volk_32f_cos_32f.h
@@ -294,6 +294,74 @@ volk_32f_cos_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_p
 
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_cos_32f_a_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    // 128-bit integer constants -- used per-half because AVX1 has no
+    // 256-bit integer AND / CMPEQ / ADD.
+    const __m128i ones_128 = _mm_set1_epi32(1);
+    const __m128i twos_128 = _mm_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_load_ps(aPtr);
+
+        // Argument reduction
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        __m256 sin_r = _mm256_sin_poly_avx(r);
+        __m256 cos_r = _mm256_cos_poly_avx(r);
+
+        // Quadrant reconstruction. For cos:
+        //   swap_mask = (n & 1) == 1       (Pattern A) -> use sin_r instead of cos_r
+        //   neg_mask  = ((n+1) & 2) == 2   (Pattern B) -> negate result
+        __m128i n_lo = _mm256_castsi256_si128(n);
+        __m128i n_hi = _mm256_extractf128_si256(n, 1);
+
+        // Pattern A
+        __m256 swap_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, ones_128);
+        __m256 result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
+
+        // Pattern B (the +1 is applied to the 128-bit halves before the helper
+        // call because AVX1 has no _mm256_add_epi32).
+        __m256 neg_mask = _mm256_mask_bit_set_avx(
+            _mm_add_epi32(n_lo, ones_128), _mm_add_epi32(n_hi, ones_128), twos_128);
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_store_ps(bPtr, result);
+        aPtr += 8;
+        bPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bPtr++ = cosf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
 #include <volk/volk_sse_intrinsics.h>
@@ -567,6 +635,71 @@ volk_32f_cos_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_p
 }
 
 #endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_cos_32f_u_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    const __m128i ones_128 = _mm_set1_epi32(1);
+    const __m128i twos_128 = _mm_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_loadu_ps(aPtr);
+
+        // Argument reduction
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        __m256 sin_r = _mm256_sin_poly_avx(r);
+        __m256 cos_r = _mm256_cos_poly_avx(r);
+
+        // Quadrant reconstruction. For cos:
+        //   swap_mask = (n & 1) == 1       (Pattern A) -> use sin_r instead of cos_r
+        //   neg_mask  = ((n+1) & 2) == 2   (Pattern B) -> negate result
+        __m128i n_lo = _mm256_castsi256_si128(n);
+        __m128i n_hi = _mm256_extractf128_si256(n, 1);
+
+        // Pattern A
+        __m256 swap_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, ones_128);
+        __m256 result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
+
+        // Pattern B
+        __m256 neg_mask = _mm256_mask_bit_set_avx(
+            _mm_add_epi32(n_lo, ones_128), _mm_add_epi32(n_hi, ones_128), twos_128);
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_storeu_ps(bPtr, result);
+        aPtr += 8;
+        bPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bPtr++ = cosf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
 
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>

--- a/kernels/volk/volk_32f_sin_32f.h
+++ b/kernels/volk/volk_32f_sin_32f.h
@@ -278,6 +278,73 @@ volk_32f_sin_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_p
 
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_sin_32f_a_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
+
+    // 128-bit integer constants -- used per-half because AVX1 has no
+    // 256-bit integer AND / CMPEQ.
+    const __m128i ones_128 = _mm_set1_epi32(1);
+    const __m128i twos_128 = _mm_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_load_ps(aPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx(r);
+        __m256 cos_r = _mm256_cos_poly_avx(r);
+
+        // Quadrant-based reconstruction. Split n once and reuse halves
+        // across both masks via the _mm256_mask_bit_set_avx helper.
+        __m128i n_lo = _mm256_castsi256_si128(n);
+        __m128i n_hi = _mm256_extractf128_si256(n, 1);
+
+        // swap when (n & 1) == 1 -> use cos_r instead of sin_r
+        __m256 swap_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, ones_128);
+        __m256 result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
+
+        // negate when (n & 2) == 2
+        __m256 neg_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, twos_128);
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_store_ps(bPtr, result);
+        aPtr += 8;
+        bPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bPtr++ = sinf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
 #include <volk/volk_sse_intrinsics.h>
@@ -550,6 +617,62 @@ volk_32f_sin_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_p
 }
 
 #endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_sin_32f_u_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    const __m128i ones_128 = _mm_set1_epi32(1);
+    const __m128i twos_128 = _mm_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_loadu_ps(aPtr);
+
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        __m256 sin_r = _mm256_sin_poly_avx(r);
+        __m256 cos_r = _mm256_cos_poly_avx(r);
+
+        __m128i n_lo = _mm256_castsi256_si128(n);
+        __m128i n_hi = _mm256_extractf128_si256(n, 1);
+
+        __m256 swap_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, ones_128);
+        __m256 result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
+
+        __m256 neg_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, twos_128);
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_storeu_ps(bPtr, result);
+        aPtr += 8;
+        bPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bPtr++ = sinf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
 
 
 #ifdef LV_HAVE_SSE4_1

--- a/kernels/volk/volk_32f_sincos_32f_x2.h
+++ b/kernels/volk/volk_32f_sincos_32f_x2.h
@@ -344,6 +344,89 @@ static inline void volk_32f_sincos_32f_x2_a_avx2(float* sinVector,
 
 #endif /* LV_HAVE_AVX2 for aligned */
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_a_avx(float* sinVector,
+                                                float* cosVector,
+                                                const float* inVector,
+                                                unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    // 128-bit integer constants -- used per-half because AVX1 has no
+    // 256-bit integer AND / CMPEQ / ADD.
+    const __m128i ones_128 = _mm_set1_epi32(1);
+    const __m128i twos_128 = _mm_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_load_ps(inPtr);
+
+        // Argument reduction
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        // Evaluate both polynomials once per iteration; reuse for sin
+        // and cos outputs.
+        __m256 sin_r = _mm256_sin_poly_avx(r);
+        __m256 cos_r = _mm256_cos_poly_avx(r);
+
+        // Split-128 once; reuse n_lo / n_hi across all three masks.
+        __m128i n_lo = _mm256_castsi256_si128(n);
+        __m128i n_hi = _mm256_extractf128_si256(n, 1);
+
+        // Shared swap mask: (n & 1) == 1   (Pattern A)
+        //   sin output uses cos_r when set, sin_r otherwise
+        //   cos output uses sin_r when set, cos_r otherwise
+        __m256 swap_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, ones_128);
+
+        // sin negation mask: (n & 2) == 2   (Pattern A)
+        __m256 sin_neg_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, twos_128);
+
+        // cos negation mask: ((n+1) & 2) == 2   (Pattern B)
+        __m256 cos_neg_mask = _mm256_mask_bit_set_avx(
+            _mm_add_epi32(n_lo, ones_128), _mm_add_epi32(n_hi, ones_128), twos_128);
+
+        // Reconstruct sin: swap to cos_r when n&1, then negate when n&2
+        __m256 sin_result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
+        sin_result = _mm256_xor_ps(sin_result, _mm256_and_ps(sin_neg_mask, sign_bit));
+
+        // Reconstruct cos: swap to sin_r when n&1, then negate when (n+1)&2
+        __m256 cos_result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
+        cos_result = _mm256_xor_ps(cos_result, _mm256_and_ps(cos_neg_mask, sign_bit));
+
+        _mm256_store_ps(sinPtr, sin_result);
+        _mm256_store_ps(cosPtr, cos_result);
+        inPtr += 8;
+        sinPtr += 8;
+        cosPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
 #include <volk/volk_sse_intrinsics.h>
@@ -650,6 +733,81 @@ static inline void volk_32f_sincos_32f_x2_u_avx2(float* sinVector,
 }
 
 #endif /* LV_HAVE_AVX2 for unaligned */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_u_avx(float* sinVector,
+                                                float* cosVector,
+                                                const float* inVector,
+                                                unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    const __m128i ones_128 = _mm_set1_epi32(1);
+    const __m128i twos_128 = _mm_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_loadu_ps(inPtr);
+
+        // Argument reduction
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        __m256 sin_r = _mm256_sin_poly_avx(r);
+        __m256 cos_r = _mm256_cos_poly_avx(r);
+
+        // Split-128 once; reuse n_lo / n_hi across all three masks.
+        __m128i n_lo = _mm256_castsi256_si128(n);
+        __m128i n_hi = _mm256_extractf128_si256(n, 1);
+
+        // Shared swap mask: (n & 1) == 1   (Pattern A)
+        __m256 swap_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, ones_128);
+
+        // sin negation mask: (n & 2) == 2   (Pattern A)
+        __m256 sin_neg_mask = _mm256_mask_bit_set_avx(n_lo, n_hi, twos_128);
+
+        // cos negation mask: ((n+1) & 2) == 2   (Pattern B)
+        __m256 cos_neg_mask = _mm256_mask_bit_set_avx(
+            _mm_add_epi32(n_lo, ones_128), _mm_add_epi32(n_hi, ones_128), twos_128);
+
+        __m256 sin_result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
+        sin_result = _mm256_xor_ps(sin_result, _mm256_and_ps(sin_neg_mask, sign_bit));
+
+        __m256 cos_result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
+        cos_result = _mm256_xor_ps(cos_result, _mm256_and_ps(cos_neg_mask, sign_bit));
+
+        _mm256_storeu_ps(sinPtr, sin_result);
+        _mm256_storeu_ps(cosPtr, cos_result);
+        inPtr += 8;
+        sinPtr += 8;
+        cosPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
 
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>


### PR DESCRIPTION
## Scope note (read first)

Issue #48 named only `volk_32f_sin_32f` and `volk_32f_cos_32f`.
During plan review the adjacent `volk_32f_sincos_32f_x2` kernel
turned out to have the same tier gap (SSE4.1 / AVX2 / AVX2+FMA /
AVX-512F / NEON, no plain AVX). Because the dominant downstream
pattern for sin+cos of the same input is to call sincos rather
than the separate kernels — IQ modulation, NCO, dechirp — filling
the gap in the two solo kernels but leaving sincos behind would
mean the dominant call pattern keeps paying the 4-wide SSE penalty
on AVX-only hardware. Included as the final commit so a maintainer who prefers to land
sin/cos only can drop the sincos commit cleanly (it is the branch's
last commit and the only one touching `volk_32f_sincos_32f_x2.h`).

## Summary

Fills the AVX (without AVX2 or FMA) tier of `volk_32f_sin_32f`,
`volk_32f_cos_32f`, and `volk_32f_sincos_32f_x2`. On x86 hosts that
report AVX but lack AVX2 or FMA — Intel Sandy Bridge (2011) and Ivy
Bridge (2012), AMD Bulldozer-family through Steamroller (2011-2014)
— these three kernels previously fell back from the 8-wide AVX2
path to the 4-wide SSE4.1 path despite 256-bit registers being
usable. This PR adds the missing tier.

Four commits. The first introduces three AVX-only helpers in
`include/volk/volk_avx_intrinsics.h`: `_mm256_sin_poly_avx` and
`_mm256_cos_poly_avx` (AVX-named siblings of the existing AVX2
polynomial helpers; the AVX2 versions happen to use only AVX1
intrinsics but live in the AVX2 header, and we want the AVX kernel
paths to include only AVX1-named headers), plus
`_mm256_mask_bit_set_avx` which emulates the AVX2
`_mm256_and_si256` + `_mm256_cmpeq_epi32` sequence used in
sin/cos quadrant reconstruction by splitting a 256-bit integer
vector into two 128-bit halves, performing the test in SSE2, and
recombining via `_mm256_insertf128_si256`. Callers extract
`n_lo` / `n_hi` once per loop iteration via `_mm256_castsi256_si128`
(free) and `_mm256_extractf128_si256` (one `vextractf128`) and
reuse them across two or three mask synthesis calls per iteration.

The three kernel commits each add a `#ifdef LV_HAVE_AVX` block
between the existing AVX2 endif and the SSE4.1 ifdef, in both the
aligned and unaligned blocks. The bodies mirror the existing AVX2
impls' Cody-Waite argument reduction and quadrant-based sin/cos
reconstruction, substituting the split-128 helper for the AVX2
integer ops and `_mm_add_epi32` on the 128-bit halves for the
cos-path `n+1` shift. All numeric constants are byte-identical to
the AVX2 references. Verifiable in one diff:

```bash
$ diff <(awk '/^static inline __m256 _mm256_sin_poly_avx\(/,/^}/' \
          include/volk/volk_avx_intrinsics.h) \
       <(awk '/^static inline __m256 _mm256_sin_poly_avx2\(/,/^}/' \
          include/volk/volk_avx2_intrinsics.h)
1c1
< static inline __m256 _mm256_sin_poly_avx(const __m256 x)
---
> static inline __m256 _mm256_sin_poly_avx2(const __m256 x)
```

The only line that differs is the function signature itself — every
constant and every operation is byte-identical. Same for the cos
polynomial helper. (The AVX2 helpers happen to use only AVX1
intrinsics, but live in `volk_avx2_intrinsics.h`; we add the
AVX-named siblings rather than restructuring the AVX2 header so this
PR stays surgical. The two helpers should be kept in sync; if a
follow-up bumps coefficients in one, it must touch both.)

## Pathological-input behavior

The kernel produces identical bit patterns to the AVX2 sibling for
all inputs, including the pathological range. For `|x| > 2^31 · π/2
≈ 3.37e9`, `_mm256_cvtps_epi32(x * 2/π)` returns the integer-
indefinite value `0x80000000`, and the resulting reconstructed
output diverges from the scalar `sinf` tail-loop fallback. This is
existing behavior of every SIMD impl in the file (SSE4.1, AVX2,
AVX2+FMA, AVX-512F) — the new AVX impl matches them exactly, not
the scalar generic path. No new pathology is introduced. For NaN
input: `_mm256_round_ps` and `_mm256_cvtps_epi32` propagate to a
deterministic NaN-or-indefinite-integer; reconstruction produces a
NaN, matching the AVX2 sibling.

## Verification

**VC1, tier present.** All six new function symbols
(`volk_32f_{sin,cos}_32f_{a,u}_avx`,
`volk_32f_sincos_32f_x2_{a,u}_avx`) compile into the five machine
objects that include the `avx` arch:

```
$ grep -lE "volk_32f_(sin|cos|sincos)_32f(_x2)?_(a|u)_avx\b" \
       build/lib/volk_machine_*.c
build/lib/volk_machine_avx_64_mmx_orc.c
build/lib/volk_machine_avx2_64_mmx_orc.c
build/lib/volk_machine_avx512cd_64_mmx_orc.c
build/lib/volk_machine_avx512dq_64_mmx_orc.c
build/lib/volk_machine_avx512f_64_mmx_orc.c
```

On an AVX-only host the runtime dispatcher selects the `avx`
machine (per `gen/machines.xml:61`), which exposes `_a_avx` /
`_u_avx`. **Directly verified** on AWS `c3.large` (Intel Xeon
E5-2680 v2 Ivy Bridge, AVX-only): `volk-config-info --machine`
reports `avx_64_mmx` selected, and the per-kernel benchmark shows
the new impls dispatched and exercised.

**VC2, QA passes.** Full `ctest` suite passes 254/254 in 250.55s.
The three modified kernels' QA tests pass at default tolerance
individually.

**VC3, accuracy matches existing tiers.** `volk_ulp_profile`
reports `max=3 ULP, mean=0.3, rms=0.6` for the new `_a_avx` and
`_u_avx` impls on all three kernels — the same envelope as the
existing `_a_sse4_1` siblings. (An envelope match is not proof of
byte-identical outputs, and the `_a_avx2_fma` / `_a_avx512f` siblings
are not covered by this claim — this section previously said
"byte-identical" to all four sibling tiers, which overclaimed.)

**VC4, faster than SSE4.1 on AVX-only hardware.** Measured two
ways, on two different microarchitectures. Both confirm the gain.

*Dev-host (Skylake-class, AVX2-capable, AVX impl built but not
dispatcher-selected at runtime — `volk_profile` times every built
impl regardless of selection):*

```
volk_32f_sin_32f       a_avx vs a_sse4_1: 1.48x
                       u_avx vs u_sse4_1: 1.48x
volk_32f_cos_32f       a_avx vs a_sse4_1: 1.44x
                       u_avx vs u_sse4_1: 1.44x
volk_32f_sincos_32f_x2 a_avx vs a_sse4_1: 1.50x
                       u_avx vs u_sse4_1: 1.50x
```

*Real silicon (AWS `c3.large`, Intel Xeon E5-2680 v2 Ivy Bridge,
AVX present, NO AVX2, NO FMA — the exact hardware class issue #48
targets; dispatcher selects `avx_64_mmx` machine on this host,
which exposes the new `_a_avx` / `_u_avx` impls):*

```
volk_32f_sin_32f       a_avx vs a_sse4_1: 1.45x
                       u_avx vs u_sse4_1: 1.45x
volk_32f_cos_32f       a_avx vs a_sse4_1: 1.43x
                       u_avx vs u_sse4_1: 1.45x
volk_32f_sincos_32f_x2 a_avx vs a_sse4_1: 1.42x
                       u_avx vs u_sse4_1: 1.43x
```

The two measurements agree within ~0.05× per kernel. Ivy Bridge
lands slightly below Skylake-proxy, consistent with weaker 256-bit
FP throughput — but well within the gain envelope.

These are honest gains, below the ~2× theoretical SIMD-width
ratio. Root cause is the expected combination of split-128 mask
synthesis overhead (~5-7 extra instructions per mask vs. AVX2's
single `_mm256_and_si256` + `_mm256_cmpeq_epi32` sequence) and the
absence of FMA in the argument reduction. The AVX2 path on the
Skylake host runs at ~1.93× SSE4.1, so the AVX-vs-AVX2 gap of
~25% is the cost of being limited to AVX1 intrinsics.

**VC5, no regression on other tiers.** Cross-branch per-impl
medians for `_a_sse4_1` / `_a_avx2` / `_a_avx2_fma` / `_a_avx512f`
across the three kernels are all within ±1.4% between `origin/main`
and this branch — well under the ±3% noise floor of
`volk_profile`. Maximum observed delta: -1.3% on
`volk_32f_cos_32f` `u_avx512f` (improvement, not regression).
This was expected because no code outside `#ifdef LV_HAVE_AVX` was
modified.

PNG evidence plots are attached below.

## Diff shape

Pure-additions diff: 4 files changed, 492 insertions, **0
deletions**. No existing line was modified or reformatted.

```
include/volk/volk_avx_intrinsics.h     +78
kernels/volk/volk_32f_sin_32f.h       +123
kernels/volk/volk_32f_cos_32f.h       +133
kernels/volk/volk_32f_sincos_32f_x2.h +158
```

Each new code block matches the surrounding sibling-impl
conventions (variable scope, parameter naming, include order)
rather than diverging toward greenfield GREP1 ideals — a
reviewer comparing my `_a_avx` against the existing `_a_avx2`
directly above it should see structurally identical functions
modulo the AVX1 substitutions.

## Static analysis and sanitizers

Run on the four modified files and the QA suite. Output filtered
to lines added by this branch.

- `cppcheck --enable=all --inconclusive`: clean (only `unusedFunction`
  false positives from dispatcher-table indirection — flagged on
  every kernel impl, pre-existing pattern).
- `cpplint`: clean (every flagged item is a Google-style convention
  that conflicts with VOLK's `.clang-format`).
- `clang-tidy` with `bugprone-*`, `readability-*`, `performance-*`,
  `clang-analyzer-*`: clean (63 style flags, all sibling-matching
  choices — lowercase `f` suffix, math identifiers, Intel `_mm256_*`
  naming).
- `scan-build`: clean for my files (19 bugs reported elsewhere in
  the codebase, none mine).
- `include-what-you-use`: clean for my headers.
- `ASan + UBSan`: 3/3 instrumented QA tests pass; zero address
  errors, zero undefined behavior.
- `TSan`: 3/3 instrumented QA tests pass; zero data races (after
  the standard Ubuntu 24.04 ASLR workaround via `setarch -R`).

## Verification performed by author

- [x] `ctest --output-on-failure` passes locally — 254/254 in 250.55s
- [x] `volk_ulp_profile` envelope for the new impls matches the
      `_a_sse4_1` siblings (`max=3 ULP, mean=0.3, rms=0.6`; the
      FMA/AVX-512 siblings are not covered — see VC3); matched on
      both Skylake dev host and Ivy Bridge `c3.large`
- [x] `volk_profile -T 15 --trial-csv` shows 1.44-1.50× `_a_avx`
      vs `_a_sse4_1` on Skylake dev host (proxy measurement)
- [x] **Same benchmark on AWS `c3.large` (Ivy Bridge, AVX-only
      silicon) shows 1.42-1.45×** — proxy confirmed within ~0.05×
- [x] Per-impl PNGs attached
- [x] Sanitizer-instrumented QA (ASan+UBSan, TSan) passes 3/3 for
      the three modified kernels

PR target: `mtibbits/volk` `dev/all-prs` (fork integration branch).
Refs: mtibbits/volk#48

