### PR TITLE
codegen-equivalence test harness

### DIFF
--- a/cmake/CodegenEquivalence.cmake
+++ b/cmake/CodegenEquivalence.cmake
@@ -1,0 +1,78 @@
+#
+# Copyright 2026 Free Software Foundation, Inc.
+#
+# This file is part of VOLK
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# CodegenEquivalence.cmake
+#
+# Build-time codegen-equivalence harness for the volk fusion framework
+# (mtibbits/volk#78). Provides ADD_CODEGEN_EQUIVALENCE_TUPLE() to declare
+# (kernel, ISA, alignment, impl_a, impl_b, criterion) tuples that
+# cmake/check_framework_codegen.py asserts after volk_obj compiles, and
+# FINALIZE_CODEGEN_EQUIVALENCE_HARNESS() to emit the manifest + custom target.
+#
+# Mirrors the build-time-check pattern of the dispatch-table integrity check
+# (mtibbits/volk#58, PR #59). See cmake/check_framework_codegen_README.md for
+# the manifest format and the whole-function comparison contract.
+
+# Accumulates per-tuple JSON fragments into a global property the finalize
+# step stitches into a manifest. Use a CMake list (not APPEND_STRING) so the
+# embedded double-quotes in each fragment survive intact.
+set_property(GLOBAL PROPERTY CODEGEN_EQUIVALENCE_TUPLES "")
+
+function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
+    set(one_value
+        KERNEL ISA ALIGNMENT CRITERION
+        IMPL_A_SYMBOL IMPL_A_MACHINE_O
+        IMPL_B_SYMBOL IMPL_B_MACHINE_O)
+    cmake_parse_arguments(CGE "" "${one_value}" "" ${ARGN})
+
+    foreach(required IN LISTS one_value)
+        if(NOT DEFINED CGE_${required})
+            message(FATAL_ERROR
+                "ADD_CODEGEN_EQUIVALENCE_TUPLE: missing required arg ${required}")
+        endif()
+    endforeach()
+    if(NOT CGE_CRITERION MATCHES "^(byte_identical|within_noise)$")
+        message(FATAL_ERROR
+            "ADD_CODEGEN_EQUIVALENCE_TUPLE: CRITERION must be byte_identical "
+            "or within_noise (got '${CGE_CRITERION}')")
+    endif()
+
+    set(frag "{\"kernel\":\"${CGE_KERNEL}\",\"isa\":\"${CGE_ISA}\",\"alignment\":\"${CGE_ALIGNMENT}\",\"criterion\":\"${CGE_CRITERION}\",\"impl_a\":{\"symbol\":\"${CGE_IMPL_A_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_A_MACHINE_O}\"},\"impl_b\":{\"symbol\":\"${CGE_IMPL_B_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_B_MACHINE_O}\"}}")
+    set_property(GLOBAL APPEND PROPERTY CODEGEN_EQUIVALENCE_TUPLES "${frag}")
+endfunction()
+
+# Emit the manifest JSON and the check target. Call once from
+# lib/CMakeLists.txt AFTER all ADD_CODEGEN_EQUIVALENCE_TUPLE() calls and AFTER
+# the volk_obj target is defined.
+function(FINALIZE_CODEGEN_EQUIVALENCE_HARNESS)
+    get_property(frags GLOBAL PROPERTY CODEGEN_EQUIVALENCE_TUPLES)
+    string(JOIN "," frags_joined ${frags})
+    set(manifest_path "${PROJECT_BINARY_DIR}/codegen_equivalence_manifest.json")
+    file(WRITE "${manifest_path}" "{\"tuples\":[${frags_joined}]}\n")
+
+    # llvm-objdump (with GNU objdump as a documented alternative) is used by
+    # the script; resolve it if available so the target fails clearly when no
+    # disassembler exists rather than mid-run.
+    find_program(CGE_OBJDUMP NAMES llvm-objdump llvm-objdump-18 objdump)
+    if(NOT CGE_OBJDUMP)
+        message(WARNING
+            "CodegenEquivalence: no llvm-objdump/objdump found; the "
+            "codegen-equivalence check will error if any tuple is declared.")
+        set(CGE_OBJDUMP "llvm-objdump")
+    endif()
+
+    add_custom_target(volk_check_framework_codegen
+        COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_DASH_B}
+                ${PROJECT_SOURCE_DIR}/cmake/check_framework_codegen.py
+                --manifest "${manifest_path}"
+                --build-lib-dir "${PROJECT_BINARY_DIR}/lib/CMakeFiles"
+                --objdump "${CGE_OBJDUMP}"
+        DEPENDS volk_obj
+        COMMENT "Checking codegen-equivalence between declared impl pairs"
+        VERBATIM
+    )
+endfunction()

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -206,18 +206,33 @@ def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
     return result.stdout
 
 
