### PR TITLE
cmake: add opt-in REQUIRE_MNEMONIC assertion to codegen-equivalence harness

### DIFF
--- a/cmake/CodegenEquivalence.cmake
+++ b/cmake/CodegenEquivalence.cmake
@@ -23,13 +23,17 @@
 set_property(GLOBAL PROPERTY CODEGEN_EQUIVALENCE_TUPLES "")
 
 function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
-    set(one_value
+    set(required_args
         KERNEL ISA ALIGNMENT CRITERION
         IMPL_A_SYMBOL IMPL_A_MACHINE_O
         IMPL_B_SYMBOL IMPL_B_MACHINE_O)
-    cmake_parse_arguments(CGE "" "${one_value}" "" ${ARGN})
+    # REQUIRE_MNEMONIC is OPTIONAL: parsed but NOT in required_args, so existing
+    # call sites without it are unaffected. When set, the harness additionally
+    # asserts the compared function contains >=1 instruction whose mnemonic
+    # matches the regex (scalar-fallback guard).
+    cmake_parse_arguments(CGE "" "${required_args};REQUIRE_MNEMONIC" "" ${ARGN})
 
-    foreach(required IN LISTS one_value)
+    foreach(required IN LISTS required_args)
         if(NOT DEFINED CGE_${required})
             message(FATAL_ERROR
                 "ADD_CODEGEN_EQUIVALENCE_TUPLE: missing required arg ${required}")
@@ -41,7 +45,14 @@ function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
             "or within_noise (got '${CGE_CRITERION}')")
     endif()
 
-    set(frag "{\"kernel\":\"${CGE_KERNEL}\",\"isa\":\"${CGE_ISA}\",\"alignment\":\"${CGE_ALIGNMENT}\",\"criterion\":\"${CGE_CRITERION}\",\"impl_a\":{\"symbol\":\"${CGE_IMPL_A_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_A_MACHINE_O}\"},\"impl_b\":{\"symbol\":\"${CGE_IMPL_B_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_B_MACHINE_O}\"}}")
+    # Emit require_mnemonic only when set, so tuples without it produce
+    # byte-identical JSON to before this change.
+    set(_extra "")
+    if(DEFINED CGE_REQUIRE_MNEMONIC)
+        set(_extra ",\"require_mnemonic\":\"${CGE_REQUIRE_MNEMONIC}\"")
+    endif()
+
+    set(frag "{\"kernel\":\"${CGE_KERNEL}\",\"isa\":\"${CGE_ISA}\",\"alignment\":\"${CGE_ALIGNMENT}\",\"criterion\":\"${CGE_CRITERION}\",\"impl_a\":{\"symbol\":\"${CGE_IMPL_A_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_A_MACHINE_O}\"},\"impl_b\":{\"symbol\":\"${CGE_IMPL_B_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_B_MACHINE_O}\"}${_extra}}")
     set_property(GLOBAL APPEND PROPERTY CODEGEN_EQUIVALENCE_TUPLES "${frag}")
 endfunction()
 

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -104,6 +104,19 @@ def parse_manifest(path: Path) -> list:
             print(f"error: unknown criterion {t['criterion']!r} (must be "
                   f"byte_identical or within_noise)", file=sys.stderr)
             sys.exit(2)
+        # Optional opt-in field: a regex the compared function must match at
+        # least one instruction mnemonic against (scalar-fallback guard).
+        if "require_mnemonic" in t:
+            if not isinstance(t["require_mnemonic"], str):
+                print(f"error: require_mnemonic must be a string regex: {t}",
+                      file=sys.stderr)
+                sys.exit(2)
+            try:
+                re.compile(t["require_mnemonic"])
+            except re.error as e:
+                print(f"error: require_mnemonic is not a valid regex "
+                      f"({t['require_mnemonic']!r}): {e}", file=sys.stderr)
+                sys.exit(2)
     return tuples
 
 
@@ -416,6 +429,21 @@ def compare_within_noise(a: list, b: list):
     return True, ""
 
 
+def check_require_mnemonic(body: list, pattern: str):
+    """Assert at least one instruction in `body` has a mnemonic matching the
+    regex `pattern`. Returns (ok, diff). Equivalence to a reference does not
+    prove an impl emits the intended ISA -- a scalar fallback could be
+    byte-identical to a scalar reference and pass; this guards against that. On
+    failure, diff names the pattern and the sorted set of mnemonics present.
+    """
+    rx = re.compile(pattern)
+    if any(rx.search(instr["mnemonic"]) for instr in body):
+        return True, ""
+    seen = sorted({instr["mnemonic"] for instr in body})
+    return False, (f"required-mnemonic assertion FAILED: no instruction "
+                   f"mnemonic matches /{pattern}/.\n  mnemonics present: {seen}")
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -481,6 +509,15 @@ def main():
             ok, diff = compare_byte_identical(a_instrs, b_instrs)
         else:
             ok, diff = compare_within_noise(a_instrs, b_instrs)
+        # Optional required-mnemonic assertion: only meaningful once the pair is
+        # otherwise equivalent. Checked against each impl independently.
+        if ok and "require_mnemonic" in t:
+            for label, instrs in (("impl_a", a_instrs), ("impl_b", b_instrs)):
+                mok, mdiff = check_require_mnemonic(instrs, t["require_mnemonic"])
+                if not mok:
+                    ok = False
+                    diff = f"[{label}] {mdiff}"
+                    break
         if not ok:
             failures.append((tuple_id(t), diff))
 

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -102,6 +102,27 @@ on.
   flag set introduces register-allocation churn without changing the
   instruction stream's shape.
 
