### PR TITLE
gen: consolidate AVX-512 tier; add `<provides>` schema extension

### DIFF
--- a/gen/archs.xml
+++ b/gen/archs.xml
@@ -162,27 +162,40 @@ at the top, as a last resort.
     <alignment>32</alignment>
 </arch>
 
+<!--
+    SKX-baseline AVX-512 tier. Bundles F + CD + DQ + BW + VL because every
+    AVX-512-capable CPU shipping in 2017 or later carries all five
+    sub-extensions (Skylake-X and successors, Zen 4+); the only F-without-
+    the-others parts (Xeon Phi Knights Landing / Knights Mill) are
+    discontinued. The arch name remains "avx512f" for kernel-header source
+    compatibility: 49 kernels gate on LV_HAVE_AVX512F directly. The
+    <provides> children define LV_HAVE_AVX512CD/DQ/BW/VL on the generated
+    machine .c so the 4 DQ-gated and 6 BW-gated kernels also compile
+    unchanged. See issue mtibbits/volk#53.
+-->
 <arch name="avx512f">
     <check name="avx512f"></check>
-    <flag compiler="gnu">-mavx512f</flag>
-    <flag compiler="clang">-mavx512f</flag>
-    <flag compiler="msvc">/arch:AVX512F</flag>
-    <alignment>64</alignment>
-</arch>
-
-<arch name="avx512cd">
     <check name="avx512cd"></check>
-    <flag compiler="gnu">-mavx512cd</flag>
-    <flag compiler="clang">-mavx512cd</flag>
-    <flag compiler="msvc">/arch:AVX512CD</flag>
-    <alignment>64</alignment>
-</arch>
-
-<arch name="avx512dq">
     <check name="avx512dq"></check>
+    <check name="avx512bw"></check>
+    <check name="avx512vl"></check>
+    <flag compiler="gnu">-mavx512f</flag>
+    <flag compiler="gnu">-mavx512cd</flag>
     <flag compiler="gnu">-mavx512dq</flag>
+    <flag compiler="gnu">-mavx512bw</flag>
+    <flag compiler="gnu">-mavx512vl</flag>
+    <flag compiler="clang">-mavx512f</flag>
+    <flag compiler="clang">-mavx512cd</flag>
     <flag compiler="clang">-mavx512dq</flag>
+    <flag compiler="clang">-mavx512bw</flag>
+    <flag compiler="clang">-mavx512vl</flag>
+    <flag compiler="msvc">/arch:AVX512F</flag>
+    <flag compiler="msvc">/arch:AVX512CD</flag>
     <flag compiler="msvc">/arch:AVX512DQ</flag>
+    <provides>avx512cd</provides>
+    <provides>avx512dq</provides>
+    <provides>avx512bw</provides>
+    <provides>avx512vl</provides>
     <alignment>64</alignment>
 </arch>
 

--- a/gen/machines.xml
+++ b/gen/machines.xml
@@ -67,19 +67,10 @@
 <archs>generic 32|64| mmx| sse sse2 sse3 ssse3 sse4_1 sse4_2 popcount avx fma avx2 orc|</archs>
 </machine>
 
+<!-- SKX-baseline AVX-512 tier; see gen/archs.xml for tier definition. -->
 <!-- trailing | bar means generate without either for MSVC -->
 <machine name="avx512f">
 <archs>generic 32|64| mmx| sse sse2 sse3 ssse3 sse4_1 sse4_2 popcount avx fma avx2 avx512f orc|</archs>
-</machine>
-
-<!-- trailing | bar means generate without either for MSVC -->
-<machine name="avx512cd">
-<archs>generic 32|64| mmx| sse sse2 sse3 ssse3 sse4_1 sse4_2 popcount avx fma avx2 avx512f avx512cd orc|</archs>
-</machine>
-
-<!-- trailing | bar means generate without either for MSVC -->
-<machine name="avx512dq">
-<archs>generic 32|64| mmx| sse sse2 sse3 ssse3 sse4_1 sse4_2 popcount avx fma avx2 avx512f avx512dq orc|</archs>
 </machine>
 
 </grammar>

--- a/gen/volk_arch_defs.py
+++ b/gen/volk_arch_defs.py
@@ -21,6 +21,8 @@ class arch_class(object):
             try: setattr(self, key, cast(kwargs[key]))
             except: setattr(self, key, failval)
         self.checks = checks
+        prov = kwargs.get('provides', [])
+        self.provides = prov if isinstance(prov, list) else []
         assert(self.name)
         self._flags = flags
 
@@ -69,7 +71,11 @@ for arch_xml in archs_xml:
         name = flag_xml.attributes["compiler"].value
         if name not in flags: flags[name] = list()
         flags[name].append(flag_xml.firstChild.data)
-    register_arch(flags=flags, checks=checks, **kwargs)
+    provides = [p.firstChild.data for p in arch_xml.getElementsByTagName("provides")]
+    # The generic child-element loop above stashed the first <provides>'s string
+    # data under kwargs['provides']; discard it so the list form below wins.
+    kwargs.pop('provides', None)
+    register_arch(flags=flags, checks=checks, provides=provides, **kwargs)
 
 if __name__ == '__main__':
     print(archs)