-def _is_trailing_padding(mnemonic: str) -> bool:
-    """Mnemonics that, when trailing the final control-flow terminator, are
-    inter-function alignment padding (belong to no function): the NOP family
-    and the lone `data16` prefix some toolchains/disassemblers emit as a pad
-    filler (e.g. GNU objdump renders a multi-byte NOP as `data16 cs nopw ...`).
-    Mid-body alignment NOPs are NOT stripped here -- only the trailing run.
+def _is_trailing_padding(instr: dict) -> bool:
+    """True if `instr`, sitting after the function's final control-flow
+    terminator, is inter-function alignment padding (belongs to no function).
+    Covers every x86 inter-function pad filler observed across the CI matrix:
+
+      - the NOP family (`nop`, `nopw`, `nopl`, `nopq`, ...),
+      - the lone `data16` prefix some disassemblers print for a multi-byte NOP
+        (GNU objdump renders it `data16 cs nopw ...`),
+      - `int3` (0xcc) gap fill,
+      - the legacy `xchg %ax,%ax` (0x66 0x90) two-byte NOP -- but ONLY the
+        self-exchange idiom (same src/dst); a real register `xchg` is never
+        stripped.
+
+    Mid-body alignment NOPs are NOT stripped -- only the trailing run.
 
     Invariant: this set MUST stay a superset of the mnemonics `_padding_line`
     accepts, so any pad the fallback absorbs is guaranteed to be stripped here
     and never reaches the comparison.
     """
-    return mnemonic.startswith("nop") or mnemonic == "data16"
+    m = instr["mnemonic"]
+    if m.startswith("nop") or m == "data16" or m == "int3":
+        return True
+    if m == "xchg":
+        # Strip only `xchg %reg,%reg` (the NOP idiom), never a real exchange.
+        ops = [o for o in instr["operands"].replace(" ", "").split(",") if o]
+        return len(ops) == 2 and ops[0] == ops[1]
+    return False
 
 
 def _instr_from_match(m) -> dict:
@@ -311,7 +326,7 @@ def extract_function_body_from_text(text: str, symbol: str,
     # belong to no function and vary with inter-function layout, so they are not
     # part of this function's codegen. Internal alignment nops (e.g. before a
     # hot loop) are mid-body and are preserved.
-    while instrs and _is_trailing_padding(instrs[-1]["mnemonic"]):
+    while instrs and _is_trailing_padding(instrs[-1]):
         instrs.pop()
     if not instrs:
         raise RuntimeError(

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -25,10 +25,19 @@ the criterion evaluated.
 Invoked by lib/CMakeLists.txt as a dependency of the volk shared-lib target
 so it runs after volk_obj compiles but before linking.
 
+Cross-compiler robustness (mtibbits/volk#145): benign codegen noise that differs
+by compiler is normalized away -- trailing alignment NOPs of any encoding and
+trailing `data16` padding are stripped (they pad the next function and belong to
+no function), and a symbol the compiler inlined rather than emitting standalone
+is skipped-with-warning (exit 0) since there is nothing to compare. A genuine
+post-normalization divergence still fails (exit 1); a genuinely unparsable
+non-padding line still errors (exit 2).
+
 Exit codes:
-    0  all declared tuples pass (or manifest is empty)
-    1  one or more tuples fail (per-tuple diff printed to stderr)
-    2  internal error (missing manifest, missing .o, symbol not found, parse)
+    0  all declared tuples pass (or are skipped/empty); skips warn on stderr
+    1  one or more tuples fail their criterion (per-tuple diff on stderr)
+    2  internal error: missing manifest/.o, ambiguous .o, unparsable
+       non-padding line, or empty function body
 
 See mtibbits/volk#78 for context. Mirrors
 the dispatch-table integrity check (mtibbits/volk#58) for shape and reporting.
@@ -52,6 +61,16 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+
+class SymbolNotEmittedError(RuntimeError):
+    """The compared symbol is absent from the object file because the compiler
+    inlined it rather than emitting it standalone (e.g. macOS clang on some
+    impls). There is nothing to compare, so main() skips the tuple with a
+    warning rather than failing the build. Distinct from the other RuntimeError
+    cases (missing/ambiguous .o, unparsable line) which remain hard errors
+    (mtibbits/volk#145).
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +140,24 @@ _continuation_line = re.compile(
     r'^\s*[0-9a-fA-F]+:\s+((?:[0-9a-fA-F]{2}[ \t]*)+)$'
 )
 
+# A NOP/padding instruction line that _disasm_line above fails to capture across
+# objdump variants. _disasm_line needs >=2 whitespace chars between the last byte
+# and the mnemonic (its byte-group [ \t]+ plus a separate mandatory [ \t]+
+# separator), but the long multi-byte alignment NOPs that clang-15+/gcc-11/14
+# emit as trailing pad render with a single tab, e.g.
+#     21656: 66 2e 0f 1f 84 00 00 00 00 00\tnopw\t%cs:(%rax,%rax)
+# This fallback drops the separate separator and anchors the padding mnemonic
+# directly after the byte column, so it matches the single-tab form. It is tried
+# ONLY when _disasm_line fails, so the passing path is unchanged; it matches only
+# the NOP family and the lone data16 prefix, both of which the trailing-strip
+# below removes when they are inter-function padding (mtibbits/volk#145).
+_padding_line = re.compile(
+    r'^\s*([0-9a-fA-F]+):\s+'
+    r'((?:[0-9a-fA-F]{2}[ \t]+)+?)'
+    r'(nop[a-z]*|data16)\b'
+    r'(?:[ \t]+(.*))?$'
+)
+
 
 def resolve_object(build_lib_dir: Path, machine_o: str) -> Path:
     """Resolve a manifest machine_o entry to an actual object-file path.
@@ -169,14 +206,56 @@ def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
     return result.stdout
 
 
+def _is_trailing_padding(mnemonic: str) -> bool:
+    """Mnemonics that, when trailing the final control-flow terminator, are
+    inter-function alignment padding (belong to no function): the NOP family
+    and the lone `data16` prefix some toolchains/disassemblers emit as a pad
+    filler (e.g. GNU objdump renders a multi-byte NOP as `data16 cs nopw ...`).
+    Mid-body alignment NOPs are NOT stripped here -- only the trailing run.
+
+    Invariant: this set MUST stay a superset of the mnemonics `_padding_line`
+    accepts, so any pad the fallback absorbs is guaranteed to be stripped here
+    and never reaches the comparison.
+    """
+    return mnemonic.startswith("nop") or mnemonic == "data16"
+
+
+def _instr_from_match(m) -> dict:
+    """Build an instruction record from a _disasm_line OR _padding_line match.
+    Both regexes capture the same four groups in the same order -- address,
+    bytes, mnemonic, operands -- and this is the single source of truth for the
+    record shape the comparison consumes.
+    """
+    addr_hex, bytes_str, mnemonic, operands = m.groups()
+    return {
+        "address": addr_hex,
+        "bytes": bytes_str.split(),
+        "mnemonic": mnemonic,
+        "operands": (operands or "").strip(),
+    }
+
+
 def extract_function_body(o_file: Path, symbol: str,
                           objdump: str = "llvm-objdump") -> list:
-    """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
-    `symbol` in the disassembly of o_file: every instruction line from the
-    `<symbol>:` header up to (exclusive) the next symbol header or a blank line
-    that ends the function's block. Raises RuntimeError if the symbol is absent.
+    """Disassemble `symbol` in o_file and return its whole-body instruction list.
+    Thin wrapper over extract_function_body_from_text (see it for the parse
+    contract); kept so callers and tests can pass a file path + objdump.
     """
     text = _disassemble(o_file, objdump, symbol=symbol)
+    return extract_function_body_from_text(text, symbol, source_label=str(o_file))
+
+
+def extract_function_body_from_text(text: str, symbol: str,
+                                    source_label: str = "<disassembly>") -> list:
+    """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
+    `symbol` in `text`: every instruction line from the `<symbol>:` header up to
+    (exclusive) the next symbol header or a blank line that ends the block.
+    Trailing inter-function padding (alignment NOPs / data16) is stripped.
+
+    Raises SymbolNotEmittedError if the symbol is absent (inlined, not emitted
+    standalone) and RuntimeError if an in-body line is unparsable and not
+    recognizable padding, or if the body is empty.
+    """
     in_body = False
     saw_symbol = False
     instrs = []
@@ -206,35 +285,37 @@ def extract_function_body(o_file: Path, symbol: str,
                     # trailing bytes to the instruction they belong to.
                     instrs[-1]["bytes"].extend(ci.group(1).split())
                     continue
+                # Lenient fallback for NOP/data16 padding lines whose single-tab
+                # byte/mnemonic spacing _disasm_line cannot match. Padding is
+                # removed by the trailing-strip below, so absorbing it here is
+                # safe and keeps the build green on clang-15+/gcc-11/14.
+                pm = _padding_line.match(line)
+                if pm:
+                    instrs.append(_instr_from_match(pm))
+                    continue
                 # Any other in-body line we cannot parse must be loud, not
                 # silently dropped: a dropped instruction would weaken the
                 # comparison without anyone noticing.
                 raise RuntimeError(
-                    f"unparsable disassembly line for {symbol!r} in {o_file}: "
-                    f"{line!r}")
-            addr_hex, bytes_str, mnemonic, operands = mi.groups()
-            instrs.append({
-                "address": addr_hex,
-                "bytes": bytes_str.split(),
-                "mnemonic": mnemonic,
-                "operands": (operands or "").strip(),
-            })
+                    f"unparsable disassembly line for {symbol!r} in "
+                    f"{source_label}: {line!r}")
+            instrs.append(_instr_from_match(mi))
 
     if not saw_symbol:
-        raise RuntimeError(
-            f"symbol {symbol!r} not found in disassembly of {o_file}. "
+        raise SymbolNotEmittedError(
+            f"symbol {symbol!r} not found in disassembly of {source_label}. "
             f"The impl must be emitted standalone (its address taken for the "
             f"dispatch table) for its symbol to appear in the object file.")
-    # Strip trailing NOP-family instructions: padding emitted after the
-    # function's final control-flow terminator to align the NEXT function. It
-    # belongs to no function and varies with inter-function layout, so it is
-    # not part of this function's codegen. Internal alignment nops (e.g. before
-    # a hot loop) are mid-body and are preserved.
-    while instrs and instrs[-1]["mnemonic"].startswith("nop"):
+    # Strip trailing padding (NOP family + data16): bytes emitted after the
+    # function's final control-flow terminator to align the NEXT function. They
+    # belong to no function and vary with inter-function layout, so they are not
+    # part of this function's codegen. Internal alignment nops (e.g. before a
+    # hot loop) are mid-body and are preserved.
+    while instrs and _is_trailing_padding(instrs[-1]["mnemonic"]):
         instrs.pop()
     if not instrs:
         raise RuntimeError(
-            f"symbol {symbol!r} found in {o_file} but its body is empty")
+            f"symbol {symbol!r} found in {source_label} but its body is empty")
     return instrs
 
 
@@ -359,6 +440,7 @@ def main():
 
     failures = []
     errors = []
+    skipped = []
     for t in tuples:
         try:
             a_o = resolve_object(args.build_lib_dir, t["impl_a"]["machine_o"])
@@ -367,6 +449,15 @@ def main():
                 a_o, t["impl_a"]["symbol"], objdump=args.objdump)
             b_instrs = extract_function_body(
                 b_o, t["impl_b"]["symbol"], objdump=args.objdump)
+        except SymbolNotEmittedError as e:
+            # Compiler inlined the impl rather than emitting it standalone
+            # (e.g. macOS clang): nothing to compare, so skip with a loud
+            # warning instead of failing the build. A present-but-divergent
+            # body is unaffected -- it still fails below.
+            print(f"codegen-equivalence: WARNING: skipping {tuple_id(t)}: {e}",
+                  file=sys.stderr)
+            skipped.append(tuple_id(t))
+            continue
         except RuntimeError as e:
             errors.append((tuple_id(t), str(e)))
             continue
@@ -406,7 +497,10 @@ def main():
             print("", file=sys.stderr)
         sys.exit(1)
 
