### PR TITLE
cmake: add per-machine impl dispatch-table integrity check

### DIFF
--- a/cmake/check_dispatch_tables.py
+++ b/cmake/check_dispatch_tables.py
@@ -45,18 +45,30 @@ def parse_machine_c(path: Path):
     #     {<deps masks>},
     #     ...
     #
-    # We pin to the *first* {"..."} brace group after the kernel-name
-    # string. The deps mask block uses {(1 << LV_X), ...} which has no
-    # double-quotes, so the next-string-group anchor is unambiguous.
+    # The match anchor is a kernel-name string immediately followed by a
+    # {"..."} brace group. The deps mask block uses {(1 << LV_X), ...}
+    # which has no double-quotes, so a string-only brace group can only
+    # be the impl-name array.
+    #
+    # `dispatch[kernel_name] = names` assigns into a dict: if a kernel
+    # ever had multiple matching blocks (it doesn't today), only the
+    # last would survive. One block per kernel is invariant per the
+    # generator's structure -- but if that ever changes, the assertion
+    # below catches the regression.
+    #
     # The inner string-group quantifier is * (not +) so a hypothetical
     # zero-impl kernel still enters the dispatch dict with an empty set,
-    # rather than silently dropping out and masking a regression.
+    # rather than silently dropping out and masking a real regression.
     block_re = re.compile(
         r'"(volk_\w+)"\s*,\s*\{\s*((?:"[^"]+"\s*,?\s*)*)\}',
         re.M,
     )
     dispatch = {}
     for kernel_name, names_block in block_re.findall(text):
+        assert kernel_name not in dispatch, (
+            f"{path.name}: kernel {kernel_name!r} has multiple impl-name "
+            f"arrays; generator structure changed -- update this parser."
+        )
         names = set(re.findall(r'"([^"]+)"', names_block))
         dispatch[kernel_name] = names
     return defined, dispatch
@@ -109,6 +121,27 @@ def main():
         print(f"error: failed to import volk_kernel_defs: {e}", file=sys.stderr)
         sys.exit(2)
 
