### PR TITLE
independent double-precision reference

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -685,6 +685,7 @@ if(ENABLE_TESTING)
         volk_gen_test(
             volk_test_correctness SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/test_correctness.cc
+            ${CMAKE_CURRENT_SOURCE_DIR}/volk_reference.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk_static)
     else()
         volk_gen_test(volk_test_all SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc
@@ -692,6 +693,7 @@ if(ENABLE_TESTING)
         volk_gen_test(
             volk_test_correctness SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/test_correctness.cc
+            ${CMAKE_CURRENT_SOURCE_DIR}/volk_reference.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk)
     endif()
     target_link_libraries(volk_test_all fmt::fmt)

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -9,6 +9,7 @@
  */
 
 #include "qa_utils.h"
+#include "volk_reference.h" // for the independent double-precision oracle registry (#88)
 #include <volk/volk.h>
 
 #include <volk/volk.h>        // for volk_func_desc_t
@@ -26,7 +27,8 @@
 #include <limits>   // for numeric_limits
 #include <map>      // for map, map<>::mappe...
 #include <random>
-#include <vector> // for vector, _Bit_refe...
+#include <stdexcept> // for runtime_error (#88)
+#include <vector>    // for vector, _Bit_refe...
 
 #include <fmt/format.h>
 
@@ -777,6 +779,125 @@ bool run_volk_tests(volk_func_desc_t desc,
                           test_params.complex_edge_cases());
 }
 