-    print(f"codegen-equivalence: ok ({len(tuples)} tuples checked)")
+    checked = len(tuples) - len(skipped)
+    extra = (f", {len(skipped)} skipped -- not emitted standalone: {skipped}"
+             if skipped else "")
+    print(f"codegen-equivalence: ok ({checked} tuples checked{extra})")
 
 
 if __name__ == "__main__":

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+# Copyright 2026 Free Software Foundation, Inc.
+#
+# This file is part of VOLK
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+"""
+Codegen-equivalence test harness for volk fusion-framework impls.
+
+Reads a JSON manifest of (kernel, ISA, alignment, impl_a, impl_b, criterion)
+tuples. For each tuple, disassembles the named symbol in each impl's compiled
+.o file, extracts that function's whole instruction body (from its `<symbol>:`
+header to the next symbol header), and applies the declared equivalence
+criterion:
+
+    byte_identical  -- raw instruction-byte sequences must match
+    within_noise    -- mnemonic sequences match and operand classes match;
+                       register reassignment and immediate-value differences
+                       are tolerated, instruction order is NOT.
+
+Failure halts the build with the offending tuple, the disassembly diff, and
+the criterion evaluated.
+
+Invoked by lib/CMakeLists.txt as a dependency of the volk shared-lib target
+so it runs after volk_obj compiles but before linking.
+
+Exit codes:
+    0  all declared tuples pass (or manifest is empty)
+    1  one or more tuples fail (per-tuple diff printed to stderr)
+    2  internal error (missing manifest, missing .o, symbol not found, parse)
+
+See mtibbits/volk#78 for context. Mirrors
+the dispatch-table integrity check (mtibbits/volk#58) for shape and reporting.
+
+DESIGN NOTE (whole-function comparison): an earlier design bracketed just the
+inner loop with source-level asm labels. That was abandoned: inserting a label
+symbol mid-function makes its address a basic-block boundary the optimizer must
+respect, which perturbs the surrounding codegen (an extra test, register-
+allocation churn) -- i.e. instrumenting the kernel for the harness would change
+the kernel that ships. Instead the harness compares the WHOLE function body
+between two impls. This needs no source markers, leaves production codegen
+untouched, and is the stronger contract for the framework use case: a framework
+instantiation that reproduces a hand-written impl produces the same *function*,
+not merely the same loop. The impl must be emitted standalone (its address taken
+for the dispatch table), which volk's kernels always are.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Manifest parsing
+# ---------------------------------------------------------------------------
+
+def parse_manifest(path: Path) -> list:
+    if not path.is_file():
+        print(f"error: manifest not found at {path}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"error: manifest is not valid JSON: {e}", file=sys.stderr)
+        sys.exit(2)
+    tuples = data.get("tuples", [])
+    for t in tuples:
+        for required in ("kernel", "isa", "alignment", "impl_a", "impl_b",
+                         "criterion"):
+            if required not in t:
+                print(f"error: manifest tuple missing required field "
+                      f"{required!r}: {t}", file=sys.stderr)
+                sys.exit(2)
+        for side in ("impl_a", "impl_b"):
+            for f in ("symbol", "machine_o"):
+                if f not in t[side]:
+                    print(f"error: manifest tuple {side} missing {f!r}: {t}",
+                          file=sys.stderr)
+                    sys.exit(2)
+        if t["criterion"] not in ("byte_identical", "within_noise"):
+            print(f"error: unknown criterion {t['criterion']!r} (must be "
+                  f"byte_identical or within_noise)", file=sys.stderr)
+            sys.exit(2)
+    return tuples
+
+
+def tuple_id(t: dict) -> str:
+    return f"{t['kernel']}.{t['isa']}.{t['alignment']}"
+
+
+# ---------------------------------------------------------------------------
+# Disassembly extraction
+# ---------------------------------------------------------------------------
+
+# A label/function header line in llvm-objdump (and GNU objdump) disassembly:
+#     0000000000000007 <fwk_codegen_my_start>:
+# The address column is optional in some objdump variants, so it is tolerated.
+_label_line = re.compile(r'^\s*(?:[0-9a-fA-F]+\s+)?<([^>+]+)>:\s*$')
+
+# A disassembled instruction line. Two whitespace styles across objdump
+# variants; both have: addr ':' raw-bytes <tab-or-spaces> mnemonic [operands].
+#     18: c5 fc 28 0c 06   <tab> vmovaps <tab> (%rsi,%rax), %ymm1   (llvm)
+#     6600:\tc5 fc 28 0c 06 \tvmovaps (%rsi,%rax,1),%ymm1           (gnu)
+_disasm_line = re.compile(
+    r'^\s*([0-9a-fA-F]+):\s+'                 # address
+    r'((?:[0-9a-fA-F]{2}[ \t]+)+?)'           # raw bytes (non-greedy)
+    r'[ \t]+'                                  # separator before mnemonic
+    r'([^\s]+)'                                # mnemonic
+    r'(?:[ \t]+(.*))?$'                        # optional operands
+)
+
+# A continuation line: GNU objdump wraps an instruction longer than 7 bytes
+# onto a second line carrying only the trailing bytes, no mnemonic, e.g.
+#     1e:	00 00
+# Those bytes belong to the previous instruction and are stitched onto it.
+_continuation_line = re.compile(
+    r'^\s*[0-9a-fA-F]+:\s+((?:[0-9a-fA-F]{2}[ \t]*)+)$'
+)
+
+
+def resolve_object(build_lib_dir: Path, machine_o: str) -> Path:
+    """Resolve a manifest machine_o entry to an actual object-file path.
+
+    machine_o may be:
+      - an absolute path (used as-is),
+      - a path relative to build_lib_dir that exists (used directly), or
+      - a bare filename, in which case the build tree is searched recursively
+        (different OBJECT libraries land their .o files in different
+        CMakeFiles/<target>.dir/ subdirs, so a recursive search avoids
+        hardcoding fragile per-target paths).
+    """
+    p = Path(machine_o)
+    if p.is_absolute() and p.is_file():
+        return p
+    direct = build_lib_dir / machine_o
+    if direct.is_file():
+        return direct
+    matches = sorted(build_lib_dir.rglob(Path(machine_o).name))
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise RuntimeError(
+            f"object file {machine_o!r} not found under {build_lib_dir}")
+    raise RuntimeError(
+        f"object file {machine_o!r} is ambiguous under {build_lib_dir} "
+        f"({len(matches)} matches): {[str(m) for m in matches]}")
+
+
+def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
+    if not o_file.is_file():
+        raise RuntimeError(f"object file not found: {o_file}")
+    # NOTE: deliberately NOT using --symbolize-operands. It makes llvm-objdump
+    # synthesize <L0>/<L1> branch labels that collide with the _label_line
+    # parser. Plain --disassemble shows symbol headers as clean <name>: lines.
+    cmd = [objdump, "--disassemble"]
+    # Efficiency: llvm-objdump can disassemble a single symbol, skipping the
+    # hundreds of other kernels in a machine .o. GNU objdump has no equivalent,
+    # so only use it for llvm-objdump and fall back to whole-object otherwise.
+    if symbol and "llvm" in Path(objdump).name:
+        cmd.append(f"--disassemble-symbols={symbol}")
+    cmd.append(str(o_file))
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"{objdump} failed on {o_file}: {result.stderr}")
+    return result.stdout
+
+
+def extract_function_body(o_file: Path, symbol: str,
+                          objdump: str = "llvm-objdump") -> list:
+    """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
+    `symbol` in the disassembly of o_file: every instruction line from the
+    `<symbol>:` header up to (exclusive) the next symbol header or a blank line
+    that ends the function's block. Raises RuntimeError if the symbol is absent.
+    """
+    text = _disassemble(o_file, objdump, symbol=symbol)
+    in_body = False
+    saw_symbol = False
+    instrs = []
+
+    for line in text.splitlines():
+        m = _label_line.match(line)
+        if m:
+            label = m.group(1)
+            if label == symbol:
+                in_body = True
+                saw_symbol = True
+                continue
+            # A different symbol header ends the body we were collecting.
+            if in_body:
+                in_body = False
+            continue
+        if in_body:
+            if not line.strip():
+                # Blank line terminates the function's disassembly block.
+                in_body = False
+                continue
+            mi = _disasm_line.match(line)
+            if not mi:
+                ci = _continuation_line.match(line)
+                if ci and instrs:
+                    # GNU objdump wrapped a long instruction: append the
+                    # trailing bytes to the instruction they belong to.
+                    instrs[-1]["bytes"].extend(ci.group(1).split())
+                    continue
+                # Any other in-body line we cannot parse must be loud, not
+                # silently dropped: a dropped instruction would weaken the
+                # comparison without anyone noticing.
+                raise RuntimeError(
+                    f"unparsable disassembly line for {symbol!r} in {o_file}: "
+                    f"{line!r}")
+            addr_hex, bytes_str, mnemonic, operands = mi.groups()
+            instrs.append({
+                "address": addr_hex,
+                "bytes": bytes_str.split(),
+                "mnemonic": mnemonic,
+                "operands": (operands or "").strip(),
+            })
+
+    if not saw_symbol:
+        raise RuntimeError(
+            f"symbol {symbol!r} not found in disassembly of {o_file}. "
+            f"The impl must be emitted standalone (its address taken for the "
+            f"dispatch table) for its symbol to appear in the object file.")
+    # Strip trailing NOP-family instructions: padding emitted after the
+    # function's final control-flow terminator to align the NEXT function. It
+    # belongs to no function and varies with inter-function layout, so it is
+    # not part of this function's codegen. Internal alignment nops (e.g. before
+    # a hot loop) are mid-body and are preserved.
+    while instrs and instrs[-1]["mnemonic"].startswith("nop"):
+        instrs.pop()
+    if not instrs:
+        raise RuntimeError(
+            f"symbol {symbol!r} found in {o_file} but its body is empty")
+    return instrs
+
+
+# ---------------------------------------------------------------------------
+# Equivalence criteria
+# ---------------------------------------------------------------------------
+
+def _operand_class(op: str) -> str:
+    """Normalize an operand string to its class for within_noise comparison:
+    strip specific register identifiers, immediate values, and disassembler
+    symbol annotations, keeping the operand's structural shape.
+
+    Coverage is x86_64-validated (SIMD + all GPR width forms). It is NOT a
+    complete model of every architecture's operand syntax; within_noise on
+    other targets needs its register table extended here.
+    """
+    # Drop disassembler symbol annotations first: branch/RIP-relative operands
+    # render as "0x18 <SYMBOL+0x18>", and SYMBOL is the function's OWN name,
+    # which differs between the two impls being compared (e.g. _a_avx vs
+    # _a_avx_ref). The numeric displacement already encodes the distance, so
+    # the annotation is pure noise that would otherwise force a false failure.
+    op = re.sub(r'<[^>]*>', '', op)
+    # SIMD vector registers: %xmm0..31 / %ymm.. / %zmm..  -> %xmmN etc.
+    op = re.sub(r'%(x|y|z)mm\d+', r'%\1mmN', op)
+    # Extended GPRs r8-r15 with optional d/w/b width suffix -> %rN.
+    op = re.sub(r'%r1[0-5][dwb]?\b', '%rN', op)
+    op = re.sub(r'%r[89][dwb]?\b', '%rN', op)
+    # 64-/32-bit ABI-named GPRs. (%rip is left intact: rip-relative addressing
+    # is semantically distinct and should not collapse to a GPR class.)
+    op = re.sub(r'%r(?:ax|bx|cx|dx|si|di|sp|bp)\b', '%rregN', op)
+    op = re.sub(r'%e(?:ax|bx|cx|dx|si|di|sp|bp)\b', '%eregN', op)
+    # 16-bit GPRs (%ax..%bp) and 8-bit GPRs (%al/%ah/%bl.., %sil/%dil/%spl/%bpl).
+    op = re.sub(r'%(?:ax|bx|cx|dx|si|di|sp|bp)\b', '%wregN', op)
+    op = re.sub(r'%(?:[abcd][lh]|sil|dil|spl|bpl)\b', '%bregN', op)
+    # Immediates: hex, signed/unsigned decimal.
+    op = re.sub(r'\$0x[0-9a-fA-F]+', '$imm', op)
+    op = re.sub(r'\$-?\d+', '$imm', op)
+    # Bare hex displacements in memory operands: 0x10(%reg) -> IMMx(%reg).
+    op = re.sub(r'\b0x[0-9a-fA-F]+', 'IMMx', op)
+    # GNU objdump renders branch targets as a bare hex address (no 0x); after
+    # the <...> strip above, a leading bare-hex token may remain -> normalize.
+    op = re.sub(r'^\s*[0-9a-fA-F]+\s*$', 'IMMx', op)
+    # Canonicalize whitespace so e.g. a stripped annotation leaving a trailing
+    # space cannot make two otherwise-equal operand classes compare unequal.
+    return re.sub(r'\s+', ' ', op).strip()
+
+
+def compare_byte_identical(a: list, b: list):
+    if len(a) != len(b):
+        return False, (f"instruction count differs: {len(a)} vs {len(b)}\n"
+                       f"  a: {[i['mnemonic'] for i in a]}\n"
+                       f"  b: {[i['mnemonic'] for i in b]}")
+    diffs = []
+    for i, (ia, ib) in enumerate(zip(a, b)):
+        if ia["bytes"] != ib["bytes"]:
+            diffs.append(
+                f"  [{i}] bytes differ: "
+                f"{' '.join(ia['bytes'])} ({ia['mnemonic']}) vs "
+                f"{' '.join(ib['bytes'])} ({ib['mnemonic']})")
+    if diffs:
+        return False, "byte_identical comparison FAILED:\n" + "\n".join(diffs)
+    return True, ""
+
+
+def compare_within_noise(a: list, b: list):
+    if len(a) != len(b):
+        return False, (f"instruction count differs: {len(a)} vs {len(b)}\n"
+                       f"  a: {[i['mnemonic'] for i in a]}\n"
+                       f"  b: {[i['mnemonic'] for i in b]}")
+    diffs = []
+    for i, (ia, ib) in enumerate(zip(a, b)):
+        if ia["mnemonic"] != ib["mnemonic"]:
+            diffs.append(
+                f"  [{i}] mnemonic differs: {ia['mnemonic']} vs {ib['mnemonic']}")
+            continue
+        ca, cb = _operand_class(ia["operands"]), _operand_class(ib["operands"])
+        if ca != cb:
+            diffs.append(
+                f"  [{i}] {ia['mnemonic']} operand class differs: "
+                f"{ca!r} vs {cb!r}")
+    if diffs:
+        return False, "within_noise comparison FAILED:\n" + "\n".join(diffs)
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Codegen-equivalence test harness for volk fusion impls",
+        epilog="See mtibbits/volk#78 for context.",
+    )
+    ap.add_argument("--manifest", required=True, type=Path,
+                    help="JSON manifest of equivalence tuples")
+    ap.add_argument("--build-lib-dir", type=Path,
+                    help="Dir containing the compiled .o files "
+                         "(required unless --list-only)")
+    ap.add_argument("--objdump", default="llvm-objdump",
+                    help="Disassembler binary (default: llvm-objdump; "
+                         "GNU objdump also works)")
+    ap.add_argument("--list-only", action="store_true",
+                    help="List declared tuples and exit (no disassembly)")
+    args = ap.parse_args()
+
+    tuples = parse_manifest(args.manifest)
+
+    if args.list_only:
+        for t in tuples:
+            print(tuple_id(t))
+        sys.exit(0)
+
+    if not args.build_lib_dir:
+        print("error: --build-lib-dir required unless --list-only",
+              file=sys.stderr)
+        sys.exit(2)
+
+    if not tuples:
+        print("codegen-equivalence: ok (0 tuples declared)")
+        sys.exit(0)
+
+    failures = []
+    errors = []
+    for t in tuples:
+        try:
+            a_o = resolve_object(args.build_lib_dir, t["impl_a"]["machine_o"])
+            b_o = resolve_object(args.build_lib_dir, t["impl_b"]["machine_o"])
+            a_instrs = extract_function_body(
+                a_o, t["impl_a"]["symbol"], objdump=args.objdump)
+            b_instrs = extract_function_body(
+                b_o, t["impl_b"]["symbol"], objdump=args.objdump)
+        except RuntimeError as e:
+            errors.append((tuple_id(t), str(e)))
+            continue
+
+        if t["criterion"] == "byte_identical":
+            ok, diff = compare_byte_identical(a_instrs, b_instrs)
+        else:
+            ok, diff = compare_within_noise(a_instrs, b_instrs)
+        if not ok:
+            failures.append((tuple_id(t), diff))
+
+    if errors:
+        print("CODEGEN-EQUIVALENCE CHECK ERROR", file=sys.stderr)
+        print("", file=sys.stderr)
+        for tid, msg in errors:
+            print(f"--- {tid} ---", file=sys.stderr)
+            print(f"  {msg}", file=sys.stderr)
+            print("", file=sys.stderr)
+        sys.exit(2)
+
+    if failures:
+        print("CODEGEN-EQUIVALENCE CHECK FAILED", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("One or more declared (kernel, ISA, alignment) tuples failed",
+              file=sys.stderr)
+        print("their codegen-equivalence criterion. A framework instantiation",
+              file=sys.stderr)
+        print("no longer emits the machine code its reference impl emits.",
+              file=sys.stderr)
+        print("", file=sys.stderr)
+        print("See https://github.com/mtibbits/volk/issues/78 for context.",
+              file=sys.stderr)
+        print("", file=sys.stderr)
+        for tid, diff in failures:
+            print(f"--- {tid} ---", file=sys.stderr)
+            print(diff, file=sys.stderr)
+            print("", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"codegen-equivalence: ok ({len(tuples)} tuples checked)")
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -1,0 +1,181 @@
+# Codegen-Equivalence Test Harness
+
+A build-time check that asserts byte-identical-or-within-noise machine code
+between declared `(kernel, ISA, alignment)` impl pairs. It is the codegen-side
+counterpart to the dispatch-table integrity check (mtibbits/volk#58, PR #59):
+that check verifies the right impls are *wired into dispatch*; this one
+verifies a framework-instantiated impl *emits the machine code its hand-written
+reference emits*.
+
+Context: mtibbits/volk#78.
+
+## Why this exists
+
+The volk fusion framework rewrites hand-written SIMD kernels as instantiations
+of a generic driver. The framework's core correctness invariant is that the
+generated inner loop is byte-identical (or within measurement noise) to the
+hand-written impl it replaces. Without a permanent check, the first downstream
+framework refactor that subtly perturbs codegen on one ISA lands unnoticed.
+This harness runs in every build and breaks it on a regression, with a diff.
+
+## When to add a tuple
+
+When a new framework-instantiated impl ships, declare a tuple comparing it
+against the hand-written impl it replaces (or, for a pure framework rewrite,
+against the pre-rewrite impl captured as a reference). The build then fails
+fast if the framework's codegen ever diverges.
+
+## What gets compared: the whole function
+
+The harness compares the **whole function body** of each impl — every
+instruction from the `<symbol>:` disassembly header to the next symbol — not
+just the inner loop. This needs **no source markers**: you declare a tuple
+naming the two symbols, and the harness disassembles and compares them.
+
+> **Why whole-function, not inner-loop?** An earlier design bracketed just the
+> inner loop with source-level asm labels. That was abandoned: inserting a
+> label symbol mid-function makes its address a basic-block boundary the
+> optimizer must respect, which *perturbs the surrounding codegen* (an added
+> test instruction, register-allocation churn). Instrumenting a kernel for the
+> harness would change the kernel that ships — unacceptable. Whole-function
+> comparison leaves production codegen untouched and is the stronger contract:
+> a framework instantiation that reproduces a hand-written impl produces the
+> same *function*, not merely the same loop.
+
+Requirements on a compared impl:
+
+- It must be **emitted standalone** — its symbol must appear in the object
+  file. Volk's dispatch-table kernels satisfy this automatically because their
+  address is taken for the dispatch array. A purely-inlined-away `static
+  inline` with no address taken would have no symbol to find (the harness
+  errors clearly: "symbol not found").
+- Trailing NOP-family padding after the function's final `ret`/`jmp` is
+  alignment padding for the *next* function; the harness strips it before
+  comparing, so inter-function layout differences do not cause false failures.
+  Internal alignment nops (mid-body, e.g. before a hot loop) are preserved.
+
+## Manifest format
+
+Tuples are declared from CMake via the `ADD_CODEGEN_EQUIVALENCE_TUPLE` macro
+(defined in `cmake/CodegenEquivalence.cmake`). One invocation per tuple:
+
+```cmake
+ADD_CODEGEN_EQUIVALENCE_TUPLE(
+    KERNEL    volk_32f_x2_add_32f
+    ISA       avx
+    ALIGNMENT a
+    CRITERION byte_identical
+    IMPL_A_SYMBOL    volk_32f_x2_add_32f_a_avx
+    IMPL_A_MACHINE_O volk_machine_avx_64_mmx_orc.c.o
+    IMPL_B_SYMBOL    volk_32f_x2_add_32f_a_avx_ref
+    IMPL_B_MACHINE_O codegen_bootstrap_ref.c.o
+)
+```
+
+- `SYMBOL` is the function symbol the harness disassembles and compares.
+- `MACHINE_O` is the **bare object-file name**. The harness searches for it
+  recursively under the build tree (`build/lib/CMakeFiles/`), so different
+  OBJECT libraries landing their `.o` in different `<target>.dir/` subdirs
+  need no path hardcoding. An absolute path is also accepted.
+- When the two impls are compiled with the same codegen-relevant flags, use
+  `byte_identical`. When a wrapper or a different flag set introduces benign
+  register/immediate churn without changing the instruction stream's shape,
+  use `within_noise`.
+
+`FINALIZE_CODEGEN_EQUIVALENCE_HARNESS()` is called once (already wired in
+`lib/CMakeLists.txt`) after all tuple declarations and after `volk_obj` is
+defined. It writes `build/codegen_equivalence_manifest.json` and creates the
+`volk_check_framework_codegen` target, which the `volk` shared library depends
+on.
+
+## Equivalence criteria
+
+- **`byte_identical`** — the raw instruction-byte sequences must match exactly
+  between impl A and impl B. Use this for framework instantiations designed to
+  compile to the same machine code as the hand-written predecessor (Approach A
+  in the fusion design doc §4).
+- **`within_noise`** — mnemonic sequences must match in order, and operand
+  *classes* must match; differences in specific register identifiers (`%ymm0`
+  vs `%ymm2`), immediate values, and hex displacements are tolerated.
+  Instruction **order is not** tolerated — a reordered loop body fails. Use
+  this when a static-inline wrapper (Approach B) or a different optimization
+  flag set introduces register-allocation churn without changing the
+  instruction stream's shape.
+
+## How the check runs
+
+1. **CMake configure:** each `ADD_CODEGEN_EQUIVALENCE_TUPLE` appends a JSON
+   fragment to a global property.
+2. **CMake configure end:** `FINALIZE_CODEGEN_EQUIVALENCE_HARNESS` writes the
+   manifest and creates the `volk_check_framework_codegen` custom target,
+   resolving a disassembler (`llvm-objdump`, then `llvm-objdump-18`, then
+   `objdump`).
+3. **Build:** after `volk_obj` compiles, the target runs
+   `cmake/check_framework_codegen.py --manifest ... --build-lib-dir
+   build/lib/CMakeFiles --objdump <found>`.
+4. The script disassembles each declared `SYMBOL` in its `MACHINE_O`, extracts
+   the whole function body, and applies the criterion. On failure it halts the
+   build with a per-tuple diff.
+
+With **zero tuples declared** the manifest is `{"tuples":[]}` and the check
+prints `codegen-equivalence: ok (0 tuples declared)` and exits 0 — no false
+positives on a clean tree.
+
+## Diagnostics
+
+- `symbol '<x>' not found in disassembly of <o>` — the impl was inlined away
+  (no address taken, so no symbol emitted), or the symbol is in a different
+  `.o` than declared.
+- `object file '<x>' not found under <dir>` — the `MACHINE_O` name does not
+  match any compiled object; check the build actually produced it.
+- `object file '<x>' is ambiguous` — more than one `.o` with that name exists;
+  give a more specific (relative or absolute) path.
+- `byte_identical comparison FAILED` — the function diverged from the
+  reference; the offending instruction index and both byte sequences are
+  printed.
+- `within_noise comparison FAILED` — either mnemonics differ (compiler chose a
+  different instruction) or operand classes differ (e.g. a register operand
+  became a memory operand). The offending index is printed.
+
+## Adding a tuple, end-to-end
+
+1. Confirm both impls are emitted standalone (their symbols appear via `nm` on
+   the relevant `.o`).
+2. Call `ADD_CODEGEN_EQUIVALENCE_TUPLE` in `lib/CMakeLists.txt` naming the two
+   symbols, their object files, and the criterion.
+3. Rebuild. Success prints `codegen-equivalence: ok (N tuples checked)`;
+   a regression halts the build with the diff.
+
+## Running the script's own tests
+
+`cmake/test_check_framework_codegen.py` is an informal standalone suite (not
+wired into ctest) covering manifest parsing, whole-function extraction against
+a real-toolchain fixture, and both comparison criteria:
+
+```bash
+python3 cmake/test_check_framework_codegen.py
+```
+
+`check_framework_codegen.py --manifest <m> --list-only` prints the declared
+tuple ids without disassembling, useful for inspecting a generated manifest.
+
+## Limitations
+
+- If any tuple **errors** (a missing symbol or `.o`), the harness exits 2 and
+  reports only the errors — accumulated codegen **failures** from other tuples
+  are not shown until the erroring entry is fixed. Fix manifest errors first.
+- `MACHINE_O` is resolved by bare-name recursive search under the build tree,
+  which assumes the object name is unique there. If a future build compiles the
+  same source into more than one OBJECT-library dir, give `MACHINE_O` as a path
+  relative to `build/lib/CMakeFiles` (or absolute) to disambiguate.
+- `within_noise` operand-class normalization is x86_64-validated. Comparing on
+  another architecture requires extending the register table in
+  `_operand_class`.
+
+## See also
+
+- the dispatch-table integrity check (mtibbits/volk#58, PR #59) — the
+  integrity check this harness is modeled on.
+- the fusion-framework epic (mtibbits/volk#77) and its design notes for the
+  C/C++ integration approaches (A vs B) that inform whether a given impl pair
+  should be compared with `byte_identical` or `within_noise`.

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -172,6 +172,36 @@ tuple ids without disassembling, useful for inspecting a generated manifest.
   another architecture requires extending the register table in
   `_operand_class`.
 
+## Cross-compiler robustness (mtibbits/volk#145)
+
+The harness runs across the full CI compiler matrix (gcc-11..14, clang-14..19,
+macOS clang, static builds, with either `llvm-objdump` or GNU `objdump`). It
+normalizes away codegen *noise* that differs by compiler but is not a real
+equivalence violation, while still hard-failing on a genuine divergence.
+
+**Stripped / tolerated (not a failure):**
+
+- **Trailing alignment NOPs** of any encoding, including the multi-byte forms
+  clang-15+ and gcc-11/14 emit after the function's final terminator
+  (`66 2e 0f 1f 84 00 00 00 00 00  nopw %cs:(%rax,%rax)`). These pad the *next*
+  function's alignment and belong to no function. Some objdump variants render
+  such a line with only a single tab between the byte column and the mnemonic,
+  which the primary line regex cannot parse; a padding-only fallback regex
+  (`_padding_line`) handles that form. **Mid-body** alignment NOPs (e.g. before
+  a hot loop) are *preserved* — only the trailing run is stripped.
+- **Trailing `data16` padding** — how GNU objdump renders a multi-byte NOP pad
+  (`data16 cs nopw …`); treated as padding like the NOP family.
+- **Symbol not emitted standalone** (e.g. macOS clang inlines the impl): there
+  is nothing to compare, so the tuple is **skipped with a warning** and the
+  build stays green. The summary line reports `N skipped`.
+
+**Still a hard failure:**
+
+- A genuine post-normalization divergence (differing mnemonic sequence or
+  operand class) → `CHECK FAILED`, exit 1.
+- A missing/ambiguous `.o`, malformed manifest, an unparsable *non-padding*
+  in-body line, or an empty function body → `CHECK ERROR`, exit 2.
+
 ## See also
 
 - the dispatch-table integrity check (mtibbits/volk#58, PR #59) — the

--- a/cmake/codegen_bootstrap_ref.c
+++ b/cmake/codegen_bootstrap_ref.c
@@ -1,0 +1,65 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+/*
+ * Bootstrap codegen-equivalence reference for mtibbits/volk#78.
+ *
+ * Defines volk_32f_x2_add_32f_a_avx_ref as a byte-for-byte copy of the
+ * existing _a_avx impl body from kernels/volk/volk_32f_x2_add_32f.h. This TU
+ * is compiled with the SAME flags the impl gets in its machine TU
+ * (-O3 -mavx), so the codegen-equivalence harness should find the two
+ * functions byte_identical. This is the harness's first consumer: it proves
+ * the harness extracts and compares whole-function disassembly correctly on a
+ * known-equal baseline, independent of any fusion-framework code.
+ *
+ * No source labels are used -- the harness compares the whole function body.
+ * Inserting labels would perturb codegen (a label symbol becomes a basic-block
+ * boundary the optimizer must respect); whole-function comparison avoids that
+ * entirely. See cmake/check_framework_codegen_README.md.
+ *
+ * The body below is intentionally identical to the in-header _a_avx impl. The
+ * duplication is the experimental setup: two independent compilations of the
+ * same logic, asserted equal. volk_32f_x2_add_32f_a_avx is mathematically
+ * c = a + b over 8 AVX lanes and does not change, so the maintenance cost of
+ * the copy is effectively zero. Child mtibbits/volk#79 brings the real
+ * framework-instantiated impls online as the first non-bootstrap consumers.
+ */
+#include <immintrin.h>
+
+void volk_32f_x2_add_32f_a_avx_ref(float* cVector,
+                                   const float* aVector,
+                                   const float* bVector,
+                                   unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    const float* bPtr = bVector;
+
+    __m256 aVal, bVal, cVal;
+    for (; number < eighthPoints; number++) {
+
+        aVal = _mm256_load_ps(aPtr);
+        bVal = _mm256_load_ps(bPtr);
+
+        cVal = _mm256_add_ps(aVal, bVal);
+
+        _mm256_store_ps(cPtr, cVal); // Store the results back into the C container
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) + (*bPtr++);
+    }
+}

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -405,7 +405,46 @@ def test_padding_line_mnemonics_are_strippable():
     self-defending if someone extends one side without the other."""
     mod = _load_module()
     for m in ("nop", "nopw", "nopl", "nopq", "data16"):