+## Required-mnemonic assertion (scalar-fallback guard)
+
+Equivalence to a reference does not prove an impl emits the intended ISA — a
+scalar fallback could be byte-identical to a scalar reference and pass every
+criterion above. Declare an optional `REQUIRE_MNEMONIC <regex>` on a tuple to
+*additionally* assert the compared function contains at least one instruction
+whose mnemonic matches the regex, checked against **each** impl independently:
+
+```cmake
+ADD_CODEGEN_EQUIVALENCE_TUPLE(
+    ...
+    REQUIRE_MNEMONIC "^vaddps"   # the function MUST emit a packed vaddps
+)
+```
+
+The regex is matched against each instruction's mnemonic (pass if any matches).
+On failure the build halts, naming the tuple, the pattern, and the mnemonics
+actually present. The field is **opt-in**: tuples without it are unaffected and
+produce identical manifest JSON to before. Use it on framework-instantiation
+tuples to guarantee the instantiation didn't silently fall back to scalar code.
+
 ## How the check runs
 
 1. **CMake configure:** each `ADD_CODEGEN_EQUIVALENCE_TUPLE` appends a JSON

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -248,6 +248,25 @@ def test_gnu_objdump_continuation_lines():
         assert ok, f"GNU vs llvm byte streams differ after stitching:\n{diff}"
 
 
+def test_require_mnemonic_present_passes():
+    """A required-mnemonic assertion passes when the pattern is in the body."""
+    mod = _load_module()
+    body = [{"address": "10", "bytes": ["aa"], "mnemonic": "vaddps",
+             "operands": "%ymm0, %ymm1, %ymm2"}]
+    ok, diff = mod.check_require_mnemonic(body, "^vadd")
+    assert ok, diff
+
+
+def test_require_mnemonic_absent_fails():
+    """It fails (with the observed mnemonics) when the pattern is absent."""
+    mod = _load_module()
+    body = [{"address": "10", "bytes": ["aa"], "mnemonic": "addss",
+             "operands": "%xmm0, %xmm1"}]
+    ok, diff = mod.check_require_mnemonic(body, "^vadd")
+    assert not ok
+    assert "^vadd" in diff and "addss" in diff, diff
+
+
 # ---------------------------------------------------------------------------
 # Cross-compiler robustness (mtibbits/volk#145)
 # ---------------------------------------------------------------------------

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -670,6 +670,7 @@ if(_cge_bootstrap_enabled)
         IMPL_A_MACHINE_O volk_machine_${_cge_avx_machine}.c.o
         IMPL_B_SYMBOL    volk_32f_x2_add_32f_a_avx_ref
         IMPL_B_MACHINE_O codegen_bootstrap_ref.c.o
+        REQUIRE_MNEMONIC "^vaddps"
     )
 elseif(_cge_avx_machine)
     message(STATUS "codegen-equivalence: base-avx machine present but build is "


### PR DESCRIPTION
## Summary

Add an **opt-in** `REQUIRE_MNEMONIC <regex>` argument to the codegen-equivalence
harness's `ADD_CODEGEN_EQUIVALENCE_TUPLE` macro. When set, the harness — after
its existing byte-identical/within-noise comparison — *additionally* asserts the
compared function contains at least one instruction whose mnemonic matches the
regex, checked against **each** impl independently, and fails the build (naming
the tuple, the pattern, and the mnemonics seen) if absent.

**Why:** equivalence to a reference does not prove an impl emits the intended
ISA. A scalar fallback could be byte-identical to a scalar reference and pass
every existing criterion while issuing no SIMD. This is the guard that catches
that. It gives #79 (framework birth) a declarative, permanent AVX-presence check
instead of a manual `objdump | grep` step in the PR body.

The field is **opt-in and backward-compatible**: tuples without it emit
identical manifest JSON and behave exactly as before. The bootstrap tuple gains
`REQUIRE_MNEMONIC "^vaddps"` as the first live consumer. (The pushed commit message still says `"^vadd"` — the divergence is noted here rather than rewriting history; the shipped pattern is at `lib/CMakeLists.txt:673`.)

## Stacking

**This PR is stacked on #82** (the codegen-equivalence harness). It modifies that
harness, which is not on `origin/main` — so the branch is cut from #82's branch
and the PR base is that branch, keeping the diff surgical (5 files, +93/−4).
When #82 lands, this rebases onto it.

## Related issues

- Related: https://github.com/mtibbits/volk/issues/83
- Stacked on: #82 (harness, issue #78)
- Unblocks: #79's AVX-presence acceptance criterion
- Parent epic: #77

## Testing

- **Self-test suite: 12/12 pass** — adds a present-case (pattern matched →
  pass) and an absent-case (pattern missing → fail with the observed mnemonics).
- **Live assertion passes in-build**: the bootstrap tuple's `^vaddps` matches
  `vaddps` in `volk_32f_x2_add_32f_a_avx` → `codegen-equivalence: ok (1 tuples
  checked)`.
- **Negative check** (manual, not shipped): swapping the bootstrap pattern to an
  absent mnemonic makes the harness exit 1 with `required-mnemonic assertion
  FAILED … mnemonics present: [...]` — confirming it would catch a real scalar
  fallback.
- **Backward-compat**: CMake smoke-test confirms a tuple *with* the field emits
  `require_mnemonic` in the JSON and a tuple *without* it does not (identical to
  pre-change output).
- `ctest` 254/254; both build-time checks green; codespell clean; no C/C++ files
  changed (clang-format N/A).

## Checklist

- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest` 254/254; harness self-tests 12/12)
- [x] Commit is signed off (DCO trailer present)
- [x] PR does one thing — opt-in additive field, no existing-tuple behavior
      change, no kernel-source changes