+// Shared setup for run_volk_tests and run_volk_reference_test (#88): build the
+// arch list, parse the kernel signature, generate ONE set of random inputs, and
+// build the per-arch buffer copies. `vlen` is the already-twiddled buffer length
+// (the caller owns the twiddle). Emits the same diagnostics and returns
+// ok=false on <2 archs (non-benchmark) or an unparseable signature. `mem_pool`
+// must outlive the returned buffers. This is pure setup (no kernel execution and
+// no comparison), so run_volk_tests' observable behaviour is unchanged.
+struct qa_test_data {
+    std::vector<std::string> arch_list;
+    std::map<std::string, size_t> arch_to_orig_idx;
+    std::vector<volk_type_t> inputsig;
+    std::vector<volk_type_t> outputsig;
+    std::vector<volk_type_t> inputsc;
+    std::vector<volk_type_t> both_sigs;
+    std::vector<void*> inbuffs;
+    std::vector<std::vector<void*>> test_data;
+    bool ok = true;
+};
+
+static qa_test_data setup_test_data(volk_func_desc_t desc,
+                                    const std::string& name,
+                                    unsigned int vlen,
+                                    bool benchmark_mode,
+                                    const std::vector<float>& float_edge_cases,
+                                    const std::vector<lv_32fc_t>& complex_edge_cases,
+                                    volk_qa_aligned_mem_pool& mem_pool)
+{
+    qa_test_data d;
+
+    // first let's get a list of available architectures for the test
+    d.arch_list = get_arch_list(desc);
+
+    // Build map from arch name to original index (for impl_alignment lookup)
+    for (size_t i = 0; i < d.arch_list.size(); i++) {
+        d.arch_to_orig_idx[d.arch_list[i]] = i;
+    }
+
+    // Reorder arch_list to put generic implementations first for consistent output
+    // Priority: "generic" first, then other generic_* variants, then everything else
+    std::vector<std::string> plain_generic;
+    std::vector<std::string> other_generic_impls;
+    std::vector<std::string> other_impls;
+    for (const auto& arch : d.arch_list) {
+        if (arch == "generic") {
+            plain_generic.push_back(arch);
+        } else if (arch.find("generic") == 0) { // starts with "generic"
+            other_generic_impls.push_back(arch);
+        } else {
+            other_impls.push_back(arch);
+        }
+    }
+    d.arch_list.clear();
+    d.arch_list.insert(d.arch_list.end(), plain_generic.begin(), plain_generic.end());
+    d.arch_list.insert(
+        d.arch_list.end(), other_generic_impls.begin(), other_generic_impls.end());
+    d.arch_list.insert(d.arch_list.end(), other_impls.begin(), other_impls.end());
+
+    if ((!benchmark_mode) && (d.arch_list.size() < 2)) {
+        std::cerr << "no architectures to test" << std::endl;
+        d.ok = false;
+        return d;
+    }
+
+    // now we have to get a function signature by parsing the name
+    try {
+        get_signatures_from_name(d.inputsig, d.outputsig, name);
+    } catch (std::exception& error) {
+        std::cerr << "Error: unable to get function signature from kernel name"
+                  << std::endl;
+        std::cerr << "  - " << name << std::endl;
+        d.ok = false;
+        return d;
+    }
+
+    // pull the input scalars into their own vector
+    for (size_t i = 0; i < d.inputsig.size(); i++) {
+        if (d.inputsig[i].is_scalar) {
+            d.inputsc.push_back(d.inputsig[i]);
+            d.inputsig.erase(d.inputsig.begin() + i);
+            i -= 1;
+        }
+    }
+    for (unsigned int inputsig_index = 0; inputsig_index < d.inputsig.size();
+         ++inputsig_index) {
+        volk_type_t sig = d.inputsig[inputsig_index];
+        if (!sig.is_scalar) // we don't make buffers for scalars
+            d.inbuffs.push_back(
+                mem_pool.get_new(vlen * sig.size * (sig.is_complex ? 2 : 1)));
+    }
+    for (size_t i = 0; i < d.inbuffs.size(); i++) {
+        load_random_data(
+            d.inbuffs[i], d.inputsig[i], vlen, float_edge_cases, complex_edge_cases);
+    }
+
+    // ok let's make a vector of vector of void buffers, which holds the input/output
+    // vectors for each arch
+    for (size_t i = 0; i < d.arch_list.size(); i++) {
+        std::vector<void*> arch_buffs;
+        for (size_t j = 0; j < d.outputsig.size(); j++) {
+            arch_buffs.push_back(mem_pool.get_new(vlen * d.outputsig[j].size *
+                                                  (d.outputsig[j].is_complex ? 2 : 1)));
+        }
+        for (size_t j = 0; j < d.inputsig.size(); j++) {
+            void* arch_inbuff = mem_pool.get_new(vlen * d.inputsig[j].size *
+                                                 (d.inputsig[j].is_complex ? 2 : 1));
+            memcpy(arch_inbuff,
+                   d.inbuffs[j],
+                   vlen * d.inputsig[j].size * (d.inputsig[j].is_complex ? 2 : 1));
+            arch_buffs.push_back(arch_inbuff);
+        }
+        d.test_data.push_back(arch_buffs);
+    }
+
+    d.both_sigs.insert(d.both_sigs.end(), d.outputsig.begin(), d.outputsig.end());
+    d.both_sigs.insert(d.both_sigs.end(), d.inputsig.begin(), d.inputsig.end());
+
+    return d;
+}
+
 bool run_volk_tests(volk_func_desc_t desc,
                     void (*manual_func)(),
                     std::string name,
@@ -808,99 +929,24 @@ bool run_volk_tests(volk_func_desc_t desc,
     const float tol_f = tol;
     const unsigned int tol_i = static_cast<unsigned int>(tol);
 
-    // first let's get a list of available architectures for the test
-    std::vector<std::string> arch_list = get_arch_list(desc);
-
-    // Build map from arch name to original index (for impl_alignment lookup)
-    std::map<std::string, size_t> arch_to_orig_idx;
-    for (size_t i = 0; i < arch_list.size(); i++) {
-        arch_to_orig_idx[arch_list[i]] = i;
-    }
-
-    // Reorder arch_list to put generic implementations first for consistent output
-    // Priority: "generic" first, then other generic_* variants, then everything else
-    std::vector<std::string> plain_generic;
-    std::vector<std::string> other_generic_impls;
-    std::vector<std::string> other_impls;
-    for (const auto& arch : arch_list) {
-        if (arch == "generic") {
-            plain_generic.push_back(arch);
-        } else if (arch.find("generic") == 0) { // starts with "generic"
-            other_generic_impls.push_back(arch);
-        } else {
-            other_impls.push_back(arch);
-        }
-    }
-    arch_list.clear();
-    arch_list.insert(arch_list.end(), plain_generic.begin(), plain_generic.end());
-    arch_list.insert(
-        arch_list.end(), other_generic_impls.begin(), other_generic_impls.end());
-    arch_list.insert(arch_list.end(), other_impls.begin(), other_impls.end());
-
-    if ((!benchmark_mode) && (arch_list.size() < 2)) {
-        std::cout << "no architectures to test" << std::endl;
-        return false;
-    }
-
     // something that can hang onto memory and cleanup when this function exits
     volk_qa_aligned_mem_pool mem_pool;
 
-    // now we have to get a function signature by parsing the name
-    std::vector<volk_type_t> inputsig, outputsig;
-    try {
-        get_signatures_from_name(inputsig, outputsig, name);
-    } catch (std::exception& error) {
-        std::cerr << "Error: unable to get function signature from kernel name"
-                  << std::endl;
-        std::cerr << "  - " << name << std::endl;
+    // Build arch list, parse the signature, generate inputs, and per-arch buffer
+    // copies (shared with run_volk_reference_test; #88). `vlen` is twiddled here.
+    qa_test_data test_setup = setup_test_data(
+        desc, name, vlen, benchmark_mode, float_edge_cases, complex_edge_cases, mem_pool);
+    if (!test_setup.ok) {
         return false;
     }
-
-    // pull the input scalars into their own vector
-    std::vector<volk_type_t> inputsc;
-    for (size_t i = 0; i < inputsig.size(); i++) {
-        if (inputsig[i].is_scalar) {
-            inputsc.push_back(inputsig[i]);
-            inputsig.erase(inputsig.begin() + i);
-            i -= 1;
-        }
-    }
-    std::vector<void*> inbuffs;
-    for (unsigned int inputsig_index = 0; inputsig_index < inputsig.size();
-         ++inputsig_index) {
-        volk_type_t sig = inputsig[inputsig_index];
-        if (!sig.is_scalar) // we don't make buffers for scalars
-            inbuffs.push_back(
-                mem_pool.get_new(vlen * sig.size * (sig.is_complex ? 2 : 1)));
-    }
-    for (size_t i = 0; i < inbuffs.size(); i++) {
-        load_random_data(
-            inbuffs[i], inputsig[i], vlen, float_edge_cases, complex_edge_cases);
-    }
-
-    // ok let's make a vector of vector of void buffers, which holds the input/output
-    // vectors for each arch
-    std::vector<std::vector<void*>> test_data;
-    for (size_t i = 0; i < arch_list.size(); i++) {
-        std::vector<void*> arch_buffs;
-        for (size_t j = 0; j < outputsig.size(); j++) {
-            arch_buffs.push_back(mem_pool.get_new(vlen * outputsig[j].size *
-                                                  (outputsig[j].is_complex ? 2 : 1)));
-        }
-        for (size_t j = 0; j < inputsig.size(); j++) {
-            void* arch_inbuff = mem_pool.get_new(vlen * inputsig[j].size *
-                                                 (inputsig[j].is_complex ? 2 : 1));
-            memcpy(arch_inbuff,
-                   inbuffs[j],
-                   vlen * inputsig[j].size * (inputsig[j].is_complex ? 2 : 1));
-            arch_buffs.push_back(arch_inbuff);
-        }
-        test_data.push_back(arch_buffs);
-    }
-
-    std::vector<volk_type_t> both_sigs;
-    both_sigs.insert(both_sigs.end(), outputsig.begin(), outputsig.end());
-    both_sigs.insert(both_sigs.end(), inputsig.begin(), inputsig.end());
+    std::vector<std::string>& arch_list = test_setup.arch_list;
+    std::map<std::string, size_t>& arch_to_orig_idx = test_setup.arch_to_orig_idx;
+    std::vector<volk_type_t>& inputsig = test_setup.inputsig;
+    std::vector<volk_type_t>& outputsig = test_setup.outputsig;
+    std::vector<volk_type_t>& inputsc = test_setup.inputsc;
+    std::vector<volk_type_t>& both_sigs = test_setup.both_sigs;
+    std::vector<void*>& inbuffs = test_setup.inbuffs;
+    std::vector<std::vector<void*>>& test_data = test_setup.test_data;
 
     // now run the test
     vlen = vlen - vlen_twiddle;
@@ -1549,5 +1595,173 @@ bool run_volk_tests(volk_func_desc_t desc,
     results->back().best_arch_a = best_arch_a;
     results->back().best_arch_u = best_arch_u;
 
+    return fail_global;
+}
+
+// #88: run every impl (generic included) and compare each against an INDEPENDENT
+// double-precision reference (the registry oracle), instead of impl-vs-generic.
+// This catches defects all impls share. run_volk_tests is untouched; default qa
+// is unaffected. Returns true if ANY impl diverges from the oracle past tol.
+// Supported signatures: 1-3 buffers with an optional real (s32f) scalar and a
+// float/complex-float output — covers the registered reference kernels.
+bool run_volk_reference_test(volk_func_desc_t desc,
+                             void (*manual_func)(),
+                             std::string name,
+                             const volk_reference_entry& ref,
+                             lv_32fc_t scalar,
+                             unsigned int vlen,
+                             std::vector<volk_test_results_t>* results,
+                             const std::vector<float>& float_edge_cases,
+                             const std::vector<lv_32fc_t>& complex_edge_cases)
+{
+    results->push_back(volk_test_results_t());
+    results->back().name = name;
+    results->back().vlen = vlen;
+    results->back().iter = 1;
+    fmt::print("\nRUN_VOLK_REFERENCE_TEST: {}(vlen={}, tol={:.0e}, {})\n",
+               name,
+               vlen,
+               ref.tol,
+               ref.absolute ? "abs" : "rel");
+
+    const unsigned int vlen_twiddle = 5;
+    const unsigned int vlen_alloc = vlen + vlen_twiddle;
+
+    volk_qa_aligned_mem_pool mem_pool;
+    // Pass benchmark_mode=true to setup_test_data ONLY to bypass its "need >=2
+    // archs" guard: reference mode compares a single impl (e.g. power_32fc's
+    // generic-only) against the oracle — that single-impl case is exactly the
+    // blind spot #88 exists to cover, so it must NOT be skipped.
+    qa_test_data d = setup_test_data(
+        desc, name, vlen_alloc, true, float_edge_cases, complex_edge_cases, mem_pool);
+    if (!d.ok) {
+        return false;
+    }
+
+    const bool s32f =
+        (d.inputsc.size() == 1) && d.inputsc[0].is_float && !d.inputsc[0].is_complex;
+    if (d.inputsc.size() != 0 && !s32f) {
+        std::cerr << "reference mode: unsupported scalar signature for " << name
+                  << std::endl;
+        return false;
+    }
+
+    // Run every impl ONCE into its own buffer set, at the user vlen.
+    for (size_t i = 0; i < d.arch_list.size(); i++) {
+        const std::string arch = d.arch_list[i];
+        switch (d.both_sigs.size()) {
+        case 1:
+            if (s32f)
+                run_cast_test1_s32f((volk_fn_1arg_s32f)(manual_func),
+                                    d.test_data[i],
+                                    scalar.real(),
+                                    vlen,
+                                    1,
+                                    arch);
+            else
+                run_cast_test1(
+                    (volk_fn_1arg)(manual_func), d.test_data[i], vlen, 1, arch);
+            break;
+        case 2:
+            if (s32f)
+                run_cast_test2_s32f((volk_fn_2arg_s32f)(manual_func),
+                                    d.test_data[i],
+                                    scalar.real(),
+                                    vlen,
+                                    1,
+                                    arch);
+            else
+                run_cast_test2(
+                    (volk_fn_2arg)(manual_func), d.test_data[i], vlen, 1, arch);
+            break;
+        case 3:
+            if (s32f)
+                run_cast_test3_s32f((volk_fn_3arg_s32f)(manual_func),
+                                    d.test_data[i],
+                                    scalar.real(),
+                                    vlen,
+                                    1,
+                                    arch);
+            else
+                run_cast_test3(
+                    (volk_fn_3arg)(manual_func), d.test_data[i], vlen, 1, arch);
+            break;
+        default:
+            std::cerr << "reference mode: unsupported arity for " << name << std::endl;
+            return false;
+        }
+    }
+
+    // Independent double-precision golden, computed from the PRISTINE inputs
+    // (d.inbuffs is the original fill; impls run on per-arch memcpy copies, so
+    // inbuffs is never mutated by a kernel).
+    std::vector<const void*> oracle_in;
+    for (size_t k = 0; k < d.inbuffs.size(); k++) {
+        oracle_in.push_back(d.inbuffs[k]);
+    }
+    std::vector<void*> oracle_out;
+    for (size_t j = 0; j < d.outputsig.size(); j++) {
+        oracle_out.push_back(mem_pool.get_new(vlen_alloc * d.outputsig[j].size *
+                                              (d.outputsig[j].is_complex ? 2 : 1)));
+    }
+    ref.fn(oracle_in, oracle_out, scalar, vlen);
+
+    // Output type is a signature property — validate once up front and fail
+    // LOUDLY (throw; the driver catches and reports a failure) on an unsupported
+    // registration, rather than silently reporting ok.
+    if (d.outputsig.empty()) {
+        throw std::runtime_error("reference mode: kernel has no output: " + name);
+    }
+    for (size_t j = 0; j < d.outputsig.size(); j++) {
+        if (!d.outputsig[j].is_float) {
+            throw std::runtime_error("reference mode: non-float output unsupported for " +
+                                     name);
+        }
+    }
+
+    // Compare EVERY impl (generic included) against the golden.
+    bool fail_global = false;
+    for (size_t i = 0; i < d.arch_list.size(); i++) {
+        bool arch_fail = false;
+        double arch_max_err = 0.0;
+        for (size_t j = 0; j < d.outputsig.size(); j++) {
+            std::vector<unsigned int> fail_indices;
+            double max_err = 0.0;
+            bool fail;
+            if (d.outputsig[j].is_complex) {
+                fail = ccompare((float*)oracle_out[j],
+                                (float*)d.test_data[i][j],
+                                vlen,
+                                ref.tol,
+                                ref.absolute,
+                                fail_indices,
+                                max_err);
+            } else {
+                fail = fcompare((float*)oracle_out[j],
+                                (float*)d.test_data[i][j],
+                                vlen,
+                                ref.tol,
+                                ref.absolute,
+                                fail_indices,
+                                max_err);
+            }
+            arch_fail = arch_fail || fail;
+            if (max_err > arch_max_err) {
+                arch_max_err = max_err;
+            }
+        }
+        volk_test_time_t result;
+        result.name = d.arch_list[i];
+        result.time = 0.0; // reference mode does not time the run; avoid an
+                           // uninitialized read when the result is consumed
+        result.units = "ref";
+        result.pass = !arch_fail;
+        results->back().results[d.arch_list[i]] = result;
+        if (arch_fail) {
+            fail_global = true;
+            std::cout << "reference mismatch on arch: " << d.arch_list[i]
+                      << " (max_err=" << arch_max_err << ")" << std::endl;
+        }
+    }
     return fail_global;
 }

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -205,6 +205,21 @@ bool run_volk_tests(
     const std::vector<float>& float_edge_cases = std::vector<float>(),
     const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
 
+// #88: compare every impl against an independent double-precision reference oracle
+// (catches defects all impls share). Defined in qa_utils.cc; oracle from the
+// volk_reference registry. Returns true if any impl diverges past the entry tol.
+struct volk_reference_entry;
+bool run_volk_reference_test(
+    volk_func_desc_t,
+    void (*)(),
+    std::string,
+    const volk_reference_entry&,
+    lv_32fc_t,
+    unsigned int,
+    std::vector<volk_test_results_t>* results = NULL,
+    const std::vector<float>& float_edge_cases = std::vector<float>(),
+    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
+
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \
                    (void (*)())func##_manual,    \

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -19,15 +19,19 @@
  * reports per kernel which vlens failed — the triage list for the per-kernel fix tickets.
  * It reuses run_volk_tests unchanged; default qa is untouched.
  *
- * The other detection capabilities are separate epic-#85 children: an independent
- * double-precision reference (#88, catches bugs all impls share, e.g. a swapped atan2),
- * output canary + ASan (#89), input-immutability (#90), and misaligned `_u` runs (#91).
- * This child catches the (large) class where impls disagree at a tail/edge boundary.
+ * Child #88 adds an INDEPENDENT double-precision reference: for kernels in the
+ * volk_reference registry, every impl (generic included) is compared against a
+ * double-precision oracle instead of impl-vs-generic, catching defects ALL impls
+ * share (e.g. the swapped atan2 in volk_32fc_s32f_power_32fc). Unregistered kernels
+ * fall back to this child's impl-vs-impl comparison; each kernel's mode (ref|impl)
+ * is reported. Output canary + ASan (#89), input-immutability (#90), and misaligned
+ * `_u` runs (#91) are the remaining epic-#85 children.
  */
 
 #include "kernel_tests.h" // for init_test_list
 #include "qa_utils.h"     // for volk_test_case_t, run_volk_tests
 #include "volk/volk_complex.h"
+#include "volk_reference.h" // for the independent double-precision oracle registry (#88)
 #include <volk/volk.h>
 
 #include <cstdio>  // fflush
@@ -73,10 +77,17 @@ static const std::vector<lv_32fc_t> kComplexEdges = {
     lv_32fc_t(6, -6), lv_32fc_t(-8, 8), lv_32fc_t(1, 0)
 };
 
-// Run run_volk_tests with its stdout (fmt::print + std::cout) muted at the fd level,
-// so the sweep emits only our per-kernel report. Returns true on FAILURE.
-static bool
-quiet_run(volk_test_case_t& tc, float tol, lv_32fc_t scalar, int iter, unsigned int v)
+// Run a single (kernel, vlen) with stdout (fmt::print + std::cout) muted at the fd
+// level, so the sweep emits only our per-kernel report. If `ref` is non-null the
+// kernel is checked against the independent double-precision oracle (#88, every impl
+// vs truth); otherwise it falls back to the impl-vs-impl comparison. Returns true on
+// FAILURE.
+static bool quiet_run(volk_test_case_t& tc,
+                      const volk_reference_entry* ref,
+                      float tol,
+                      lv_32fc_t scalar,
+                      int iter,
+                      unsigned int v)
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
@@ -93,19 +104,31 @@ quiet_run(volk_test_case_t& tc, float tol, lv_32fc_t scalar, int iter, unsigned 
     }
     bool fail = false;
     try {
-        fail = run_volk_tests(tc.desc(),
-                              tc.kernel_ptr(),
-                              tc.name(),
-                              tol,
-                              scalar,
-                              v /*vlen*/,
-                              iter,
-                              &results,
-                              tc.puppet_master_name(),
-                              false /*absolute_mode*/,
-                              false /*benchmark_mode*/,
-                              kFloatEdges,
-                              kComplexEdges);
+        if (ref) {
+            fail = run_volk_reference_test(tc.desc(),
+                                           tc.kernel_ptr(),
+                                           tc.name(),
+                                           *ref,
+                                           scalar,
+                                           v /*vlen*/,
+                                           &results,
+                                           kFloatEdges,
+                                           kComplexEdges);
+        } else {
+            fail = run_volk_tests(tc.desc(),
+                                  tc.kernel_ptr(),
+                                  tc.name(),
+                                  tol,
+                                  scalar,
+                                  v /*vlen*/,
+                                  iter,
+                                  &results,
+                                  tc.puppet_master_name(),
+                                  false /*absolute_mode*/,
+                                  false /*benchmark_mode*/,
+                                  kFloatEdges,
+                                  kComplexEdges);
+        }
     } catch (...) {
         fail = true; // an exception at this vlen is itself a defect to report
     }
@@ -148,7 +171,7 @@ int main(int argc, char* argv[])
     if (const char* rp = std::getenv("HARNESS_REPORT")) {
         report = std::fopen(rp, "w");
         if (report)
-            std::fprintf(report, "kernel,result,failed_vlens\n");
+            std::fprintf(report, "kernel,mode,result,failed_vlens\n");
         else
             std::cerr << "HARNESS_REPORT: cannot open '" << rp
                       << "' — human output only\n";
@@ -158,20 +181,36 @@ int main(int argc, char* argv[])
     std::cout.flush();
 
     int tested = 0, failed = 0;
+    // Negative-control tracking: power_seen = power_32fc was in the (filtered) sweep
+    // at all; power_ref_tested = it ran in reference mode. The two together detect a
+    // dropped/renamed registration (the likelier regression), not just a broken oracle.
+    bool power_seen = false, power_ref_tested = false;
     for (auto& tc : test_cases) {
         if (!filter.empty() && tc.name() != filter)
             continue;
         ++tested;
+        // Registered kernels run against the independent double reference (#88);
+        // the rest fall back to the impl-vs-impl comparison.
+        const volk_reference_entry* ref = volk_reference_lookup(tc.name());
+        const char* mode = ref ? "ref" : "impl";
+        // Reference mode needs the kernel's OWN scalar (e.g. power exponent 2.5, not
+        // the driver default 327 — which would overflow |x|^327 to inf and mask the
+        // defect). Impl mode keeps the driver default to preserve #87's sweep.
+        const lv_32fc_t kscalar = ref ? tc.test_parameters().scalar() : scalar;
         std::vector<unsigned int> bad;
         for (unsigned int v : vlens) {
-            if (quiet_run(tc, tol, scalar, iter, v))
+            if (quiet_run(tc, ref, tol, kscalar, iter, v))
                 bad.push_back(v);
         }
+        if (tc.name() == "volk_32fc_s32f_power_32fc") {
+            power_seen = true;
+            power_ref_tested = (ref != nullptr);
+        }
         if (bad.empty()) {
-            std::cout << "ok    " << tc.name() << "\n";
+            std::cout << "ok    [" << mode << "] " << tc.name() << "\n";
         } else {
             ++failed;
-            std::cout << "FAIL  " << tc.name() << "  vlens:";
+            std::cout << "FAIL  [" << mode << "] " << tc.name() << "  vlens:";
             for (unsigned int v : bad)
                 std::cout << " " << v;
             std::cout << "\n";
@@ -183,8 +222,9 @@ int main(int argc, char* argv[])
                 vs += ' ';
             }
             std::fprintf(report,
-                         "%s,%s,%s\n",
+                         "%s,%s,%s,%s\n",
                          tc.name().c_str(),
+                         mode,
                          bad.empty() ? "ok" : "FAIL",
                          vs.c_str());
         }
@@ -194,5 +234,22 @@ int main(int argc, char* argv[])
         std::fclose(report);
     std::cerr << "\ncorrectness remainder sweep: " << failed << " / " << tested
               << " kernels failed\n";
+
+    // #88 coverage guard: volk_32fc_s32f_power_32fc is the harness's motivating
+    // escaped defect (swapped atan2f; it has no SIMD impl, so the impl-vs-impl
+    // comparison can never see it — the double oracle is its only detector).
+    // Deliberately state-independent: whether the live kernel passes or fails
+    // reference mode is NOT asserted here — a kernel regression already fails
+    // the sweep above (exit 1), and the detector itself is proven continuously
+    // by the planted-twin combined negative control (HARNESS_COMBINED_NC).
+    // The one failure nothing else catches is the reference REGISTRATION
+    // silently disappearing (dropped/renamed) — only that is guarded.
+    if (power_seen && !power_ref_tested) {
+        std::cerr << "NEGATIVE CONTROL LOST: volk_32fc_s32f_power_32fc ran but is NOT "
+                     "reference-registered (dropped/renamed registration) — a power "
+                     "defect of the escaped swapped-atan2 class would go undetected.\n";
+        return 2;
+    }
+
     return failed > 0 ? 1 : 0;
 }

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -1,0 +1,132 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "volk_reference.h"
+
+#include <cmath>
+
+// Each oracle reads the kernel's input buffer(s) from `in`, computes the
+// kernel's mathematically-defined output in DOUBLE precision, and narrows to the
+// kernel's native float/complex output type only at the final store into `out`.
+// The double-precision intermediate is what exposes defects all impls share.
+
+// volk_32fc_s32f_power_32fc: c = a^power  (polar: |a|^power * e^{i*power*arg(a)},
+// arg(a) = atan2(imag, real)). The shipping kernel swaps the atan2 args and
+// negates the real part — this oracle implements the CORRECT definition, so the
+// generic impl diverges and reference mode fails it (the #88 negative control).
+static void ref_power_32fc(const std::vector<const void*>& in,
+                           const std::vector<void*>& out,
+                           lv_32fc_t scalar,
+                           unsigned int vlen)
+{
+    const lv_32fc_t* a = static_cast<const lv_32fc_t*>(in[0]);
+    lv_32fc_t* c = static_cast<lv_32fc_t*>(out[0]);
+    const double power = static_cast<double>(lv_creal(scalar));
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double re = static_cast<double>(lv_creal(a[i]));
+        const double im = static_cast<double>(lv_cimag(a[i]));
+        const double mag = std::pow(std::hypot(re, im), power);
+        const double ang = power * std::atan2(im, re);
+        c[i] = lv_cmake(static_cast<float>(mag * std::cos(ang)),
+                        static_cast<float>(mag * std::sin(ang)));
+    }
+}
+
+// volk_32f_tanh_32f: c = tanh(a). The generic is correct; the SIMD tail handler
+// has a stale-read bug, so reference mode fails the SIMD impls (conditionally, at
+// non-aligned vlens with a large-magnitude clamp element).
+static void ref_tanh_32f(const std::vector<const void*>& in,
+                         const std::vector<void*>& out,
+                         lv_32fc_t /*scalar*/,
+                         unsigned int vlen)
+{
+    const float* a = static_cast<const float*>(in[0]);
+    float* c = static_cast<float*>(out[0]);
+    for (unsigned int i = 0; i < vlen; i++) {
+        c[i] = static_cast<float>(std::tanh(static_cast<double>(a[i])));
+    }
+}
+
+// volk_32fc_magnitude_32f: m = sqrt(re^2 + im^2).
+static void ref_magnitude_32f(const std::vector<const void*>& in,
+                              const std::vector<void*>& out,
+                              lv_32fc_t /*scalar*/,
+                              unsigned int vlen)
+{
+    const lv_32fc_t* a = static_cast<const lv_32fc_t*>(in[0]);
+    float* m = static_cast<float*>(out[0]);
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double re = static_cast<double>(lv_creal(a[i]));
+        const double im = static_cast<double>(lv_cimag(a[i]));
+        m[i] = static_cast<float>(std::sqrt(re * re + im * im));
+    }
+}
+
+// volk_32fc_s32f_atan2_32f: o = atan2(imag, real) / normalizeFactor.
+static void ref_atan2_32f(const std::vector<const void*>& in,
+                          const std::vector<void*>& out,
+                          lv_32fc_t scalar,
+                          unsigned int vlen)
+{
+    const lv_32fc_t* a = static_cast<const lv_32fc_t*>(in[0]);
+    float* o = static_cast<float*>(out[0]);
+    const double inv = 1.0 / static_cast<double>(lv_creal(scalar));
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double re = static_cast<double>(lv_creal(a[i]));
+        const double im = static_cast<double>(lv_cimag(a[i]));
+        o[i] = static_cast<float>(std::atan2(im, re) * inv);
+    }
+}
+
+// volk_32f_log2_32f: b = log2(a) with the kernel's NON-IEEE contract
+// (0 -> -127, +Inf -> +127, negative|NaN -> NaN), mirroring volk_log2f_non_ieee.
+static void ref_log2_32f(const std::vector<const void*>& in,
+                         const std::vector<void*>& out,
+                         lv_32fc_t /*scalar*/,
+                         unsigned int vlen)
+{
+    const float* a = static_cast<const float*>(in[0]);
+    float* b = static_cast<float*>(out[0]);
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double r = std::log2(static_cast<double>(a[i]));
+        if (std::isnan(r)) {
+            b[i] = static_cast<float>(r); // negative input or NaN -> NaN
+        } else if (std::isinf(r)) {
+            b[i] =
+                std::copysign(127.0f, static_cast<float>(r)); // 0 -> -127, +Inf -> +127
+        } else {
+            b[i] = static_cast<float>(r);
+        }
+    }
+}
+
+static const std::vector<volk_reference_entry> g_registry = {
+    // name                          oracle             tol      absolute
+    { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
+    { "volk_32f_tanh_32f", ref_tanh_32f, 1e-2f, false },
+    { "volk_32fc_magnitude_32f", ref_magnitude_32f, 1e-1f, false },
+    { "volk_32fc_s32f_atan2_32f", ref_atan2_32f, 1e-5f, false },
+    // log2 abs tol = 2e-5: the SIMD log2 POLYNOMIAL diverges from true double
+    // log2 by up to ~5e-6 (measured), so default qa's 5e-6 (SIMD-vs-generic) is
+    // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
+    // envelope with margin while still catching gross defects (off by >>1e-4).
+    { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+};
+
+const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }
+
+const volk_reference_entry* volk_reference_lookup(const std::string& name)
+{
+    for (const auto& e : g_registry) {
+        if (name == e.name) {
+            return &e;
+        }
+    }
+    return nullptr;
+}

--- a/lib/volk_reference.h
+++ b/lib/volk_reference.h
@@ -1,0 +1,53 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/*
+ * Independent double-precision reference oracles for the kernel-correctness
+ * harness (#88). Each oracle computes a kernel's mathematically-defined output
+ * in double precision from the SAME input buffers the impls consumed, narrowing
+ * to the kernel's native float/complex output type only at the final store.
+ * Because it is independent of the kernel's own code, it catches defects that
+ * every impl shares (e.g. the swapped-atan2 in volk_32fc_s32f_power_32fc), which
+ * the impl-vs-impl harness cannot.
+ */
+
+#ifndef INCLUDED_VOLK_REFERENCE_H
+#define INCLUDED_VOLK_REFERENCE_H
+
+#include <volk/volk_complex.h>
+#include <string>
+#include <vector>
+
+// Computes the double-precision golden output for ONE kernel.
+//   inputs  : the kernel's input buffers (post load_random_data), in signature
+//             order, each already cast-able to the kernel's input element type.
+//   outputs : the golden output buffer(s) to fill, in signature order.
+//   scalar  : test_params.scalar() — real part carries an s32f scalar
+//             (e.g. power exponent, atan2 normalizeFactor); full value for s32fc.
+//   vlen    : the USER vlen (number of elements), not the twiddled buffer size.
+typedef void (*volk_reference_fn)(const std::vector<const void*>& inputs,
+                                  const std::vector<void*>& outputs,
+                                  lv_32fc_t scalar,
+                                  unsigned int vlen);
+
+struct volk_reference_entry {
+    const char* name;     // exact kernel name, e.g. "volk_32fc_s32f_power_32fc"
+    volk_reference_fn fn; // double-precision oracle
+    float tol;            // reference comparison tolerance
+    bool absolute;        // absolute (true) vs relative (false) comparison
+};
+
+// The opt-in registry. Sparse by design: only registered kernels use reference
+// mode; everything else falls back to impl-vs-impl. Grows over time.
+const std::vector<volk_reference_entry>& volk_reference_registry();
+
+// Returns the entry for `name`, or nullptr if the kernel is not registered.
+const volk_reference_entry* volk_reference_lookup(const std::string& name);
+
+#endif /* INCLUDED_VOLK_REFERENCE_H */


### PR DESCRIPTION
## Summary

Adds an **independent double-precision reference** to the kernel-correctness harness so it catches
defects that *all* implementations of a kernel share — which the foundation's (#87) impl-vs-impl
comparison structurally cannot. VOLK qa derives "expected" from one of the kernel's own impls (the
generic) and compares the others to it; when every impl shares a bug, they agree and qa passes.
The exemplar is `volk_32fc_s32f_power_32fc`: its `atan2f` arguments are swapped (plus a negated
cosine), so it is wrong for every non-trivial input, yet it has no SIMD impl and qa reports `ok`.

For kernels in an opt-in registry, the harness now computes the expected output from an
**independent double-precision implementation** of the kernel's mathematical definition (not the
kernel's own code) and fails any impl — generic included — that diverges past a per-kernel
tolerance. Unregistered kernels fall back to #87's impl-vs-impl comparison; each kernel's mode
(`ref`|`impl`) is reported.

## How it works (architecture)

The oracle comparison needs symbols that are file-static to `qa_utils.cc` (signature parser, arch
list, mem pool, the `fcompare`/`ccompare` comparators), so it lives there — but in a **new,
separately-named** `run_volk_reference_test()`, **not** by editing `run_volk_tests`. So
`run_volk_tests` and the default qa (`testqa.cc`) are untouched. A small `setup_test_data()` helper
(the signature parse + one random-input fill + per-arch buffer build) is shared by both functions;
`run_volk_tests`' observable behaviour is held **provably byte-identical** (see Testing). Per-kernel
oracles live in a new `lib/volk_reference.{h,cc}` registry. The driver (`test_correctness.cc`) gains
a ref/impl branch and a `mode` report column.

## Negative control (proven)

With the live swapped-`atan2` defect, `volk_32fc_s32f_power_32fc` **FAILS in reference mode** (the
double oracle computes the correct polar form `|a|^p · e^{i·p·atan2(im,re)}`), where the impl-vs-impl
harness reports `ok`. A hard assertion in the driver requires this; if power ever passes in ref mode
the harness exits non-zero ("negative control lost"). Bug-gated — when the `e29bc7f` power fix lands
on the branch, the assertion flips to expect-pass. `volk_32f_tanh_32f` is a conditional second
control (its SIMD tail stale-read fails at non-aligned vlens).

## Initial reference set (5)

`power_32fc` (1e-4 rel), `tanh` (1e-2 rel), `magnitude` (1e-1 rel — NEON/Pade are ~1% by design),
`atan2` (1e-5 rel), `log2` (**2e-5 abs** — covers the SIMD log2 polynomial's ~5e-6 envelope vs
true double, with the non-IEEE `0→-127 / +Inf→+127 / neg|NaN→NaN` contract). The registry is sparse/opt-in and grows over later PRs; coverage (ref vs impl) is
reported per kernel.

## Related issues

- Closes #88. Parent epic: #85. **Stacked on #87** (`feat/87`); `depends 88→87`. All issue numbers
  are **fork-local**; re-link before any upstream submission.
- Detects (does not fix) the swapped-atan2 (`e29bc7f`) — that's a separate per-kernel ticket.
- Out of scope (future): references for all kernels, ctest registration, the kernel fixes.

## Testing

- **`run_volk_tests` byte-identical:** default qa `ctest -R qa_` is **154/154 before == after** the
  `setup_test_data` refactor (diff empty), and **154/154 again** after adding the additive
  `run_volk_reference_test`. The refactor is pure code-motion; default qa is unaffected.
- **Negative control fires (stable on random inputs):** `volk_32fc_s32f_power_32fc` → `FAIL [ref]`
  at vlens 2-40 + both primes on **10/10** runs (the swapped-atan2 is wrong for essentially all
  inputs, so it fails robustly despite the random data); magnitude/atan2/log2 `ok [ref]` and tanh conditional
  `FAIL [ref]` are stable over 10-20 runs each (log2's tol was widened to 2e-5 to cover the SIMD
  log2 polynomial's ~5e-6 envelope vs true double — see below). Unregistered kernels `[impl]`; CSV
  is the 4-column `kernel,mode,result,failed_vlens`.
- **Sanitizers:** ASan/UBSan/TSan each run the full default suite at **254/254, 0 failures**, which
  exercises the `setup_test_data` refactor via `run_volk_tests`. The default ctest set does NOT
  include `volk_test_correctness`, so the new `run_volk_reference_test` + 5 oracles were
  *additionally* run under **ASan** directly (the 5 registered kernels through
  `build-asan/.../volk_test_correctness`): **0 AddressSanitizer errors** — the new path is
  memory-clean.
- Builds clean (`volk_test_all`, `volk_test_correctness`), no compiler warnings, clang-formatted.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (default qa 154/154 unchanged; ASan/UBSan/TSan 254/254; negative control fires)
- [x] Commits are signed off (`git commit -s` — DCO)
- [x] PR does one thing — the independent reference layer (no kernel source/signature/ABI change)


## Update 2026-06-09

- Amended in place (`c2351af` → `bfbea5f`): `run_volk_reference_test` now initializes
  `volk_test_time_t::time`/`units` before copying the struct into the results map
  (cppcheck error-level uninitvar; same populate-every-field pattern #89 uses).
- Base re-targeted `main` → `feat/87` so this diff shows only #88's delta (matches the
  stacked layout of #95/#97).