-        assert mod._is_trailing_padding(m), m
+        assert mod._is_trailing_padding({"mnemonic": m, "operands": ""}), m
+
+
+def test_trailing_xchg_and_int3_padding_stripped():
+    """Trailing `xchg %ax,%ax` (0x66 0x90, the legacy 2-byte NOP) and `int3`
+    (0xcc gap fill) are inter-function alignment padding and must be stripped.
+    Real-world: clang-15 on ubuntu-22.04 emits a trailing `xchg %ax,%ax` after
+    the function's final jmp, which failed byte_identical before this
+    (mtibbits/volk#145)."""
+    mod = _load_module()
+    xchg_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: eb 00                        \tjmp\t0x2 <f+0x2>\n"
+        "       2: 66 90                        \txchg\t%ax, %ax\n"
+    )
+    int3_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+        "       1: cc                           \tint3\n"
+    )
+    plain = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+    )
+    a = mod.extract_function_body_from_text(xchg_pad, "f")
+    b = mod.extract_function_body_from_text(int3_pad, "f")
+    c = mod.extract_function_body_from_text(plain, "f")
+    assert [i["mnemonic"] for i in a] == ["jmp"], a
+    assert [i["mnemonic"] for i in b] == ["retq"], b
+    assert mod.compare_byte_identical(b, c)[0]
+
+
+def test_real_xchg_is_not_stripped():
+    """Safety: a genuine register exchange `xchg %rax,%rbx` (different operands)
+    must NOT be treated as padding -- only the self-exchange NOP idiom is."""
+    mod = _load_module()
+    assert not mod._is_trailing_padding(
+        {"mnemonic": "xchg", "operands": "%rax, %rbx"})
+    assert mod._is_trailing_padding(
+        {"mnemonic": "xchg", "operands": "%ax, %ax"})
 
 
 def main():

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -248,6 +248,166 @@ def test_gnu_objdump_continuation_lines():
         assert ok, f"GNU vs llvm byte streams differ after stitching:\n{diff}"
 
 
