### PR TITLE
kernels: add AVX-512 tier to volk_32f_stddev_and_mean_32f_x2

### DIFF
--- a/include/volk/volk_avx512_intrinsics.h
+++ b/include/volk/volk_avx512_intrinsics.h
@@ -268,4 +268,23 @@ static inline __m512 _mm512_log2_poly_avx512(const __m512 x)
     return poly;
 }
 
+////////////////////////////////////////////////////////////////////////
+// Youngs & Cramer recurrence accumulator: update a running square-sum
+// triple (sq_acc, acc, val) over 16 parallel lanes. Algebraic form:
+//   aux = (n+1) * val - acc
+//   sq_acc += rec * aux * aux
+// where rec = 1 / (n * (n+1)) is precomputed scalar broadcast.
+// AVX-512 variant fuses the (n+1)*val - acc into a single fmsub,
+// strictly more accurate than the AVX sibling's mul + sub pair.
+// Requires AVX512F.
+////////////////////////////////////////////////////////////////////////
+static inline __m512 _mm512_accumulate_square_sum_ps(
+    __m512 sq_acc, __m512 acc, __m512 val, __m512 rec, __m512 aux)
+{
+    aux = _mm512_fmsub_ps(aux, val, acc);
+    aux = _mm512_mul_ps(aux, aux);
+    aux = _mm512_mul_ps(aux, rec);
+    return _mm512_add_ps(sq_acc, aux);
+}
+
 #endif /* INCLUDE_VOLK_VOLK_AVX512_INTRINSICS_H_ */

--- a/kernels/volk/volk_32f_stddev_and_mean_32f_x2.h
+++ b/kernels/volk/volk_32f_stddev_and_mean_32f_x2.h
@@ -416,6 +416,84 @@ static inline void volk_32f_stddev_and_mean_32f_x2_u_avx(float* stddev,
 }
 #endif /* LV_HAVE_AVX */
 
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void volk_32f_stddev_and_mean_32f_x2_u_avx512(float* stddev,
+                                                            float* mean,
+                                                            const float* inputBuffer,
+                                                            unsigned int num_points)
+{
+    if (num_points < 32) {
+        volk_32f_stddev_and_mean_32f_x2_generic(stddev, mean, inputBuffer, num_points);
+        return;
+    }
+
+    const float* in_ptr = inputBuffer;
+
+    __VOLK_ATTR_ALIGNED(64) float SumLocal[32] = { 0.f };
+    __VOLK_ATTR_ALIGNED(64) float SquareSumLocal[32] = { 0.f };
+
+    const unsigned int thirty_second_points = num_points / 32;
+
+    __m512 Sum0 = _mm512_loadu_ps(in_ptr);
+    in_ptr += 16;
+    __m512 Sum1 = _mm512_loadu_ps(in_ptr);
+    in_ptr += 16;
+
+    __m512 SquareSum0 = _mm512_setzero_ps();
+    __m512 SquareSum1 = _mm512_setzero_ps();
+    __m512 Values0, Values1;
+    __m512 Aux0, Aux1;
+    __m512 Reciprocal;
+
+    for (uint32_t number = 1; number < thirty_second_points; number++) {
+        Values0 = _mm512_loadu_ps(in_ptr);
+        in_ptr += 16;
+        __VOLK_PREFETCH(in_ptr + 16);
+
+        Values1 = _mm512_loadu_ps(in_ptr);
+        in_ptr += 16;
+        __VOLK_PREFETCH(in_ptr + 16);
+
+        float n = (float)number;
+        float n_plus_one = n + 1.f;
+
+        Reciprocal = _mm512_set1_ps(1.f / (n * n_plus_one));
+
+        Sum0 = _mm512_add_ps(Sum0, Values0);
+        Aux0 = _mm512_set1_ps(n_plus_one);
+        SquareSum0 =
+            _mm512_accumulate_square_sum_ps(SquareSum0, Sum0, Values0, Reciprocal, Aux0);
+
+        Sum1 = _mm512_add_ps(Sum1, Values1);
+        Aux1 = _mm512_set1_ps(n_plus_one);
+        SquareSum1 =
+            _mm512_accumulate_square_sum_ps(SquareSum1, Sum1, Values1, Reciprocal, Aux1);
+    }
+
+    _mm512_store_ps(&SumLocal[0], Sum0);
+    _mm512_store_ps(&SumLocal[16], Sum1);
+    _mm512_store_ps(&SquareSumLocal[0], SquareSum0);
+    _mm512_store_ps(&SquareSumLocal[16], SquareSum1);
+
+    accrue_result(SquareSumLocal, SumLocal, 32, thirty_second_points);
+
+    uint32_t points_done = thirty_second_points * 32;
+
+    for (; points_done < num_points; points_done++) {
+        float val = (*in_ptr++);
+        SumLocal[0] += val;
+        SquareSumLocal[0] =
+            update_square_sum_1_val(SquareSumLocal[0], SumLocal[0], points_done, val);
+    }
+
+    *stddev = sqrtf(SquareSumLocal[0] / num_points);
+    *mean = SumLocal[0] / num_points;
+}
+#endif /* LV_HAVE_AVX512F */
+
 #ifdef LV_HAVE_SSE
 #include <xmmintrin.h>
 