--- a/gen/volk_machine_defs.py
+++ b/gen/volk_machine_defs.py
@@ -23,6 +23,19 @@ class machine_class(object):
             self.arch_names.append(arch_name)
         self.alignment = max([a.alignment for a in self.archs])
 
+    @property
+    def impl_arch_names(self):
+        # arch_names plus each arch's <provides> names. Used by the
+        # per-machine kernel-impl filter in get_impls; downstream consumers
+        # that care about *real* (declared) arch entries — like the
+        # machine-availability check in volk_compile_utils — stick with
+        # arch_names. Provides count as arch names only for source-gate
+        # dispatch (LV_HAVE_<provides>), not for CPUID detection.
+        names = list(self.arch_names)
+        for arch in self.archs:
+            names.extend(arch.provides)
+        return names
+
     def __repr__(self): return self.name
 
 def register_machine(name, archs):

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -217,7 +217,6 @@ if(NOT CPU_IS_x86)
     overrule_arch(sse4_2 "Architecture is not x86 or x86_64")
     overrule_arch(avx "Architecture is not x86 or x86_64")
     overrule_arch(avx512f "Architecture is not x86 or x86_64")
-    overrule_arch(avx512cd "Architecture is not x86 or x86_64")
 endif(NOT CPU_IS_x86)
 
 ########################################################################

--- a/tmpl/volk_config_fixed.tmpl.h
+++ b/tmpl/volk_config_fixed.tmpl.h
@@ -10,6 +10,11 @@
 #ifndef INCLUDED_VOLK_CONFIG_FIXED_H
 #define INCLUDED_VOLK_CONFIG_FIXED_H
 
+/* LV_<provides> aliases below share the parent arch's bit index by design:
+ * the consolidated arch's CPUID check guarantees all <provides>'d sub-extensions
+ * are present together, so OR'ing them in generated dispatch-table deps masks
+ * (e.g. `(1 << LV_AVX512F) | (1 << LV_AVX512DQ)`) degenerates to a single-bit
+ * test - which is the correct semantic, not a bug. */
 %for i, arch in enumerate(archs):
 #define LV_${arch.name.upper()} ${i}
 %for prov in arch.provides:

--- a/tmpl/volk_config_fixed.tmpl.h
+++ b/tmpl/volk_config_fixed.tmpl.h
@@ -12,6 +12,9 @@
 
 %for i, arch in enumerate(archs):
 #define LV_${arch.name.upper()} ${i}
+%for prov in arch.provides:
+#define LV_${prov.upper()} ${i}
+%endfor
 %endfor
 
 #endif /*INCLUDED_VOLK_CONFIG_FIXED*/

--- a/tmpl/volk_machine_xxx.tmpl.c
+++ b/tmpl/volk_machine_xxx.tmpl.c
@@ -12,6 +12,9 @@
 
 %for arch in this_machine.archs:
 #define LV_HAVE_${arch.name.upper()} 1
+%for prov in arch.provides:
+#define LV_HAVE_${prov.upper()} 1
+%endfor
 %endfor
 
 #include <volk/volk_common.h>

--- a/tmpl/volk_machine_xxx.tmpl.c
+++ b/tmpl/volk_machine_xxx.tmpl.c
@@ -8,7 +8,7 @@
  */
 
 <% this_machine = machine_dict[args[0]] %>
-<% arch_names = this_machine.arch_names %>
+<% arch_names = this_machine.impl_arch_names %>
 
 %for arch in this_machine.archs:
 #define LV_HAVE_${arch.name.upper()} 1


### PR DESCRIPTION
# gen: consolidate AVX-512 tier; add `<provides>` schema extension

## Summary

Two changes, one shipped together because they're load-bearing for each other:

1. **Consolidate the three AVX-512 arch entries.** `avx512f`, `avx512cd`, `avx512dq`, and the orphan `LV_HAVE_AVX512BW` reference fold into a single SKX-baseline arch + machine that bundles F + CD + DQ + BW + VL. Every Intel and AMD AVX-512 CPU shipping after Skylake-X (2017) carries all five sub-extensions; the only F-without-the-others parts (Xeon Phi Knights Landing / Knights Mill) are discontinued. The previous three-way split never discriminated between any shipping silicon — runtime selection always fell through to `avx512dq` on any AVX-512-capable host.

2. **Add a new `<provides>` child element to the `<arch>` XML schema.** This lets one arch declare additional `LV_HAVE_*` macros (and `LV_*` enum aliases) for source-gate compatibility, so the consolidated `avx512f` arch defines `LV_HAVE_AVX512CD/DQ/BW/VL` on its machine without modifying any of the 49 F-gated, 4 DQ-gated, or 6 BW-gated kernel headers. The mechanism generalises to future tier consolidations (Ice Lake / VBMI, AVX10).