+# ---------------------------------------------------------------------------
+# Cross-compiler robustness (mtibbits/volk#145)
+# ---------------------------------------------------------------------------
+
+def test_extract_from_text_seam_basic():
+    """The text seam parses a literal disassembly block: collects the body of
+    the named symbol, stops at the next symbol, strips the trailing NOP."""
+    mod = _load_module()
+    text = (
+        "0000000000000000 <fixture>:\n"
+        "       0: c5 fc 58 04 06               \tvaddps\t(%rsi,%rax), %ymm0, %ymm0\n"
+        "       5: c3                           \tretq\n"
+        "       6: 90                           \tnop\n"
+        "0000000000000010 <other>:\n"
+        "      10: c3                           \tretq\n"
+    )
+    instrs = mod.extract_function_body_from_text(text, "fixture")
+    assert [i["mnemonic"] for i in instrs] == ["vaddps", "retq"], instrs
+
+
+def test_trailing_multibyte_nop_does_not_raise():
+    """The multi-byte alignment NOP clang-15+/gcc-11/14 emit as trailing pad
+    renders with a SINGLE tab between the last byte and the mnemonic, which
+    _disasm_line cannot match. The padding fallback must parse it so the
+    trailing-strip drops it -- not raise 'unparsable'. The line below is the
+    real rendering captured from `llvm-objdump` on a clang-18 build of
+    volk_machine_avx_*.o (mtibbits/volk#145)."""
+    mod = _load_module()
+    # Normal short instructions render space-padded (>=2 ws before the tab);
+    # only the full-width 10-byte NOP renders with a lone tab -- the real
+    # captured failing form from llvm-objdump on a clang-18 machine .o.
+    text = (
+        "0000000000000000 <f1>:\n"
+        "       0: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+        "       4: c3                           \tretq\n"
+        "       5: 66 2e 0f 1f 84 00 00 00 00 00\tnopw\t%cs:(%rax,%rax)\n"
+        "0000000000000020 <f2>:\n"
+        "      20: c3                           \tretq\n"
+    )
+    instrs = mod.extract_function_body_from_text(text, "f1")
+    assert [i["mnemonic"] for i in instrs] == ["vaddps", "retq"], instrs
+
+
+def test_trailing_data16_padding_stripped():
+    """A trailing `data16` padding instruction (how GNU objdump renders the
+    multi-byte NOP pad) is not part of the function body and must be stripped,
+    so a data16-vs-none pad does not fail byte_identical."""
+    mod = _load_module()
+    with_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+        "       1: 66 66 2e 0f 1f 84 00 \tdata16\tcs nopw 0x0(%rax,%rax,1)\n"
+    )
+    without_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+    )
+    a = mod.extract_function_body_from_text(with_pad, "f")
+    b = mod.extract_function_body_from_text(without_pad, "f")
+    assert [i["mnemonic"] for i in a] == ["retq"], a
+    ok, diff = mod.compare_byte_identical(a, b)
+    assert ok, diff
+
+
+def test_symbol_not_standalone_raises_typed():
+    """When a symbol is absent (inlined, not emitted standalone) the parser
+    raises the typed SymbolNotEmittedError so main() can skip-with-warning,
+    not the bare RuntimeError that aggregates into a build-failing CHECK ERROR."""
+    mod = _load_module()
+    text = ("0000000000000000 <other>:\n"
+            "       0: c3\tretq\n")
+    try:
+        mod.extract_function_body_from_text(text, "inlined_away")
+        assert False, "expected SymbolNotEmittedError"
+    except mod.SymbolNotEmittedError as e:
+        assert "inlined_away" in str(e), str(e)
+    # It must be a RuntimeError subclass so existing `except RuntimeError`
+    # callers still see it if they do not special-case it.
+    assert issubclass(mod.SymbolNotEmittedError, RuntimeError)
+
+
+def test_padding_strip_does_not_swallow_real_instruction():
+    """Negative control: a trailing NON-padding instruction (an extra vaddps)
+    must remain and still cause a divergence -- the strip is padding-only."""
+    mod = _load_module()
+    longer = ("0000000000000000 <f>:\n"
+              "       0: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+              "       4: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+              "       8: c3                           \tretq\n")
+    shorter = ("0000000000000000 <f>:\n"
+               "       0: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+               "       4: c3                           \tretq\n")
+    a = mod.extract_function_body_from_text(longer, "f")
+    b = mod.extract_function_body_from_text(shorter, "f")
+    ok, diff = mod.compare_byte_identical(a, b)
+    assert not ok and "count differs" in diff, (ok, diff)
+
+
+def test_end_to_end_divergent_pair_fails_build():
+    """Negative control (end-to-end): a manifest comparing two genuinely
+    divergent impls (add vs mul) exits 1 with CHECK FAILED -- proving the
+    hardened parser still breaks the build on a real codegen divergence."""
+    import shutil
+    cc = shutil.which("cc")
+    objdump = _which_objdump()
+    if not cc:
+        print("  (skip test_end_to_end_divergent_pair_fails_build: no cc)")
+        return
+    add = ("#include <immintrin.h>\n"
+           "__m256 nc_fn(__m256 a,__m256 b){return _mm256_add_ps(a,b);}\n")
+    mul = ("#include <immintrin.h>\n"
+           "__m256 nc_fn(__m256 a,__m256 b){return _mm256_mul_ps(a,b);}\n")
+    a_c = Path("/tmp/cge_nc_a.c"); a_c.write_text(add)
+    b_c = Path("/tmp/cge_nc_b.c"); b_c.write_text(mul)
+    a_o = Path("/tmp/cge_nc_a.o"); b_o = Path("/tmp/cge_nc_b.o")
+    for s, o in ((a_c, a_o), (b_c, b_o)):
+        subprocess.run([cc, "-O3", "-mavx", "-c", str(s), "-o", str(o)],
+                       check=True)
+    manifest = {"tuples": [{
+        "kernel": "nc", "isa": "avx", "alignment": "a",
+        "impl_a": {"symbol": "nc_fn", "machine_o": str(a_o)},
+        "impl_b": {"symbol": "nc_fn", "machine_o": str(b_o)},
+        "criterion": "byte_identical",
+    }]}
+    mpath = Path("/tmp/cge_nc_manifest.json"); mpath.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(mpath),
+         "--build-lib-dir", "/tmp", "--objdump", objdump],
+        capture_output=True, text=True)
+    assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+    assert "CHECK FAILED" in result.stderr, result.stderr
+
+
+def test_padding_fallback_data16_single_tab():
+    """Exercises the _padding_line fallback's `data16` arm specifically: a
+    single-tab `data16` pad line (which _disasm_line cannot parse) must be
+    caught by the fallback and then stripped. A space-padded `data16` line would
+    not reach the fallback -- it matches the primary _disasm_line -- so without
+    this case the fallback's data16 branch is untested (red-team Nit G2)."""
+    mod = _load_module()
+    text = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+        "       1: 66 66 2e 0f 1f 84 00 00 00\tdata16\tcs nopw 0x0(%rax,%rax,1)\n"
+    )
+    instrs = mod.extract_function_body_from_text(text, "f")
+    assert [i["mnemonic"] for i in instrs] == ["retq"], instrs
+
+
+def test_padding_line_mnemonics_are_strippable():
+    """Invariant (red-team Nit J): every mnemonic the _padding_line fallback
+    accepts must also be removed by _is_trailing_padding -- otherwise a
+    fallback-absorbed pad would survive into the comparison and silently change
+    it. Pin representative members of the accepted set so the invariant is
+    self-defending if someone extends one side without the other."""
+    mod = _load_module()
+    for m in ("nop", "nopw", "nopl", "nopq", "data16"):
+        assert mod._is_trailing_padding(m), m
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright 2026 Free Software Foundation, Inc.
+#
+# This file is part of VOLK
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+"""
+Informal test suite for cmake/check_framework_codegen.py (mtibbits/volk#78).
+
+Not wired into ctest -- documents the script's internal contracts and is
+runnable standalone:  python3 cmake/test_check_framework_codegen.py
+
+Exercises manifest parsing, whole-function disassembly extraction, and the
+byte_identical / within_noise comparison criteria. The extraction tests
+assemble tiny fixtures with the system toolchain, so they require `cc` and
+a disassembler (llvm-objdump or objdump) on PATH.
+"""
+
+import json
+import subprocess
+import sys
+from importlib import util
+from pathlib import Path
+
+THIS_DIR = Path(__file__).parent
+SCRIPT = THIS_DIR / "check_framework_codegen.py"
+
+
+def _load_module():
+    spec = util.spec_from_file_location("cfc", str(SCRIPT))
+    mod = util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _which_objdump():
+    for cand in ("llvm-objdump", "llvm-objdump-18", "objdump"):
+        if subprocess.run(["which", cand], capture_output=True).returncode == 0:
+            return cand
+    raise RuntimeError("no disassembler found (llvm-objdump / objdump)")
+
+
+def test_manifest_parse():
+    """Script accepts a JSON manifest and lists declared tuples via --list-only."""
+    manifest = {
+        "tuples": [
+            {
+                "kernel": "volk_32f_x2_add_32f",
+                "isa": "avx",
+                "alignment": "a",
+                "impl_a": {
+                    "symbol": "volk_32f_x2_add_32f_a_avx",
+                    "machine_o": "volk_machine_avx_64_mmx_orc.c.o",
+                },
+                "impl_b": {
+                    "symbol": "volk_32f_x2_add_32f_a_avx_ref",
+                    "machine_o": "codegen_bootstrap_ref.c.o",
+                },
+                "criterion": "byte_identical",
+            }
+        ]
+    }
+    manifest_path = Path("/tmp/cge_test_manifest.json")
+    manifest_path.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--manifest", str(manifest_path), "--list-only"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "volk_32f_x2_add_32f.avx.a" in result.stdout, result.stdout
+
+
+def test_empty_manifest_ok():
+    """An empty manifest is a valid zero-false-positives configuration."""
+    manifest_path = Path("/tmp/cge_empty_manifest.json")
+    manifest_path.write_text('{"tuples":[]}')
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--manifest", str(manifest_path), "--build-lib-dir", "/tmp"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "0 tuples" in result.stdout, result.stdout
+
+
+def test_bad_criterion_rejected():
+    """A manifest tuple with an unknown criterion fails with exit 2."""
+    manifest = {"tuples": [{
+        "kernel": "k", "isa": "avx", "alignment": "a",
+        "impl_a": {"symbol": "s", "machine_o": "m.o"},
+        "impl_b": {"symbol": "s2", "machine_o": "m2.o"},
+        "criterion": "bogus",
+    }]}
+    manifest_path = Path("/tmp/cge_bad_manifest.json")
+    manifest_path.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--manifest", str(manifest_path), "--list-only"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2, (result.returncode, result.stdout)
+    assert "bogus" in result.stderr
+
+
+def test_function_body_extraction():
+    """extract_function_body collects the whole function body (prologue through
+    epilogue) for the named symbol, and stops at the next symbol."""
+    objdump = _which_objdump()
+    fixture_c = Path("/tmp/cge_fixture.c")
+    fixture_c.write_text(
+        "#include <immintrin.h>\n"
+        "void fixture_fn(float* c, const float* a, const float* b, unsigned n){\n"
+        "    unsigned e = n / 8;\n"
+        "    for (unsigned i = 0; i < e; i++) {\n"
+        "        __m256 x = _mm256_load_ps(a + i*8);\n"
+        "        __m256 y = _mm256_load_ps(b + i*8);\n"
+        "        _mm256_store_ps(c + i*8, _mm256_add_ps(x, y));\n"
+        "    }\n"
+        "}\n"
+        "void other_fn(void){}\n"
+    )
+    fixture_o = Path("/tmp/cge_fixture.o")
+    subprocess.run(["cc", "-O3", "-mavx", "-c", str(fixture_c),
+                    "-o", str(fixture_o)], check=True)
+    mod = _load_module()
+    instrs = mod.extract_function_body(fixture_o, "fixture_fn", objdump=objdump)
+    mnemonics = [i["mnemonic"] for i in instrs]
+    # Whole-body extraction includes prologue (endbr64) and the SIMD loop.
+    assert any(m.startswith("vadd") for m in mnemonics), mnemonics
+    # The next function's body must NOT bleed in: fixture_fn ends before
+    # other_fn. A 1-instruction `ret`-only other_fn would be the giveaway, so
+    # assert the extracted body is the add loop, not a degenerate stub.
+    assert len(instrs) > 3, mnemonics
+
+
+def test_byte_identical_same():
+    mod = _load_module()
+    a = [{"address": "10", "bytes": ["c5", "f4", "58", "04", "02"],
+          "mnemonic": "vaddps", "operands": "(%rdx,%rax), %ymm1, %ymm0"}]
+    ok, diff = mod.compare_byte_identical(a, a)
+    assert ok, diff
+
+
+def test_byte_identical_diff():
+    mod = _load_module()
+    a = [{"address": "10", "bytes": ["c5", "f4", "58", "04", "02"],
+          "mnemonic": "vaddps", "operands": "(%rdx,%rax), %ymm1, %ymm0"}]
+    b = [{"address": "10", "bytes": ["c5", "f4", "59", "04", "02"],
+          "mnemonic": "vmulps", "operands": "(%rdx,%rax), %ymm1, %ymm0"}]
+    ok, diff = mod.compare_byte_identical(a, b)
+    assert not ok
+    assert "vaddps" in diff and "vmulps" in diff, diff
+
+
+def test_within_noise_register_swap():
+    """Register reassignment within the same operand class passes within_noise."""
+    mod = _load_module()
+    a = [{"address": "10", "bytes": ["aa"], "mnemonic": "vaddps",
+          "operands": "(%rsi,%rax), %ymm0, %ymm1"}]
+    b = [{"address": "10", "bytes": ["bb"], "mnemonic": "vaddps",
+          "operands": "(%rdx,%rcx), %ymm2, %ymm3"}]
+    ok, diff = mod.compare_within_noise(a, b)
+    assert ok, diff
+
+
+def test_within_noise_mnemonic_diff_fails():
+    mod = _load_module()
+    a = [{"address": "10", "bytes": ["aa"], "mnemonic": "vaddps",
+          "operands": "%ymm0, %ymm1, %ymm2"}]
+    b = [{"address": "10", "bytes": ["bb"], "mnemonic": "vmulps",
+          "operands": "%ymm0, %ymm1, %ymm2"}]
+    ok, diff = mod.compare_within_noise(a, b)
+    assert not ok
+    assert "vaddps" in diff and "vmulps" in diff, diff
+
+
+def test_within_noise_real_two_symbols():
+    """End-to-end within_noise over two real, differently-named compilations of
+    the same loop. Exercises the branch-target annotation path (<symbol+off>):
+    the two functions have different symbol names, so their internal jump
+    operands annotate differently -- within_noise must tolerate that. This is
+    the regression guard for the branch-operand false-failure bug."""
+    objdump = _which_objdump()
+    src = ("#include <immintrin.h>\n"
+           "void NAME(float* c, const float* a, const float* b, unsigned n){\n"
+           "    unsigned e = n / 8;\n"
+           "    for (unsigned i = 0; i < e; i++) {\n"
+           "        __m256 x = _mm256_loadu_ps(a + i*8);\n"
+           "        __m256 y = _mm256_loadu_ps(b + i*8);\n"
+           "        _mm256_storeu_ps(c + i*8, _mm256_add_ps(x, y));\n"
+           "    }\n"
+           "    for (unsigned i = e*8; i < n; i++) c[i] = a[i] + b[i];\n"
+           "}\n")
+    a_c = Path("/tmp/cge_wn_a.c"); a_c.write_text(src.replace("NAME", "wn_fn_a"))
+    b_c = Path("/tmp/cge_wn_b.c"); b_c.write_text(src.replace("NAME", "wn_fn_b"))
+    a_o = Path("/tmp/cge_wn_a.o"); b_o = Path("/tmp/cge_wn_b.o")
+    for s, o in ((a_c, a_o), (b_c, b_o)):
+        subprocess.run(["cc", "-O3", "-mavx", "-c", str(s), "-o", str(o)],
+                       check=True)
+    mod = _load_module()
+    ia = mod.extract_function_body(a_o, "wn_fn_a", objdump=objdump)
+    ib = mod.extract_function_body(b_o, "wn_fn_b", objdump=objdump)
+    # The two bodies have internal jne/je to <wn_fn_a+off> vs <wn_fn_b+off>.
+    # byte_identical would fail on the differing symbol bytes; within_noise
+    # must PASS because the operand classes match once annotations are stripped.
+    ok, diff = mod.compare_within_noise(ia, ib)
+    assert ok, f"within_noise should tolerate differing branch-target symbol "\
+               f"names but failed:\n{diff}"
+
+
+def test_gnu_objdump_continuation_lines():
+    """GNU objdump wraps instructions longer than 7 bytes onto a second,
+    mnemonic-less line (e.g. the 9-byte nopw alignment pad before a hot loop).
+    The harness must stitch those bytes onto the prior instruction, not error.
+    This guards the GNU-objdump path (the rest of the suite prefers
+    llvm-objdump). Skips cleanly if GNU objdump is unavailable."""
+    import shutil
+    gnu = shutil.which("objdump")
+    if not gnu or "llvm" in gnu:
+        print("  (skip test_gnu_objdump_continuation_lines: no GNU objdump)")
+        return
+    fixture_c = Path("/tmp/cge_gnu_fixture.c")
+    fixture_c.write_text(
+        "#include <immintrin.h>\n"
+        "void gnu_fn(float* c, const float* a, const float* b, unsigned n){\n"
+        "    unsigned e = n / 8;\n"
+        "    for (unsigned i = 0; i < e; i++) {\n"
+        "        __m256 x = _mm256_load_ps(a + i*8);\n"
+        "        __m256 y = _mm256_load_ps(b + i*8);\n"
+        "        _mm256_store_ps(c + i*8, _mm256_add_ps(x, y));\n"
+        "    }\n"
+        "}\n"
+    )
+    fixture_o = Path("/tmp/cge_gnu_fixture.o")
+    subprocess.run(["cc", "-O3", "-mavx", "-c", str(fixture_c),
+                    "-o", str(fixture_o)], check=True)
+    mod = _load_module()
+    # Must not raise on the continuation line GNU objdump emits for the nopw pad.
+    instrs = mod.extract_function_body(fixture_o, "gnu_fn", objdump=gnu)
+    # If llvm-objdump is also present, the stitched GNU byte stream must match
+    # llvm's byte-for-byte, proving the stitch reassembles the wrapped bytes.
+    llvm = shutil.which("llvm-objdump") or shutil.which("llvm-objdump-18")
+    if llvm:
+        ill = mod.extract_function_body(fixture_o, "gnu_fn", objdump=llvm)
+        ok, diff = mod.compare_byte_identical(instrs, ill)
+        assert ok, f"GNU vs llvm byte streams differ after stitching:\n{diff}"
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -538,6 +538,13 @@ if(MSVC)
     set_source_files_properties(${volk_sources} PROPERTIES LANGUAGE CXX)
 endif()
 