@@ -568,6 +646,84 @@ static inline void volk_32f_stddev_and_mean_32f_x2_a_avx(float* stddev,
     *mean = SumLocal[0] / num_points;
 }
 #endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void volk_32f_stddev_and_mean_32f_x2_a_avx512(float* stddev,
+                                                            float* mean,
+                                                            const float* inputBuffer,
+                                                            unsigned int num_points)
+{
+    if (num_points < 32) {
+        volk_32f_stddev_and_mean_32f_x2_generic(stddev, mean, inputBuffer, num_points);
+        return;
+    }
+
+    const float* in_ptr = inputBuffer;
+
+    __VOLK_ATTR_ALIGNED(64) float SumLocal[32] = { 0.f };
+    __VOLK_ATTR_ALIGNED(64) float SquareSumLocal[32] = { 0.f };
+
+    const unsigned int thirty_second_points = num_points / 32;
+
+    __m512 Sum0 = _mm512_load_ps(in_ptr);
+    in_ptr += 16;
+    __m512 Sum1 = _mm512_load_ps(in_ptr);
+    in_ptr += 16;
+
+    __m512 SquareSum0 = _mm512_setzero_ps();
+    __m512 SquareSum1 = _mm512_setzero_ps();
+    __m512 Values0, Values1;
+    __m512 Aux0, Aux1;
+    __m512 Reciprocal;
+
+    for (uint32_t number = 1; number < thirty_second_points; number++) {
+        Values0 = _mm512_load_ps(in_ptr);
+        in_ptr += 16;
+        __VOLK_PREFETCH(in_ptr + 16);
+
+        Values1 = _mm512_load_ps(in_ptr);
+        in_ptr += 16;
+        __VOLK_PREFETCH(in_ptr + 16);
+
+        float n = (float)number;
+        float n_plus_one = n + 1.f;
+
+        Reciprocal = _mm512_set1_ps(1.f / (n * n_plus_one));
+
+        Sum0 = _mm512_add_ps(Sum0, Values0);
+        Aux0 = _mm512_set1_ps(n_plus_one);
+        SquareSum0 =
+            _mm512_accumulate_square_sum_ps(SquareSum0, Sum0, Values0, Reciprocal, Aux0);
+
+        Sum1 = _mm512_add_ps(Sum1, Values1);
+        Aux1 = _mm512_set1_ps(n_plus_one);
+        SquareSum1 =
+            _mm512_accumulate_square_sum_ps(SquareSum1, Sum1, Values1, Reciprocal, Aux1);
+    }
+
+    _mm512_store_ps(&SumLocal[0], Sum0);
+    _mm512_store_ps(&SumLocal[16], Sum1);
+    _mm512_store_ps(&SquareSumLocal[0], SquareSum0);
+    _mm512_store_ps(&SquareSumLocal[16], SquareSum1);
+
+    accrue_result(SquareSumLocal, SumLocal, 32, thirty_second_points);
+
+    uint32_t points_done = thirty_second_points * 32;
+
+    for (; points_done < num_points; points_done++) {
+        float val = (*in_ptr++);
+        SumLocal[0] += val;
+        SquareSumLocal[0] =
+            update_square_sum_1_val(SquareSumLocal[0], SumLocal[0], points_done, val);
+    }
+
+    *stddev = sqrtf(SquareSumLocal[0] / num_points);
+    *mean = SumLocal[0] / num_points;
+}
+#endif /* LV_HAVE_AVX512F */
 
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>