The schema extension is reusable, but this PR's only consumer is the consolidated AVX-512 arch. If reviewers prefer the point-fix (special-case the AVX-512 case in templates without a new schema element), I'm open to refactoring — the consolidation is the load-bearing change.

### User-visible behaviour

- `volk_get_machine()` returns `"avx512f"` on hosts that previously returned `"avx512cd"` or `"avx512dq"`.
- Per-kernel impl-name strings (e.g. `volk_32f_log2_32f_a_avx512dq`) are preserved across the consolidation, so saved `~/.volk/volk_config` profiles remain valid.
- Xeon Phi Knights Landing / Knights Mill (F-only, no CD/DQ/BW/VL — both discontinued) no longer load the AVX-512 machine; they dispatch via AVX2 instead. No CPU sold after 2017 is affected.
- The 6 previously-orphan `LV_HAVE_AVX512BW` kernel implementations now compile and become reachable. They were verified to pass `ctest -R` on real AVX-512 silicon; per-kernel benchmarking and `volk_profile` integration are follow-up work.

### Mechanism choice

A `<provides>` XML child element was chosen over template special-casing or flag-less arch stubs because:

- It generalises to future tier consolidations (Ice Lake / VBMI, AVX10) without further parser changes.
- It keeps detection (`<check>`) and source-gate provisioning (`<provides>`) as independent concerns.
- The `<provides>` mechanism itself is small: ~34 changed lines across the four generator/template files (`gen/volk_arch_defs.py`, `gen/volk_machine_defs.py`, `tmpl/volk_machine_xxx.tmpl.c`, `tmpl/volk_config_fixed.tmpl.h`). The full consolidation diff is 7 files, +60/−27 — see "Files touched".

### Files touched

```
gen/archs.xml                  — collapse 3 avx512 arch blocks into 1 (with <provides>)
gen/machines.xml               — collapse 3 avx512 machine blocks into 1
gen/volk_arch_defs.py          — parse <provides> children
gen/volk_machine_defs.py       — expose machine.impl_arch_names = arch_names + provides
tmpl/volk_machine_xxx.tmpl.c   — emit LV_HAVE_<provides>; use impl_arch_names for dispatch
tmpl/volk_config_fixed.tmpl.h  — emit LV_<provides> bit-index aliases
lib/CMakeLists.txt             — drop dangling overrule_arch(avx512cd) line
```

Zero kernel modifications. `git diff --stat origin/main -- kernels/` is empty.

## Related issues

Fixes mtibbits/volk#53 (filed against fork; upstream equivalent to be opened against gnuradio/volk pending maintainer review).

## Testing

Verified on full-AVX-512 Skylake-class silicon (dev box):

- `cmake --build`: clean, no warnings about removed arch/machine names.
- Generated `volk_machine_avx512f_64_mmx_orc.c` defines all five `LV_HAVE_AVX512{F,CD,DQ,BW,VL}` macros.
- Generated `volk_machine_avx512cd_*.c` and `volk_machine_avx512dq_*.c` no longer exist in the build tree.
- `volk-config-info --machine` returns `avx512f_64_mmx_orc` (the consolidated machine).
- `ctest`: 254/254 passed (132 sec wall time). **Caveat: this same 254/254 pass count appeared on the initial broken commit on this branch — see the "Test gap & follow-up" section below.** The load-bearing evidence is the verbose `ctest -V` dispatch logs, not the pass count.
- Verbose `ctest -V` confirms the AVX-512 sub-extension impls are actually selected at runtime. Example: `a_avx512dq` wins ranking for `volk_32f_log2_32f` at 14.78x speedup over generic, beating the F-only `a_avx512` variant at 14.28x. Individual `ctest -R` spot-checks pass for all 4 DQ-gated kernels and all 6 BW-gated (previously-orphan) kernels.
- ASan: 254/254 pass.
- UBSan: 254/254 pass.

### Test gap & follow-up

Code review caught (and the second commit on this branch fixes) a class of bug that VOLK's own ctest cannot detect: the `qa_<kernel>` tests construct their own function-pointer table via `lib/qa_utils.cc` and call impls by direct lookup, bypassing the per-machine `volk_machine_<name>.impl_names[]` array that production callers actually use. A codegen-pipeline change that silently drops impls from those production tables can pass ctest 254/254 and still ship a runtime dispatch regression — which is exactly what the first commit on this branch did before the fix.

The bug was caught manually by `grep -c avx512dq /path/to/volk_machine_avx512f_*.c` returning `0` during independent code review. That's not a sustainable mitigation for the next contributor adding a `<provides>`-using arch. **A separate follow-up issue should be filed proposing an automated regression check** (CMake-time integrity check, or golden-file dispatch-matrix ctest). I'm deliberately not bundling that with this PR to keep scope surgical; happy to file the follow-up separately if you'd like.

(The branch is deliberately left unsquashed as three commits — the consolidation, the dispatch-table fix, and the bit-aliasing comment — for this reason. The bug-and-fix sequence is the cautionary tale that motivates the follow-up.)

## Checklist

- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`) — 254/254 on AVX-512 silicon
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in (no kernel-header touches; one structural consolidation)