+# Codegen-equivalence harness (mtibbits/volk#78): define the
+# ADD_CODEGEN_EQUIVALENCE_TUPLE / FINALIZE_CODEGEN_EQUIVALENCE_HARNESS API
+# before any tuple-declaration call sites. The harness asserts
+# byte-identical-or-within-noise machine code between declared impl pairs at
+# build time. See cmake/check_framework_codegen_README.md.
+include(${PROJECT_SOURCE_DIR}/cmake/CodegenEquivalence.cmake)
+
 #Create an object to reference Volk source and object files.
 #
 #NOTE: This object cannot be used to propagate include directories or
@@ -610,6 +617,64 @@ target_include_directories(
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC $<INSTALL_INTERFACE:include>)
+
+# Bootstrap codegen-equivalence assertion (mtibbits/volk#78 first consumer):
+# compile a byte-for-byte copy of volk_32f_x2_add_32f_a_avx into a separate TU
+# and assert the whole function is byte_identical to the in-header impl. Proves
+# the harness extracts and compares disassembly correctly on a known-equal
+# baseline, independent of any fusion-framework code.
+#
+# The base-avx machine TU name is detected from the configured machine list,
+# NOT hardcoded: with ORC it is avx_64_mmx_orc, without it is avx_64_mmx, and
+# matching "^avx_" excludes avx2_/avx512*. If no base-avx machine is built
+# (e.g. a non-x86 target), the bootstrap tuple is skipped and the harness runs
+# with zero tuples -- still valid (no false positives on a clean tree).
+set(_cge_avx_machine "")
+foreach(_cge_m ${available_machines})
+    if(_cge_m MATCHES "^avx_")
+        set(_cge_avx_machine "${_cge_m}")
+        break()
+    endif()
+endforeach()
+if(_cge_avx_machine)
+    # Optimisation flags are INHERITED from the build config (CMAKE_C_FLAGS_<cfg>),
+    # not hardcoded, so this TU matches the avx machine TU under any build type
+    # (Release -O3, Debug -O0, ...) rather than only Release. Only the avx
+    # machine arch flags and PIC (to match the shared lib) are added here.
+    add_library(volk_codegen_bootstrap_ref OBJECT
+        ${PROJECT_SOURCE_DIR}/cmake/codegen_bootstrap_ref.c)
+    set_target_properties(volk_codegen_bootstrap_ref PROPERTIES
+        POSITION_INDEPENDENT_CODE ON)
+    target_compile_options(volk_codegen_bootstrap_ref PRIVATE
+        -fvisibility=hidden
+        -m64 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mavx)
+
+    ADD_CODEGEN_EQUIVALENCE_TUPLE(
+        KERNEL    volk_32f_x2_add_32f
+        ISA       avx
+        ALIGNMENT a
+        CRITERION byte_identical
+        IMPL_A_SYMBOL    volk_32f_x2_add_32f_a_avx
+        IMPL_A_MACHINE_O volk_machine_${_cge_avx_machine}.c.o
+        IMPL_B_SYMBOL    volk_32f_x2_add_32f_a_avx_ref
+        IMPL_B_MACHINE_O codegen_bootstrap_ref.c.o
+    )
+else()
+    message(STATUS "codegen-equivalence: no base-avx machine built; "
+                   "bootstrap tuple skipped (harness runs with zero tuples)")
+endif()
+
+# Codegen-equivalence harness (mtibbits/volk#78): emit the manifest from the
+# ADD_CODEGEN_EQUIVALENCE_TUPLE() calls above and create the check target, then
+# make the shared lib depend on it so a regression in a framework
+# instantiation's machine code breaks the build. With zero tuples declared the
+# manifest is empty and the check is a no-op (zero false positives on
+# origin/main). Mirrors the volk_check_dispatch_tables wiring (PR #59 / B15).
+FINALIZE_CODEGEN_EQUIVALENCE_HARNESS()
+if(_cge_avx_machine)
+    add_dependencies(volk_check_framework_codegen volk_codegen_bootstrap_ref)
+endif()
+add_dependencies(volk volk_check_framework_codegen)
 
 #Configure target properties
 if(ORC_FOUND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -636,7 +636,19 @@ foreach(_cge_m ${available_machines})
         break()
     endif()
 endforeach()
-if(_cge_avx_machine)
+# Gate the bootstrap tuple to native 64-bit builds. The reference TU hardcodes
+# -m64 (below) to mirror the 64-bit host machine TU, but a 32-bit / cross target
+# that still builds an avx machine -- notably Android NDK "x86" (i686, 32-bit) --
+# compiles the machine TU 32-bit while the reference TU is forced 64-bit, so the
+# two genuinely diverge (addl/movl vs addq) and byte_identical fails on benign
+# bitness, not a real codegen regression. The reference TU cannot faithfully
+# mirror a 32-bit/cross machine TU, so skip the tuple there (zero tuples is a
+# valid, false-positive-free configuration). mtibbits/volk#145.
+set(_cge_bootstrap_enabled FALSE)
+if(_cge_avx_machine AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
+    set(_cge_bootstrap_enabled TRUE)
+endif()
+if(_cge_bootstrap_enabled)
     # Optimisation flags are INHERITED from the build config (CMAKE_C_FLAGS_<cfg>),
     # not hardcoded, so this TU matches the avx machine TU under any build type
     # (Release -O3, Debug -O0, ...) rather than only Release. Only the avx
@@ -659,6 +671,11 @@ if(_cge_avx_machine)
         IMPL_B_SYMBOL    volk_32f_x2_add_32f_a_avx_ref
         IMPL_B_MACHINE_O codegen_bootstrap_ref.c.o
     )
+elseif(_cge_avx_machine)
+    message(STATUS "codegen-equivalence: base-avx machine present but build is "
+                   "not 64-bit (sizeof(void*)=${CMAKE_SIZEOF_VOID_P}); bootstrap "
+                   "tuple skipped -- the 64-bit reference TU cannot match a "
+                   "32-bit/cross machine TU (e.g. Android NDK x86)")
 else()
     message(STATUS "codegen-equivalence: no base-avx machine built; "
                    "bootstrap tuple skipped (harness runs with zero tuples)")
@@ -671,7 +688,7 @@ endif()
 # manifest is empty and the check is a no-op (zero false positives on
 # origin/main). Mirrors the volk_check_dispatch_tables wiring (PR #59 / B15).
 FINALIZE_CODEGEN_EQUIVALENCE_HARNESS()
-if(_cge_avx_machine)
+if(_cge_bootstrap_enabled)
     add_dependencies(volk_check_framework_codegen volk_codegen_bootstrap_ref)
 endif()
 add_dependencies(volk volk_check_framework_codegen)


### PR DESCRIPTION
## Summary

Add a build-time codegen-equivalence test harness: a check that asserts
byte-identical-or-within-noise machine code between declared
`(kernel, ISA, alignment)` impl pairs. It is the codegen-side counterpart to
the per-machine dispatch-table integrity check (#58): that verifies the right
impls are *wired into dispatch*; this verifies a framework-instantiated impl
*emits the machine code its hand-written reference emits*. The harness exists
so the first downstream fusion-framework refactor that subtly perturbs codegen
on one ISA breaks the build instead of landing unnoticed. It adds **no kernel
source changes** — `kernels/` is byte-for-byte unchanged from base.

This is child A of the Stage 0 fusion-framework epic (#77); it ships the
permanent regression check before any framework instantiation exists, so #79
(framework birth) lands its first instantiation against a check that is already
in place.

## Related issues

- Related: https://github.com/mtibbits/volk/issues/78
- Parent epic: https://github.com/mtibbits/volk/issues/77
- Models the dispatch-table integrity check from #58 (PR #59).

## Design notes for reviewers

The harness disassembles two named symbols (prefers `llvm-objdump`, falls back
to GNU `objdump`) and compares their **whole function bodies** under a declared
criterion (`byte_identical` or `within_noise`).

**Why whole-function, not inner-loop?** An earlier design bracketed just the
inner loop with source-level asm labels. That was abandoned during
implementation: inserting a label symbol mid-function makes its address a
basic-block boundary the optimizer must respect, which perturbs the surrounding
codegen (an added `testl`, register-allocation churn — verified empirically with
both `volatile` and non-volatile asm). Instrumenting a kernel for the harness
would change the kernel that ships. Whole-function comparison needs no source
markers, leaves production codegen untouched, and is the stronger contract: a
framework instantiation that reproduces a hand-written impl produces the same
*function*, not merely the same loop.

**Wiring** mirrors the dispatch-table check: a custom target made a dependency
of the `volk` shared library, so a codegen regression breaks the build. Tuples
are declared from CMake via `ADD_CODEGEN_EQUIVALENCE_TUPLE`; with zero tuples
the check is a no-op (no false positives on a clean tree). The bootstrap tuple
compares `volk_32f_x2_add_32f_a_avx` against a same-flags reference compilation
(`cmake/codegen_bootstrap_ref.c`) as the first consumer — demonstrating the
harness on a known-equal baseline independent of any framework code.

The `within_noise` criterion normalizes operand classes (register reassignment,
immediates, and disassembler symbol annotations are tolerated; mnemonic
sequence and instruction order are not). Its operand-class table is
x86_64-validated; extending the harness to another architecture requires
extending that table (noted in the README "Limitations").

## Testing

- **`ctest`: 254/254 pass** on the changed tree (the harness adds no runtime
  kernel code; it only inspects compiled `.o`).
- **`cmake/test_check_framework_codegen.py`: 10/10 pass** — an informal standalone
  suite (not wired into ctest) covering manifest parsing, GNU-objdump continuation-line handling, whole-function
  extraction against a real-toolchain fixture, both comparison criteria, and an
  end-to-end `within_noise` test over two differently-named compilations (the
  regression guard for a branch-operand soundness bug fixed during review).
- **Bootstrap assertion passes**: `codegen-equivalence: ok (1 tuples checked)`
  (byte_identical, whole-function, `_a_avx` vs same-flags reference).
- **Deliberate-regression check**: perturbing the reference impl
  (`vaddps`→`vmulps`) makes the harness fail the build (exit 1) with a precise
  diff — `[10] bytes differ: c5 f4 58 04 02 (vaddps) vs c5 f4 59 04 02
  (vmulps)`. Reverted; not shipped.
- **Empty-manifest path**: `codegen-equivalence: ok (0 tuples declared)`,
  exit 0 — no false positives on a clean tree.
- **Build cost**: ~0.2 s per tuple (two `llvm-objdump` invocations + parse),
  well under the 1 s/tuple budget.
- **Static analysis on changed files**: `py_compile` clean, `cppcheck` clean,
  `codespell` clean (one fix: "unparseable"→"unparsable"), `clang-format`
  clean on the C file. ASan/UBSan/TSan library builds ran clean.
- **No kernel diff**: `git diff <base> -- kernels/` is empty.

## Checklist

- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest` 254/254)
- [x] Commits are signed off (`git commit -s` — DCO trailer present)
- [x] PR does one thing — no unrelated changes mixed in (kernels/ untouched;
      only the new harness files + ~65 lines of CMake wiring)