### PR DESCRIPTION
## Summary

Adds `_mm512_accumulate_square_sum_ps` to `include/volk/volk_avx512_intrinsics.h` (Youngs & Cramer recurrence accumulator over 16 lanes, FMA-fused via `_mm512_fmsub_ps`) and the two consuming impls `_u_avx512` / `_a_avx512` on `volk_32f_stddev_and_mean_32f_x2`. The kernel previously had SSE, AVX, NEON, RVV impls but no AVX-512 tier. Two files changed, +175 insertions, **0 deletions**.

**Naming heads-up:** in-tree helper is `_mm512_accumulate_square_sum_ps` (matches the existing `_mm256_accumulate_square_sum_ps` / `_mm_accumulate_square_sum_ps` siblings). The issue body proposed `_mm512_youngs_cramer_square_sum_avx512`; renamed during plan tightening for sibling consistency. Same rename pattern as fork PR #63 (B4c sibling).

The PR's value prop is **precision + dispatch tier completion**, with throughput as a modest tertiary measurement:

- **Precision (load-bearing).** AVX-512 dispatch path produces `max=355 ULP` vs the AVX sibling's `max=455 ULP` — a **22% relative reduction** in worst-case rounding error. Variance is the known failure mode for fast-FP stddev algorithms; the helper's FMA-fusion saves exactly one rounding step per inner iter (1 rounding in `_mm512_fmsub_ps(a, b, c) = a*b - c` vs 2 in the AVX sibling's `mul + sub` pair) and that gain compounds across thousands of inner iterations at large N. (Note: "100 ULP better" is the arithmetic difference of the two max-ULP numbers; ULP isn't strictly a linear unit, so the percentage framing is more meaningful.) The kernel's QA test passes both `stddev` and `mean` outputs at the existing tolerance band — this precision improvement is delta, not threshold-crossing.
- **Tier completion.** Skylake-class AVX-512 silicon previously fell back to `_a_avx`. After this PR the dispatcher picks `_a_avx512` for large-N workloads.
- **Throughput.** Modest +4% over `_a_avx` at vlen=131071, parity at vlen=8192, slight loss at vlen=512 (AVX-512 startup cost). Bandwidth-bound at L2/DRAM-resident sizes; reduction-overhead-bound at small sizes.

Pre-emptive 3-filter analysis at scope time predicted this throughput profile: kernel is stream-in-scalar-out (fails "no serial reduction at terminus") with AI ~1.25 ops/byte (marginal on "not DRAM-bound"). The Issue body's "win at large N" hypothesis is borne out directionally but the magnitude is small. Honest framing throughout this MR body reflects that.

## Related issues

Fixes mtibbits/volk#61.

Decomposed from the closed bulk PR #10 (B4d row of masterPlan §5.6). Sibling references: PR #50 (B4a) — same pure-additions pattern. Issue-Fork-58 (B15 dispatch-integrity check) will sweep this PR's symbols after it lands on `dev/all-prs`. Issue-Fork-60 (B4c) was the prior PR in this sibling series — its lessons (3-filter pre-screen, helper rename for sibling consistency, honest precision-first framing) shaped this PR's plan.

## Testing

**Build + dispatch presence.** `cmake --build` clean on `Release`. New symbols appear in all 3 AVX-512 machine TUs:

```
$ grep -l 'volk_32f_stddev_and_mean_32f_x2_[au]_avx512\b' build/lib/volk_machine_*.c
build/lib/volk_machine_avx512f_64_mmx_orc.c
build/lib/volk_machine_avx512cd_64_mmx_orc.c
build/lib/volk_machine_avx512dq_64_mmx_orc.c
```

**QA.** `ctest --output-on-failure` 254/254 in 137.78s. Both `stddev` and `mean` outputs accurate on all impl rows.

**ULP envelope** (via `volk_ulp_profile`, fork-only from mtibbits/volk#29):

```
arch                           max          mean          rms
----------------------------------------------------------------
u_sse / a_sse                  349           0.0          0.7    ← 8 partitions, 3-stage reduce
u_avx / a_avx                  455           0.0          0.9    ← 16 partitions, 4-stage reduce, non-FMA helper
u_avx512 / a_avx512            355           0.0          0.7    ← 32 partitions, 5-stage reduce, FMA-fused helper  *new*
```

Net: AVX-512 is **22% better than AVX** on the max-ULP axis. Two effects pull in opposite directions: (a) the AVX-512 helper's FMA fusion saves one rounding step per inner iter (1 vs 2 in the `(n+1)*val - acc` substep), and (b) the 32-partition `accrue_result` tree adds one extra stage (5 vs 4) of recombination rounding. The measured outcome — AVX-512 strictly better than AVX — establishes that (a) dominates (b) on this dataset distribution; a follow-up could rebuild with a non-fused helper to quantify the (a) vs (b) split, but the strictly-better result makes that experiment optional, not load-bearing for this PR.

**Perf** (via `volk_profile -T 25 --trial-csv`, fork-only from mtibbits/volk#37):

```
vlen=131071 (L2/DRAM boundary)
arch                           median      throughput   speedup-vs-generic
---------------------------------------------------------------------------
generic                        181.60 ms    17210 MB/s   -
u_avx                           25.19 ms   124059 MB/s   7.21x
u_avx512                        24.15 ms   129416 MB/s   7.52x   ← best, +4% over u_avx
a_avx                           25.24 ms   123817 MB/s   7.19x
a_avx512                        24.16 ms   129373 MB/s   7.52x

vlen=8192 (L2-resident): all AVX-family within 1% of each other (parity)
vlen=512   (L1-resident): u_avx 0.16ms, u_avx512 0.17ms (slight startup loss)
```

Across the N-sweep: throughput gain scales with N. At vlen=131071 the dispatcher selects `u_avx512` as best (volk_profile's own footer line: `Best aligned arch | u_avx512 (7.52x)`, `Best unaligned arch | u_avx512 (7.52x)` — that's the real-silicon dispatch confirmation the Issue body's AC6 asks for). At vlen=8192 it's parity. At vlen=512 there's a modest loss to AVX-512 startup overhead (kernel falls back to generic for N<32 entirely; for N=33-63 the AVX-512 path executes its initial 32-load + tail loop with no inner-loop iterations, slightly slower than the AVX impl's `< 16` threshold which gets one inner iter at that range — acceptable boundary behavior, matches the existing AVX/SSE threshold convention). Evidence plot persisted to per-issue dev doc at `evidence-vlen-sweep.png` (**PNG attachment to PR pending via web UI** — `gh` CLI cannot attach images to PR bodies).

**Static analysis** (via `static_analysis_diff.py`, scoped to lines this PR touches):

| Tool | Total | Novel | Status |
|------|-------|-------|--------|
| clang-tidy (bugprone-/readability-/performance-/clang-analyzer-) | 0 | 0 | clean |
| scan-build | — | — | pass |
| iwyu | 0 | 0 | clean |
| clang-format | 0 | 0 | clean (`git clang-format` was a no-op on the diff) |
| codespell | 1 | 0 | clean for this PR |
| cpplint | 80+ | 18 | 18 novel; all sibling-matching style flags (line length > 80, brace placement that conflicts with the project's `.clang-format`, `#include` re-emission inside per-arch guards — every kernel in `kernels/volk/` does the same) |
| ASan + UBSan | — | — | pass — 254/254 instrumented tests pass on each |
| TSan | — | — | **infrastructure-blocked** on Ubuntu 24.04+ (kernel ASLR layout incompatible with TSan runtime's shadow memory; documented workaround is `setarch -R` / `setarch <machine> --addr-no-randomize`, not yet wired into `analyze-sanitizers.sh` — separate devAgent issue filed). The kernel under test is pure-compute (no shared state, no atomics, no thread interaction); ASan + UBSan provide the load-bearing sanitizer coverage for this code shape. |

**Cppcheck note.** Same pre-existing tooling gap as Issue-Fork-60 — `build/compile_commands.json` not generated by the project's default cmake invocation. Reviewer can rebuild with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to get it, then re-run cppcheck against the changed lines. The 18 cpplint flags already cover the style space cppcheck would have looked at.

## Reviewer notes

This PR is a sibling of Issue-Fork-60 (B4c AVX2+FMA tier-fill on `volk_32fc_magnitude_32f`) — same pure-additions diff shape, same fork-first workflow, same precision-first framing rationale. If you've reviewed #63 (the B4c sibling PR; merged into `dev/all-prs`), the structural review here should be quick.

Where the change does load-bear:

1. **Precision improvement.** The 100-ULP ULP-envelope reduction is the headline. On a kernel where variance is the historical FP-precision failure mode, that's a real correctness improvement, not just a tier-completion.
2. **Dispatch tier completion.** Skylake-class hosts gain a dedicated AVX-512 impl rather than falling back to `_avx`.
3. **Reusable helper.** `_mm512_accumulate_square_sum_ps` is available for any future variance/moment kernel at the AVX-512 tier. None exist today; if any arrive they reuse the helper.
4. **Modest throughput gain.** +4% over `_a_avx` at vlen=131071, scaling with N. Reaches the user but is not the headline.

**Naming note:** in-tree helper is `_mm512_accumulate_square_sum_ps`. The issue body proposed `_mm512_youngs_cramer_square_sum_avx512`; during plan tightening I renamed for sibling consistency with the existing `_mm256_accumulate_square_sum_ps` (`volk_avx_intrinsics.h:286`) and `_mm_accumulate_square_sum_ps` (`volk_sse_intrinsics.h:141`). Same rename pattern as Issue-Fork-60.

**FMA-fusion design decision:** AVX-512 always has FMA, so the helper uses `_mm512_fmsub_ps((n+1), val, acc)` — one fewer instruction and one fewer rounding step than the byte-faithful `mul + sub` form. The Task 4 ULP check validated this was the right call (strictly better than the AVX sibling). The existing AVX (FMA-tier) and SSE3 helpers could adopt the same fusion in a separate one-line PR; deferred per [feedback_avoid_while_here_fixes.md] discipline.

**Disclosure: AWS validation not required for this PR.** Issue-Fork-60 needed AWS Haswell silicon to reach the new impl's real-dispatch path because that PR's dev-host dispatcher picked `_a_avx512f` for `volk_32fc_magnitude_32f`. This PR's dispatcher picks `_a_avx512` on the dev host (because there's no faster tier above), so the perf and ULP measurements reach the production dispatch path directly. No AWS spin-up needed.

**Surgical-diff scope:** only two named files touched. Out-of-scope items (other AVX-512 helpers, double-precision variant, B4b/c/e sibling work, FMA-fusion retrofit of AVX/SSE helpers) recorded in this PR's per-issue dev doc.

## Checklist

- [x] Builds cleanly (`cmake --build` on `Release`)
- [x] Tests pass (`ctest` 254/254)
- [x] Commits are signed off (`git commit -s` — `Signed-off-by: Matthew Tibbits`)
- [x] PR does one thing — only the Y&C accumulator helper + the two consuming impls; no while-here cleanup
- [x] Static analysis clean for changed lines (modulo 18 cpplint sibling-style flags + TSan infra block — both documented above)
- [x] Pure-additions diff (0 deletions, 175 insertions)
- [x] Naming-divergence-from-issue-body documented in the body of this MR
- [x] Perf evidence PNG attached (text reference; manual web-UI drag-drop pending)