+    # Defensive assertions: this script depends on gen/volk_kernel_defs.py
+    # internals (kernels list, kernel._impls, impl.deps, impl.name). If any
+    # of those go away, fail fast with a clear message rather than later
+    # with a cryptic AttributeError mid-iteration.
+    if not hasattr(K, "kernels") or not K.kernels:
+        print("error: gen/volk_kernel_defs exposes no `kernels` attribute "
+              "(or it is empty)", file=sys.stderr)
+        sys.exit(2)
+    _k = K.kernels[0]
+    for attr in ("_impls", "name"):
+        if not hasattr(_k, attr):
+            print(f"error: gen/volk_kernel_defs kernel objects lack `{attr}` "
+                  f"-- generator API changed; update this check.",
+                  file=sys.stderr)
+            sys.exit(2)
+    if _k._impls and not all(hasattr(i, "deps") and hasattr(i, "name")
+                             for i in _k._impls):
+        print("error: gen/volk_kernel_defs impl objects lack `deps` or `name` "
+              "-- generator API changed; update this check.", file=sys.stderr)
+        sys.exit(2)
+
     machine_files = sorted(args.build_lib_dir.glob("volk_machine_*.c"))
     if not machine_files:
         print(f"warning: no volk_machine_*.c files in {args.build_lib_dir} "
@@ -127,6 +160,12 @@ def main():
         print("missing from the machine's per-kernel _impl_names[] dispatch", file=sys.stderr)
         print("array. The kernel will silently fall back to a lower impl at", file=sys.stderr)
         print("runtime even though the better impl is present in the .so.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("To diagnose, look at:", file=sys.stderr)
+        print("  - gen/volk_kernel_defs.py    (impl-deps extraction)", file=sys.stderr)
+        print("  - gen/volk_machine_defs.py   (per-machine arch set)", file=sys.stderr)
+        print("  - tmpl/volk_machine_xxx.tmpl.c (dispatch-array codegen)", file=sys.stderr)
+        print("  - gen/archs.xml, gen/machines.xml (arch/machine grammar)", file=sys.stderr)
         print("", file=sys.stderr)
         print("See https://github.com/mtibbits/volk/issues/58 for context.", file=sys.stderr)
         print("", file=sys.stderr)

--- a/cmake/check_dispatch_tables.py
+++ b/cmake/check_dispatch_tables.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Per-machine impl dispatch-table integrity check.
+
+Reads each generated volk_machine_<name>.c file. For each kernel block,
+verifies that every implementation whose LV_HAVE_* source-gates are all
+defined by that machine's #define section is present in the machine's
+per-kernel _impl_names[] dispatch array.
+
+Catches the bug class introduced (and later fixed) by fork PR
+mtibbits/volk#57 cd2d50d: a codegen-pipeline change that silently
+filtered impls out of production dispatch tables. ctest does not
+catch this -- VOLK's qa_<kernel> tests construct their own
+function-pointer table via lib/qa_utils.cc and bypass the per-machine
+arrays that production callers use.
+
+Invoked by lib/CMakeLists.txt as a custom target made an explicit
+dependency of volk_obj.
+
+Exit codes:
+    0  all dispatch tables consistent with their machine's gates,
+       or no machine .c files to check (cross-compile lane)
+    1  one or more impls are missing from a machine's dispatch
+       (prints each violation with machine name, kernel, impl, gates)
+    2  internal error (parse failure, missing inputs)
+
+See mtibbits/volk#58 for context.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def parse_machine_c(path: Path):
+    """Return (defined_macros: set[str], dispatch: dict[kernel_name, set[impl_name]])."""
+    text = path.read_text()
+    defined = set(re.findall(r'^#define (LV_HAVE_\w+)\s+1', text, re.M))
+
+    # Each kernel block in the generated machine .c has this shape:
+    #
+    #     "volk_<kernel>",
+    #     {"impl0", "impl1", ...},
+    #     {<deps masks>},
+    #     ...
+    #
+    # We pin to the *first* {"..."} brace group after the kernel-name
+    # string. The deps mask block uses {(1 << LV_X), ...} which has no
+    # double-quotes, so the next-string-group anchor is unambiguous.
+    block_re = re.compile(
+        r'"(volk_\w+)"\s*,\s*\{\s*((?:"[^"]+"\s*,?\s*)+)\}',
+        re.M,
+    )
+    dispatch = {}
+    for kernel_name, names_block in block_re.findall(text):
+        names = set(re.findall(r'"([^"]+)"', names_block))
+        dispatch[kernel_name] = names
+    return defined, dispatch
+
+
+def check_machine(path: Path, all_kernels):
+    """Return a list of (machine, kernel, impl, gates) violations for this file."""
+    defined, dispatch = parse_machine_c(path)
+    violations = []
+    machine_name = path.stem.replace("volk_machine_", "")
+
+    for kernel in all_kernels:
+        actual_impls = dispatch.get(kernel.name)
+        if actual_impls is None:
+            # Kernel not in this machine .c at all -- should never happen
+            # (every machine includes every kernel header per the template).
+            continue
+        # Reads kernel._impls (the unfiltered list) rather than calling
+        # the public kernel.get_impls(archs) because the latter applies
+        # the same intersection-with-archs filter we are auditing here;
+        # we want every declared impl, then apply our own gate test.
+        for impl in kernel._impls:
+            required = {f"LV_HAVE_{dep.upper()}" for dep in impl.deps}
+            if required.issubset(defined) and impl.name not in actual_impls:
+                violations.append((machine_name, kernel.name, impl.name,
+                                   sorted(required)))
+    return violations
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    ap.add_argument("--source-dir", required=True, type=Path,
+                    help="Volk source root (the dir with gen/, kernels/, ...)")
+    ap.add_argument("--build-lib-dir", required=True, type=Path,
+                    help="Build output dir containing volk_machine_*.c files")
+    args = ap.parse_args()
+
+    gen_dir = args.source_dir / "gen"
+    if not gen_dir.is_dir():
+        print(f"error: gen dir not found at {gen_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    sys.path.insert(0, str(gen_dir))
+    try:
+        import volk_kernel_defs as K  # noqa: E402
+    except Exception as e:
+        print(f"error: failed to import volk_kernel_defs: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    machine_files = sorted(args.build_lib_dir.glob("volk_machine_*.c"))
+    if not machine_files:
+        print(f"warning: no volk_machine_*.c files in {args.build_lib_dir} "
+              f"(nothing to check; likely a cross-compile lane that doesn't "
+              f"produce x86 machine .c)", file=sys.stderr)
+        sys.exit(0)
+
+    all_violations = []
+    for mc in machine_files:
+        all_violations.extend(check_machine(mc, K.kernels))
+
+    if all_violations:
+        print("DISPATCH TABLE INTEGRITY CHECK FAILED", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Impls compiled by the machine's #define LV_HAVE_* set are", file=sys.stderr)
+        print("missing from the machine's per-kernel _impl_names[] dispatch", file=sys.stderr)
+        print("array. The kernel will silently fall back to a lower impl at", file=sys.stderr)
+        print("runtime even though the better impl is present in the .so.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("See https://github.com/mtibbits/volk/issues/58 for context.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Violations:", file=sys.stderr)
+        for machine, kernel, impl, gates in all_violations:
+            gates_str = " && ".join(gates)
+            print(f"  {machine}: {kernel}.{impl} (gated on {gates_str})",
+                  file=sys.stderr)
+        sys.exit(1)
+
+    print(f"dispatch-table integrity: ok ({len(machine_files)} machines checked)")
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/check_dispatch_tables.py
+++ b/cmake/check_dispatch_tables.py
@@ -7,12 +7,12 @@ verifies that every implementation whose LV_HAVE_* source-gates are all
 defined by that machine's #define section is present in the machine's
 per-kernel _impl_names[] dispatch array.
 
-Catches the bug class introduced (and later fixed) by fork PR
-mtibbits/volk#57 cd2d50d: a codegen-pipeline change that silently
-filtered impls out of production dispatch tables. ctest does not
-catch this -- VOLK's qa_<kernel> tests construct their own
-function-pointer table via lib/qa_utils.cc and bypass the per-machine
-arrays that production callers use.
+Catches a class of bug VOLK's own ctest cannot detect: a
+codegen-pipeline change that silently filters impls out of production
+dispatch tables. The qa_<kernel> tests construct their own
+function-pointer table via lib/qa_utils.cc and never exercise the
+per-machine arrays that production callers use, so ctest 254/254 can
+pass even with the dispatch broken.
 
 Invoked by lib/CMakeLists.txt as a custom target made an explicit
 dependency of volk_obj.
@@ -35,7 +35,7 @@ from pathlib import Path
 
 def parse_machine_c(path: Path):
     """Return (defined_macros: set[str], dispatch: dict[kernel_name, set[impl_name]])."""
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     defined = set(re.findall(r'^#define (LV_HAVE_\w+)\s+1', text, re.M))
 
     # Each kernel block in the generated machine .c has this shape:
@@ -48,8 +48,11 @@ def parse_machine_c(path: Path):
     # We pin to the *first* {"..."} brace group after the kernel-name
     # string. The deps mask block uses {(1 << LV_X), ...} which has no
     # double-quotes, so the next-string-group anchor is unambiguous.
+    # The inner string-group quantifier is * (not +) so a hypothetical
+    # zero-impl kernel still enters the dispatch dict with an empty set,
+    # rather than silently dropping out and masking a regression.
     block_re = re.compile(
-        r'"(volk_\w+)"\s*,\s*\{\s*((?:"[^"]+"\s*,?\s*)+)\}',
+        r'"(volk_\w+)"\s*,\s*\{\s*((?:"[^"]+"\s*,?\s*)*)\}',
         re.M,
     )
     dispatch = {}
@@ -84,7 +87,10 @@ def check_machine(path: Path, all_kernels):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    ap = argparse.ArgumentParser(
+        description="Per-machine impl dispatch-table integrity check",
+        epilog="See mtibbits/volk#58 for context.",
+    )
     ap.add_argument("--source-dir", required=True, type=Path,
                     help="Volk source root (the dir with gen/, kernels/, ...)")
     ap.add_argument("--build-lib-dir", required=True, type=Path,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -59,6 +59,20 @@ VOLK unit tests compare the results of each kernel version to the generic versio
 Keep the generic kernel version as simple as possible and verify your optimized
 kernels against the generic version.
 
+## Per-machine dispatch-table integrity check
+
+CMake invokes `cmake/check_dispatch_tables.py` after codegen and before
+compiling any `volk_machine_<name>.c`. The script verifies that every
+kernel implementation whose `LV_HAVE_*` source-gates are all defined by
+a machine's macro set is also present in that machine's per-kernel
+dispatch array. If you change anything under `gen/` or `tmpl/` and the
+build fails with `DISPATCH TABLE INTEGRITY CHECK FAILED`, your change
+silently dropped impls from the dispatch table on at least one machine
+— the failure message names the affected (machine, kernel, impl, gates).
+This is a class of bug VOLK's own ctest cannot detect, because the
+`qa_<kernel>` test harness bypasses the per-machine dispatch arrays
+production callers use. See mtibbits/volk#58 for background.
+
 ## The Buddy Principle: Submit One, Review One
 
 When you've submitted a pull request, please take the time to review another

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -538,6 +538,19 @@ if(MSVC)
     set_source_files_properties(${volk_sources} PROPERTIES LANGUAGE CXX)
 endif()
 
+# Verify per-machine dispatch-table integrity after codegen, before
+# compiling any machine .c file. See mtibbits/volk#58
+# for the bug class this catches.
+add_custom_target(volk_check_dispatch_tables
+    COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_DASH_B}
+            ${PROJECT_SOURCE_DIR}/cmake/check_dispatch_tables.py
+            --source-dir ${PROJECT_SOURCE_DIR}
+            --build-lib-dir ${PROJECT_BINARY_DIR}/lib
+    DEPENDS ${volk_gen_sources}
+    COMMENT "Checking per-machine impl dispatch-table integrity"
+    VERBATIM
+)
+
 #Create an object to reference Volk source and object files.
 #
 #NOTE: This object cannot be used to propagate include directories or
@@ -545,6 +558,7 @@ endif()
 #work. There are options starting with CMake 3.13 for using the OBJECT
 #to propagate this information.
 add_library(volk_obj OBJECT ${volk_sources})
+add_dependencies(volk_obj volk_check_dispatch_tables)
 target_include_directories(
     volk_obj
     PRIVATE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>


### PR DESCRIPTION
# cmake: add per-machine impl dispatch-table integrity check

## Summary

Adds `cmake/check_dispatch_tables.py`, invoked as a build dependency of `volk_obj`, that verifies every kernel impl whose `LV_HAVE_*` source-gates are all defined by a machine's macro set appears in that machine's per-kernel `_impl_names[]` dispatch array.

This closes a test-coverage gap that the AVX-512 tier consolidation (fork PR #57) ran into during implementation: a codegen-pipeline change can silently filter impls out of the dispatch table that production callers use, while ctest 254/254 keeps passing because the `qa_<kernel>` test harness constructs its own function-pointer table and never exercises the per-machine arrays. The bug only surfaced via manual inspection of generated machine .c files during code review. The check formalizes that manual inspection step.

## Mechanism

The script imports `gen/volk_kernel_defs.py` to reuse the existing `LV_HAVE_(\w+)` deps extractor (avoids re-implementing gate parsing). It then parses each generated `volk_machine_<name>.c` for two things:

1. The `#define LV_HAVE_*` block at the top — what gates the machine has activated.
2. Each per-kernel `{"impl0", "impl1", ...}` string array — what impls are actually in the dispatch table.

For each (machine, kernel) pair: if all of an impl's `LV_HAVE_*` deps are in the machine's defined set but the impl name isn't in the dispatch array, the check reports a violation and exits 1, which causes the CMake build to fail.

Empty `--build-lib-dir` (cross-compile lane producing no x86 machine .c) is a benign no-op: warning to stderr, exit 0.

## Related issues

Closes mtibbits/volk#58. Motivated by the bug-and-fix sequence on mtibbits/volk#57 (the consolidation commit's dropped-dispatch-entry regression and its follow-up fix; that branch's SHAs have since been restacked).

## Testing

Verified on the dev box (Skylake-class, full AVX-512):

- Clean baseline on `origin/main`: check prints `dispatch-table integrity: ok (12 machines checked)`, exit 0. Zero false positives — acceptance criterion satisfied.
- CMake build invokes the check at ~26% of build (post-codegen, before `volk_obj` starts compiling its sources). Direct builds of an individual machine `.c.o` target via `cmake --build . --target volk_machine_xyz.c.o` would bypass the check; this is a known niche and not a regular workflow.
- With a deliberate template-injection fixture (inject `#define LV_HAVE_AVX512DQ 1` into the macro section of `avx512f`-containing machines without touching the impl filter): `cmake --build` fails with exit 2 and a clean violation list naming 16 affected impls across the `avx512f` and `avx512cd` machines, each with `(machine, kernel, impl, gates)` identification.
- After fixture revert: clean build, check passes, `ctest` 254/254 pass (138 sec wall time).
- ASan / UBSan: 254/254 pass. TSan: pre-existing Ubuntu-24.04 ASLR issue (unrelated to this PR).
- Zero kernel modifications. `git diff --stat origin/main -- kernels/` is empty.

## Forward-looking

The check is generic — it isn't AVX-512-specific. The same class of regression could in principle hit any future arch/machine grammar edit (NEON impls filtered from `neon`/`neonv7`/`neonv8` machines, RVV impls missing from `rv64gcv` after an `<archs>` edit, future `<provides>`-using arches reintroducing the same dropped-dispatch-entry class). None of those have been observed; the check covers them by construction.

This is fork-only for now (target: mtibbits/volk). The script and CMake hook are origin/main-compatible — if upstream wants the same coverage later, the changeset can land there unchanged. See [imPlan-potentialFutureEnhancements.md](imPlan-potentialFutureEnhancements.md) for deferred alternatives (golden-file ctest matrix; reverse-direction "impl in dispatch → gates defined" check).

## Checklist

- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`) — 254/254 on AVX-512 silicon
- [x] Commit is signed off (`git commit -s`)
- [x] PR does one thing — adds a build-time check; no kernel/runtime changes

