### PR TITLE
output canary and asan

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -686,6 +686,7 @@ if(ENABLE_TESTING)
             volk_test_correctness SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/test_correctness.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_reference.cc
+            ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk_static)
     else()
         volk_gen_test(volk_test_all SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc
@@ -694,6 +695,7 @@ if(ENABLE_TESTING)
             volk_test_correctness SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/test_correctness.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_reference.cc
+            ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk)
     endif()
     target_link_libraries(volk_test_all fmt::fmt)

--- a/lib/qa_canary_kernel.cc
+++ b/lib/qa_canary_kernel.cc
@@ -1,0 +1,83 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "qa_canary_kernel.h"
+
+// Each planted impl first copies the in-bounds region [0,num_points) correctly,
+// so the only thing distinguishing the negative controls is the write past the
+// end -- the canary's guard/two-sentinel check is what flags it. `arch` is
+// ignored: every planted kernel has a single "generic" impl.
+
+void volk_32f_canaryok_32f(void* out, void* in, unsigned int num_points, const char*)
+{
+    float* o = static_cast<float*>(out);
+    const float* i = static_cast<const float*>(in);
+    for (unsigned int n = 0; n < num_points; ++n) {
+        o[n] = i[n];
+    }
+}
+
+void volk_32f_canaryonepast_32f(void* out, void* in, unsigned int num_points, const char*)
+{
+    float* o = static_cast<float*>(out);
+    const float* i = static_cast<const float*>(in);
+    for (unsigned int n = 0; n < num_points; ++n) {
+        o[n] = i[n];
+    }
+    // The planted defect: one element past the end. In the canary's guarded
+    // buffer this lands in the trailing sentinel guard (in-allocation) and is
+    // caught by the post-run guard check.
+    o[num_points] = 1.0f;
+}
+
+void volk_32f_canaryunwritten_32f(void* out,
+                                  void* in,
+                                  unsigned int num_points,
+                                  const char*)
+{
+    float* o = static_cast<float*>(out);
+    const float* i = static_cast<const float*>(in);
+    // The planted defect: leave the LAST in-bounds element unwritten. `n + 1 <
+    // num_points` keeps this safe at num_points == 0 (writes nothing). The gap
+    // is invisible to value comparison but caught by the two-sentinel check.
+    for (unsigned int n = 0; n + 1 < num_points; ++n) {
+        o[n] = i[n];
+    }
+}
+
+void volk_32f_canaryfarpast_32f(void* out, void* in, unsigned int num_points, const char*)
+{
+    float* o = static_cast<float*>(out);
+    const float* i = static_cast<const float*>(in);
+    for (unsigned int n = 0; n < num_points; ++n) {
+        o[n] = i[n];
+    }
+    // Contiguous over-write stepping past the whole guarded allocation into the
+    // ASan redzone. Writing every element (rather than a single far store)
+    // guarantees the first store that crosses the allocation boundary trips
+    // ASan regardless of the exact redzone size. UNDEFINED BEHAVIOUR without
+    // ASan -- only invoked under the HARNESS_CANARY_ASAN_DEMO path.
+    for (unsigned int k = 0; k <= VOLK_CANARY_FAR_PAST_ELEMENTS; ++k) {
+        o[num_points + k] = 1.0f;
+    }
+}
+
+volk_func_desc_t volk_canary_desc()
+{
+    static const char* impl_names[] = { "generic" };
+    static const int impl_deps[] = { 0 };
+    static const bool impl_alignment[] = { false };
+
+    volk_func_desc_t desc;
+    desc.impl_names = impl_names;
+    desc.impl_deps = impl_deps;
+    desc.impl_alignment = impl_alignment;
+    desc.n_impls = 1;
+    return desc;
+}

--- a/lib/qa_canary_kernel.h
+++ b/lib/qa_canary_kernel.h
@@ -1,0 +1,84 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/*
+ * Test-only planted "kernels" for the output-canary negative control (#89,
+ * child of epic #85). These are NEVER registered in the production kernel
+ * list (init_test_list) and never run by the default qa suite; they exist
+ * solely to exercise run_volk_canary_test's over-run detection.
+ *
+ * Each has a 1-float-in / 1-float-out map signature (matching the volk_fn_2arg
+ * call shape the qa harness uses: out=buffs[0], in=buffs[1]) and deliberately
+ * differs only in how it treats the region past num_points:
+ *
+ *   volk_32f_canaryok_32f       writes exactly [0,num_points) -> MUST PASS the
+ *                               canary (proves it does not over-report).
+ *   volk_32f_canaryonepast_32f  writes [0,num_points) then out[num_points]
+ *                               (one element past) -> MUST trip the GUARD check
+ *                               (over-run) in ANY build. The write lands in the
+ *                               trailing sentinel guard (still inside the
+ *                               own-malloc'd allocation), so it is SAFE in a
+ *                               non-ASan build and is best-effort under ASan
+ *                               (in-allocation, so ASan does not trip on it --
+ *                               the canary is authoritative).
+ *   volk_32f_canaryunwritten_32f writes only [0,num_points-1), leaving the last
+ *                               in-bounds element untouched -> MUST trip the
+ *                               UNWRITTEN check (the in-bounds gap detector that
+ *                               ASan cannot provide). Proves that detector works
+ *                               on a genuine map kernel.
+ *   volk_32f_canaryfarpast_32f  writes [0,num_points) then a contiguous run
+ *                               out[num_points .. num_points+K) far enough to
+ *                               step past the whole guarded allocation into the
+ *                               ASan redzone -> heap-buffer-overflow. This is
+ *                               UNDEFINED BEHAVIOUR in a non-ASan build, so it
+ *                               is run ONLY under the ASan demo path
+ *                               (HARNESS_CANARY_ASAN_DEMO); it demonstrates that
+ *                               the guarded path's own-malloc buffers are
+ *                               bracketed by ASan redzones (acceptance #89-2).
+ */
+
+#ifndef INCLUDED_VOLK_QA_CANARY_KERNEL_H
+#define INCLUDED_VOLK_QA_CANARY_KERNEL_H
+
+#include <volk/volk.h> // for volk_func_desc_t
+
+// Number of elements the far-past planted kernel writes beyond num_points. Must
+// exceed the canary's maximum trailing-guard span (guard_bytes + alignment =
+// 2*alignment + 64 bytes; <= 192 B at VOLK's widest alignment of 64) so the
+// contiguous over-write steps out of the allocation into the ASan redzone. 64
+// floats = 260 B clears that today; if a future wider-alignment arch broke this,
+// the ASan demo would NOT abort and the driver's explicit "ASan did not abort"
+// WARNING + exit 2 surfaces it (it fails loud, never silently).
+#define VOLK_CANARY_FAR_PAST_ELEMENTS 64u
+
+// Map-signature planted impls: void(out, in, num_points, arch). Called through
+// the volk_fn_2arg cast in run_volk_canary_test.
+void volk_32f_canaryok_32f(void* out,
+                           void* in,
+                           unsigned int num_points,
+                           const char* arch);
+void volk_32f_canaryonepast_32f(void* out,
+                                void* in,
+                                unsigned int num_points,
+                                const char* arch);
+void volk_32f_canaryunwritten_32f(void* out,
+                                  void* in,
+                                  unsigned int num_points,
+                                  const char* arch);
+void volk_32f_canaryfarpast_32f(void* out,
+                                void* in,
+                                unsigned int num_points,
+                                const char* arch);
+
+// A synthetic single-impl ("generic") descriptor so the planted kernels flow
+// through the SAME run_volk_canary_test path as real kernels. impl_alignment is
+// false (unaligned): the canary supplies an aligned data region regardless.
+volk_func_desc_t volk_canary_desc();
+
+#endif /* INCLUDED_VOLK_QA_CANARY_KERNEL_H */

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -21,11 +21,14 @@
 #include <sys/types.h> // for int16_t, int32_t
 #include <chrono>
 #include <cmath>    // for sqrt, fabs, abs
+#include <cstdint>  // for uint8_t, uintptr_t (#89 canary)
+#include <cstdlib>  // for malloc, free (#89 canary)
 #include <cstring>  // for memcpy, memset
 #include <ctime>    // for clock
 #include <iostream> // for cerr
 #include <limits>   // for numeric_limits
 #include <map>      // for map, map<>::mappe...
+#include <memory>   // for unique_ptr (#89 canary)
 #include <random>
 #include <stdexcept> // for runtime_error (#88)
 #include <vector>    // for vector, _Bit_refe...
@@ -1764,4 +1767,304 @@ bool run_volk_reference_test(volk_func_desc_t desc,
         }
     }
     return fail_global;
+}
+
+// #89: a single output buffer bracketed by sentinel guard regions, allocated in
+// its OWN malloc (NOT the qa mem pool). The data region is EXACTLY data_bytes
+// long -- no twiddle slack -- so an over-run cannot hide in allocator padding;
+// it lands in the trailing guard (caught here) or, far enough past, in the ASan
+// redzone of this allocation. The data start is aligned to volk_get_alignment()
+// so `a_*` (aligned) impls stay valid; the leading guard is the bytes between the
+// malloc base and that aligned start (the alignment slack is absorbed there, so
+// the trailing guard is a known minimum width).
+//
+//   [ leading guard >= guard_bytes | data_bytes (aligned) | trailing guard ]
+//
+namespace {
+class guarded_output_buffer
+{
+public:
+    guarded_output_buffer(size_t data_bytes, size_t alignment, size_t guard_bytes)
+        : data_bytes_(data_bytes)
+    {
+        // Over-allocate: leading guard + alignment slack + data + trailing guard.
+        // align_up of (base + guard_bytes) consumes at most (alignment - 1) bytes,
+        // so the leading guard is >= guard_bytes and the trailing guard >= guard_bytes.
+        total_ = guard_bytes + alignment + data_bytes + guard_bytes;
+        base_ = static_cast<uint8_t*>(std::malloc(total_));
+        if (base_ == nullptr) {
+            throw std::runtime_error("canary: guarded buffer malloc failed");
+        }
+        uintptr_t raw = reinterpret_cast<uintptr_t>(base_) + guard_bytes;
+        uintptr_t aligned =
+            (raw + (alignment - 1)) & ~static_cast<uintptr_t>(alignment - 1);
+        data_ = reinterpret_cast<uint8_t*>(aligned);
+        assert(data_ >= base_ + guard_bytes);
+        assert(data_ + data_bytes_ + guard_bytes <= base_ + total_);
+    }
+    ~guarded_output_buffer() { std::free(base_); }
+    guarded_output_buffer(const guarded_output_buffer&) = delete;
+    guarded_output_buffer& operator=(const guarded_output_buffer&) = delete;
+
+    void* data() const { return data_; }
+    size_t data_bytes() const { return data_bytes_; }
+
+    // Fill the WHOLE allocation (both guards + data) with one sentinel byte.
+    void fill(uint8_t sentinel) { std::memset(base_, sentinel, total_); }
+
+    // True if any guard byte differs from `sentinel` (an over/under-write).
+    // `byte_off` is set to the offset relative to the data start: negative means
+    // a write before index 0 (leading guard), >= data_bytes() means a write past
+    // the end (trailing guard).
+    bool guard_violation(uint8_t sentinel, ptrdiff_t& byte_off) const
+    {
+        for (uint8_t* p = base_; p < data_; ++p) {
+            if (*p != sentinel) {
+                byte_off = p - data_;
+                return true;
+            }
+        }
+        uint8_t* tail_start = data_ + data_bytes_;
+        const uint8_t* tail_end = base_ + total_;
+        for (uint8_t* p = tail_start; p < tail_end; ++p) {
+            if (*p != sentinel) {
+                byte_off = p - data_;
+                return true;
+            }
+        }
+        return false;
+    }
+
+private:
+    uint8_t* base_;
+    uint8_t* data_;
+    size_t total_;
+    size_t data_bytes_;
+};
+} // namespace
+
+// #89: see the declaration in qa_utils.h. Runs every impl through its own
+// guarded output buffers with the two-sentinel protocol and reports per-impl
+// pass/fail into `results`. Supports the buffer signatures the qa harness can
+// drive (1-4 buffers, with an optional real s32f or complex s32fc scalar);
+// other shapes are skipped (reported as no failure) since the canary can only
+// guard what it can call.
+volk_canary_summary run_volk_canary_test(volk_func_desc_t desc,
+                                         void (*manual_func)(),
+                                         std::string name,
+                                         lv_32fc_t scalar,
+                                         unsigned int vlen,
+                                         std::vector<volk_test_results_t>* results,
+                                         const std::vector<float>& float_edge_cases,
+                                         const std::vector<lv_32fc_t>& complex_edge_cases)
+{
+    volk_canary_summary summary;
+
+    results->push_back(volk_test_results_t());
+    results->back().name = name;
+    results->back().vlen = vlen;
+    results->back().iter = 2; // two runs per impl (S1 then S2)
+    results->back().config_name = name;
+    fmt::print("\nRUN_VOLK_CANARY_TEST: {}(vlen={})\n", name, vlen);
+
+    volk_qa_aligned_mem_pool mem_pool;
+    // Inputs are sized exactly `vlen` (no twiddle) and drawn from the pool; the
+    // canary only guards the OUTPUT write side (input immutability / over-read is
+    // #90, best-effort via ASan). benchmark_mode=true bypasses the ">=2 arch"
+    // guard so single-impl kernels are still checked.
+    qa_test_data d = setup_test_data(
+        desc, name, vlen, true, float_edge_cases, complex_edge_cases, mem_pool);
+    if (!d.ok) {
+        return summary;
+    }
+
+    const bool s32f =
+        (d.inputsc.size() == 1) && d.inputsc[0].is_float && !d.inputsc[0].is_complex;
+    const bool s32fc =
+        (d.inputsc.size() == 1) && d.inputsc[0].is_float && d.inputsc[0].is_complex;
+    // These "cannot guard this kernel" cases leave summary.applied == false so the
+    // driver reports the kernel as skipped (NOT ok). Diagnostics go to stdout so the
+    // driver's per-(kernel,vlen) stdout muting suppresses them during the sweep,
+    // consistent with how the guard/unwritten messages below are emitted.
+    if (d.inputsc.size() != 0 && !s32f && !s32fc) {
+        std::cout << "canary mode: unsupported scalar signature for " << name
+                  << std::endl;
+        return summary;
+    }
+    if (d.outputsig.empty()) {
+        std::cout << "canary mode: kernel has no output buffer to guard: " << name
+                  << std::endl;
+        return summary;
+    }
+    if (d.both_sigs.size() > 4 || (d.both_sigs.size() == 4 && d.inputsc.size() != 0)) {
+        std::cout << "canary mode: unsupported arity for " << name << std::endl;
+        return summary;
+    }
+
+    const size_t alignment = volk_get_alignment();
+    // Guard wide enough that a one-past write of any element type lands inside the
+    // trailing guard (>= alignment + a few elements).
+    const size_t guard_bytes = alignment + 64;
+
+    const uint8_t S1 = 0xA5;
+    const uint8_t S2 = 0x3C;
+
+    for (size_t i = 0; i < d.arch_list.size(); i++) {
+        const std::string arch = d.arch_list[i];
+        summary.applied = true; // we are about to guard-check at least one impl
+
+        // One guarded own-malloc buffer per output; inputs stay in the pool.
+        std::vector<std::unique_ptr<guarded_output_buffer>> gbufs;
+        gbufs.reserve(d.outputsig.size());
+        for (size_t j = 0; j < d.outputsig.size(); j++) {
+            const size_t out_bytes = static_cast<size_t>(vlen) * d.outputsig[j].size *
+                                     (d.outputsig[j].is_complex ? 2 : 1);
+            gbufs.push_back(std::make_unique<guarded_output_buffer>(
+                out_bytes, alignment, guard_bytes));
+        }
+
+        // buffs layout matches setup_test_data: outputs first, then inputs.
+        auto build_buffs = [&]() {
+            std::vector<void*> buffs;
+            for (size_t j = 0; j < d.outputsig.size(); j++) {
+                buffs.push_back(gbufs[j]->data());
+            }
+            for (size_t k = 0; k < d.inputsig.size(); k++) {
+                buffs.push_back(d.test_data[i][d.outputsig.size() + k]);
+            }
+            return buffs;
+        };
+        auto reload_inputs = [&]() {
+            for (size_t k = 0; k < d.inputsig.size(); k++) {
+                const size_t in_bytes = static_cast<size_t>(vlen) * d.inputsig[k].size *
+                                        (d.inputsig[k].is_complex ? 2 : 1);
+                memcpy(d.test_data[i][d.outputsig.size() + k], d.inbuffs[k], in_bytes);
+            }
+        };
+        auto run_once = [&](std::vector<void*>& buffs) {
+            switch (d.both_sigs.size()) {
+            case 1:
+                if (s32fc)
+                    run_cast_test1_s32fc(
+                        (volk_fn_1arg_s32fc)(manual_func), buffs, scalar, vlen, 1, arch);
+                else if (s32f)
+                    run_cast_test1_s32f((volk_fn_1arg_s32f)(manual_func),
+                                        buffs,
+                                        scalar.real(),
+                                        vlen,
+                                        1,
+                                        arch);
+                else
+                    run_cast_test1((volk_fn_1arg)(manual_func), buffs, vlen, 1, arch);
+                break;
+            case 2:
+                if (s32fc)
+                    run_cast_test2_s32fc(
+                        (volk_fn_2arg_s32fc)(manual_func), buffs, scalar, vlen, 1, arch);
+                else if (s32f)
+                    run_cast_test2_s32f((volk_fn_2arg_s32f)(manual_func),
+                                        buffs,
+                                        scalar.real(),
+                                        vlen,
+                                        1,
+                                        arch);
+                else
+                    run_cast_test2((volk_fn_2arg)(manual_func), buffs, vlen, 1, arch);
+                break;
+            case 3:
+                if (s32fc)
+                    run_cast_test3_s32fc(
+                        (volk_fn_3arg_s32fc)(manual_func), buffs, scalar, vlen, 1, arch);
+                else if (s32f)
+                    run_cast_test3_s32f((volk_fn_3arg_s32f)(manual_func),
+                                        buffs,
+                                        scalar.real(),
+                                        vlen,
+                                        1,
+                                        arch);
+                else
+                    run_cast_test3((volk_fn_3arg)(manual_func), buffs, vlen, 1, arch);
+                break;
+            case 4:
+                run_cast_test4((volk_fn_4arg)(manual_func), buffs, vlen, 1, arch);
+                break;
+            default:
+                break;
+            }
+        };
+
+        bool arch_guard = false;
+        bool arch_unwritten = false;
+
+        // ---- Run 1: prefill the whole guarded buffer with sentinel S1 ----
+        for (auto& g : gbufs) {
+            g->fill(S1);
+        }
+        reload_inputs();
+        {
+            std::vector<void*> buffs = build_buffs();
+            run_once(buffs);
+        }
+        // Snapshot the data region after run 1 (before S2 overwrites it) and check
+        // the guards for an over/under-write. Guard violations go to std::cerr (NOT
+        // std::cout) so they survive the sweep's per-(kernel,vlen) stdout muting: a
+        // touched guard is ALWAYS a real defect (unlike the unwritten check below,
+        // which reduction kernels trip expectedly), so its arch/offset detail must
+        // stay visible and actionable on the one run where it fires.
+        std::vector<std::vector<uint8_t>> snap_s1(d.outputsig.size());
+        for (size_t j = 0; j < gbufs.size(); j++) {
+            ptrdiff_t off = 0;
+            if (gbufs[j]->guard_violation(S1, off)) {
+                arch_guard = true;
+                std::cerr << name << ": canary guard touched on arch " << arch
+                          << " (output " << j << ", byte offset " << off
+                          << " relative to data start)\n";
+            }
+            const uint8_t* p = static_cast<const uint8_t*>(gbufs[j]->data());
+            snap_s1[j].assign(p, p + gbufs[j]->data_bytes());
+        }
+
+        // ---- Run 2: prefill with the distinct sentinel S2 ----
+        for (auto& g : gbufs) {
+            g->fill(S2);
+        }
+        reload_inputs();
+        {
+            std::vector<void*> buffs = build_buffs();
+            run_once(buffs);
+        }
+        for (size_t j = 0; j < gbufs.size(); j++) {
+            ptrdiff_t off = 0;
+            if (gbufs[j]->guard_violation(S2, off)) {
+                arch_guard = true;
+                std::cerr << name << ": canary guard touched on arch " << arch
+                          << " (output " << j << ", byte offset " << off
+                          << " relative to data start)\n";
+            }
+            // In-bounds-unwritten check: a byte the kernel wrote holds the same
+            // (deterministic) value in both runs, so it cannot equal S1 after run 1
+            // AND S2 after run 2. A byte that still equals both sentinels was never
+            // written -- an in-bounds element left untouched (which ASan cannot see).
+            const uint8_t* d2 = static_cast<const uint8_t*>(gbufs[j]->data());
+            for (size_t b = 0; b < gbufs[j]->data_bytes(); b++) {
+                if (snap_s1[j][b] == S1 && d2[b] == S2) {
+                    arch_unwritten = true;
+                    std::cout << name << ": canary found unwritten output byte on arch "
+                              << arch << " (output " << j << ", byte offset " << b << ")"
+                              << std::endl;
+                    break;
+                }
+            }
+        }
+
+        volk_test_time_t result;
+        result.name = arch;
+        result.time = 0.0; // canary does not time the run; avoid an uninitialized read
+        result.units = "canary"; // populate every field, even though unread on this path
+        result.pass = !(arch_guard || arch_unwritten);
+        results->back().results[arch] = result;
+        summary.guard_violation = summary.guard_violation || arch_guard;
+        summary.unwritten = summary.unwritten || arch_unwritten;
+    }
+    return summary;
 }

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -220,6 +220,39 @@ bool run_volk_reference_test(
     const std::vector<float>& float_edge_cases = std::vector<float>(),
     const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
 
+// #89: outcome of run_volk_canary_test, split so the driver can treat the two
+// defect classes differently. A guard violation (a write past the end or before
+// index 0 of a buffer) is always a defect, for any kernel. An unwritten in-bounds
+// element is a defect for a MAP kernel, but expected for a reduction/index kernel
+// whose output is a fixed-size scalar rather than num_points elements -- which the
+// signature alone cannot distinguish -- so the driver surfaces it for triage
+// rather than hard-failing.
+struct volk_canary_summary {
+    bool guard_violation = false; // over/under-write past a buffer (always a defect)
+    bool unwritten = false;       // an in-bounds output element never written
+    bool applied = false;         // false => the canary could not guard this kernel
+                                  // (no output buffer / unsupported signature): the
+                                  // driver reports such kernels as skipped, not ok
+};
+
+// #89: output-buffer canary. Allocates each output buffer with leading/trailing
+// sentinel guard regions in its OWN malloc (bypassing the qa mem pool, so the
+// data region is exactly num_points elements with no slack to hide an over-run,
+// and so ASan redzones bracket it). For every impl, runs twice with two distinct
+// sentinels: a touched guard flags an over/under-write; an in-bounds byte left at
+// both sentinels across the two runs flags a never-written element. This canary is
+// allocator-independent and authoritative; ASan is best-effort double coverage.
+// Toggle is in the driver; run_volk_tests/default qa are untouched.
+volk_canary_summary run_volk_canary_test(
+    volk_func_desc_t,
+    void (*)(),
+    std::string,
+    lv_32fc_t,
+    unsigned int,
+    std::vector<volk_test_results_t>* results = NULL,
+    const std::vector<float>& float_edge_cases = std::vector<float>(),
+    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
+
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \
                    (void (*)())func##_manual,    \

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -28,8 +28,9 @@
  * `_u` runs (#91) are the remaining epic-#85 children.
  */
 
-#include "kernel_tests.h" // for init_test_list
-#include "qa_utils.h"     // for volk_test_case_t, run_volk_tests
+#include "kernel_tests.h"     // for init_test_list
+#include "qa_canary_kernel.h" // for the planted output-canary negative controls (#89)
+#include "qa_utils.h"         // for volk_test_case_t, run_volk_tests
 #include "volk/volk_complex.h"
 #include "volk_reference.h" // for the independent double-precision oracle registry (#88)
 #include <volk/volk.h>
@@ -64,6 +65,20 @@
 #include <fcntl.h>  // open, O_WRONLY
 #include <unistd.h> // dup, dup2, close, STDOUT_FILENO
 #define VOLK_DEVNULL "/dev/null"
+#endif
+
+// Compile-time AddressSanitizer detection: the far-past ASan demo deliberately
+// writes past the guarded allocation, which is undefined behaviour unless ASan
+// is bracketing it, so it must only run in an ASan build.
+#if defined(__SANITIZE_ADDRESS__)
+#define VOLK_BUILT_WITH_ASAN 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define VOLK_BUILT_WITH_ASAN 1
+#endif
+#endif
+#ifndef VOLK_BUILT_WITH_ASAN
+#define VOLK_BUILT_WITH_ASAN 0
 #endif
 
 // Adversarial edge values mixed into the random test data, so impls are exercised at
@@ -146,6 +161,50 @@ static bool quiet_run(volk_test_case_t& tc,
     return fail;
 }
 
+// #89: run the output-buffer canary for one (kernel, vlen) with stdout muted
+// (mirrors quiet_run). Returns the split summary so the driver can treat a buffer
+// over/under-write (always a defect) differently from an in-bounds unwritten
+// element (expected for reduction/index kernels). On an exception, the guarded
+// path could not complete -- reported as a guard violation to surface it.
+static volk_canary_summary quiet_canary_run(volk_test_case_t& tc, unsigned int v)
+{
+    std::vector<volk_test_results_t> results;
+    const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
+    std::fflush(stdout);
+    std::cout.flush();
+    int saved = -1, devnull = -1;
+    if (!verbose) {
+        saved = dup(STDOUT_FILENO);
+        devnull = open(VOLK_DEVNULL, O_WRONLY);
+        if (saved >= 0 && devnull >= 0)
+            dup2(devnull, STDOUT_FILENO);
+    }
+    volk_canary_summary summary;
+    try {
+        summary = run_volk_canary_test(tc.desc(),
+                                       tc.kernel_ptr(),
+                                       tc.name(),
+                                       tc.test_parameters().scalar(),
+                                       v /*vlen*/,
+                                       &results,
+                                       kFloatEdges,
+                                       kComplexEdges);
+    } catch (...) {
+        summary.guard_violation = true;
+    }
+    std::fflush(stdout);
+    std::cout.flush();
+    if (!verbose) {
+        if (saved >= 0) {
+            dup2(saved, STDOUT_FILENO);
+            close(saved);
+        }
+        if (devnull >= 0)
+            close(devnull);
+    }
+    return summary;
+}
+
 int main(int argc, char* argv[])
 {
     const float tol = 1e-6f;
@@ -175,6 +234,195 @@ int main(int argc, char* argv[])
         else
             std::cerr << "HARNESS_REPORT: cannot open '" << rp
                       << "' — human output only\n";
+    }
+
+    // #89 output-buffer canary mode (opt-in via HARNESS_CANARY). This is a
+    // distinct mode: it replaces the impl-vs-impl / reference sweep with the
+    // guarded-buffer over/under-write + unwritten check. The default qa suite
+    // and the toggle-off correctness sweep are entirely unaffected.
+    const bool canary_mode = (std::getenv("HARNESS_CANARY") != nullptr);
+    if (canary_mode) {
+        // The far-past ASan demonstration: deliberately over-run the guarded
+        // own-malloc'd buffer far enough to hit the ASan redzone, proving the
+        // guarded path's buffers are ASan-bracketed (acceptance #89-2). This is
+        // undefined behaviour without ASan, so it is gated to ASan builds.
+        if (std::getenv("HARNESS_CANARY_ASAN_DEMO") != nullptr) {
+            if (report)
+                std::fclose(report);
+#if VOLK_BUILT_WITH_ASAN
+            std::cerr << "HARNESS_CANARY_ASAN_DEMO: over-running the guarded buffer "
+                         "via volk_32f_canaryfarpast_32f; expect an ASan "
+                         "heap-buffer-overflow abort.\n";
+            std::vector<volk_test_results_t> demo;
+            run_volk_canary_test(volk_canary_desc(),
+                                 (void (*)())(&volk_32f_canaryfarpast_32f),
+                                 "volk_32f_canaryfarpast_32f",
+                                 scalar,
+                                 127u,
+                                 &demo,
+                                 kFloatEdges,
+                                 kComplexEdges);
+            std::cerr << "WARNING: ASan did not abort on the far-past over-run.\n";
+            return 2;
+#else
+            std::cerr << "HARNESS_CANARY_ASAN_DEMO requested but this binary was NOT "
+                         "built with AddressSanitizer; refusing to run the far-past "
+                         "planted kernel (undefined behaviour without ASan). Rebuild "
+                         "under build-asan/.\n";
+            return 2;
+#endif
+        }
+
+        // Hard negative control (any build), exercising the SAME run_volk_canary_test
+        // path real kernels use. Three planted kernels prove BOTH detectors:
+        //   ok        -> no violation             (canary does not over-report)
+        //   one-past  -> GUARD violation          (the over-run detector)
+        //   unwritten -> UNWRITTEN finding         (the in-bounds-gap detector)
+        // Any deviation means the canary is broken — fail hard (exit 2), per #88.
+        const unsigned int nc_vlen = 127;
+        std::vector<volk_test_results_t> nc;
+        const volk_canary_summary ok_sum =
+            run_volk_canary_test(volk_canary_desc(),
+                                 (void (*)())(&volk_32f_canaryok_32f),
+                                 "volk_32f_canaryok_32f",
+                                 scalar,
+                                 nc_vlen,
+                                 &nc,
+                                 kFloatEdges,
+                                 kComplexEdges);
+        nc.clear();
+        const volk_canary_summary one_past_sum =
+            run_volk_canary_test(volk_canary_desc(),
+                                 (void (*)())(&volk_32f_canaryonepast_32f),
+                                 "volk_32f_canaryonepast_32f",
+                                 scalar,
+                                 nc_vlen,
+                                 &nc,
+                                 kFloatEdges,
+                                 kComplexEdges);
+        nc.clear();
+        const volk_canary_summary unwritten_sum =
+            run_volk_canary_test(volk_canary_desc(),
+                                 (void (*)())(&volk_32f_canaryunwritten_32f),
+                                 "volk_32f_canaryunwritten_32f",
+                                 scalar,
+                                 nc_vlen,
+                                 &nc,
+                                 kFloatEdges,
+                                 kComplexEdges);
+        nc.clear();
+        const char* nc_err = nullptr;
+        if (ok_sum.guard_violation || ok_sum.unwritten) {
+            nc_err = "the correct planted kernel volk_32f_canaryok_32f was flagged — "
+                     "the canary over-reports";
+        } else if (!one_past_sum.guard_violation) {
+            nc_err = "the planted one-past kernel volk_32f_canaryonepast_32f did not "
+                     "trip the guard — the canary is blind to output over-runs";
+        } else if (!unwritten_sum.unwritten) {
+            nc_err = "the planted kernel volk_32f_canaryunwritten_32f did not trip the "
+                     "unwritten check — the canary is blind to in-bounds gaps";
+        }
+        if (nc_err) {
+            std::cerr << "NEGATIVE CONTROL LOST: " << nc_err << ". Aborting.\n";
+            if (report)
+                std::fclose(report);
+            return 2;
+        }
+        std::cerr << "canary negative control OK: ok-kernel clean, one-past trips the "
+                     "guard, unwritten-kernel trips the unwritten check.\n";
+
+        // Best-effort per-kernel canary sweep over the real kernels.
+        //   FAIL    -> a GUARD violation (write past the end / before index 0): a
+        //              real buffer over/under-run, the issue's core blind spot.
+        //   partial -> an in-bounds element left unwritten with NO guard violation:
+        //              expected for reduction/index/accumulator kernels (fixed-size
+        //              scalar output, not num_points elements), which the signature
+        //              cannot distinguish from a real map under-write — surfaced for
+        //              triage, not counted as a failure.
+        // Puppets are skipped: their output-buffer semantics differ from a plain map.
+        std::cout << "# output-canary sweep: vlens 1..40, 131071, 1000003\n";
+        std::cout.flush();
+        int c_tested = 0, c_failed = 0, c_partial = 0;
+        for (auto& tc : test_cases) {
+            if (!filter.empty() && tc.name() != filter)
+                continue;
+            if (tc.puppet_master_name() != "NULL") {
+                std::cout << "skip  [canary] " << tc.name() << " (puppet)\n";
+                if (report)
+                    std::fprintf(report, "%s,canary,skip,\n", tc.name().c_str());
+                std::cout.flush();
+                continue;
+            }
+            std::vector<unsigned int> over_run;
+            std::vector<unsigned int> partial;
+            bool any_applied = false;
+            for (unsigned int v : vlens) {
+                const volk_canary_summary s = quiet_canary_run(tc, v);
+                if (s.applied)
+                    any_applied = true;
+                if (s.guard_violation)
+                    over_run.push_back(v);
+                else if (s.unwritten)
+                    partial.push_back(v);
+            }
+            // A kernel the canary could not guard (no output buffer / unsupported
+            // signature) is SKIPPED, not reported ok — an unguarded kernel must not
+            // masquerade as covered. But a guard violation (incl. an exception, which
+            // quiet_canary_run reports as guard_violation) is a real defect and must
+            // FAIL even when no impl was successfully guarded: skip only when nothing
+            // was observed at all (fail closed).
+            if (!any_applied && over_run.empty() && partial.empty()) {
+                std::cout << "skip  [canary] " << tc.name()
+                          << " (no guardable output buffer)\n";
+                if (report)
+                    std::fprintf(report, "%s,canary,skip,\n", tc.name().c_str());
+                std::cout.flush();
+                continue;
+            }
+            ++c_tested;
+            const char* status;
+            const std::vector<unsigned int>* vl;
+            if (!over_run.empty()) {
+                ++c_failed;
+                status = "FAIL";
+                vl = &over_run;
+                std::cout << "FAIL  [canary] " << tc.name() << "  over-run vlens:";
+            } else if (!partial.empty()) {
+                ++c_partial;
+                status = "partial";
+                vl = &partial;
+                std::cout << "part  [canary] " << tc.name()
+                          << "  unwritten (reduction?) vlens:";
+            } else {
+                status = "ok";
+                vl = nullptr;
+                std::cout << "ok    [canary] " << tc.name();
+            }
+            if (vl) {
+                for (unsigned int v : *vl)
+                    std::cout << " " << v;
+            }
+            std::cout << "\n";
+            if (report) {
+                std::string vs;
+                if (vl) {
+                    for (unsigned int v : *vl) {
+                        vs += std::to_string(v);
+                        vs += ' ';
+                    }
+                }
+                std::fprintf(
+                    report, "%s,canary,%s,%s\n", tc.name().c_str(), status, vs.c_str());
+            }
+            std::cout.flush();
+        }
+        if (report)
+            std::fclose(report);
+        std::cerr << "\noutput-canary sweep: " << c_failed << " / " << c_tested
+                  << " kernels over-ran the output buffer; " << c_partial
+                  << " left in-bounds elements unwritten (reduction/index kernels — "
+                     "triage)\n";
+        return c_failed > 0 ? 1 : 0;
     }
 
     std::cout << "# kernel-correctness remainder sweep: vlens 1..40, 131071, 1000003\n";


### PR DESCRIPTION
## Summary

Adds an opt-in **output-buffer canary** to the kernel-correctness test harness
(`HARNESS_CANARY`), closing a long-standing harness blind spot: qa only compares
the in-bounds region `[0, num_points)`, so a kernel that writes (or leaves
unwritten) an element at the boundary passes silently. The new
`run_volk_canary_test()` allocates each output buffer in its **own `malloc`**
(bypassing the qa memory pool) as `[leading guard | aligned data of exactly
num_points elements | trailing guard]`, runs every impl twice with two distinct
sentinels (`0xA5`, `0x3C`), and fails on (a) a touched guard — an over/under-write
past the buffer — or (b) an in-bounds byte left at both sentinels across the two
runs — an element the kernel never wrote (which ASan cannot detect). Because the
data region carries no slack, an over-run lands in the trailing guard (caught by
the canary, allocator-independent and authoritative) or, far enough past, in the
**AddressSanitizer redzone** of the own-`malloc`'d allocation (best-effort double
coverage). The toggle defaults **off**, so `run_volk_tests` and the default qa
suite are byte-identical.

This is child 3 of 6 of the kernel-correctness epic (stacked on #88). **No kernel
source, signature, or ABI change** — test infrastructure only.

### What's in the diff
- `lib/qa_utils.{cc,h}`: `guarded_output_buffer` (own-`malloc`, alignment-aware
  guard regions) + `run_volk_canary_test()` returning a `{guard_violation,
  unwritten}` summary. Reuses `setup_test_data` / `run_cast_testN`; `run_volk_tests`
  untouched.
- `lib/qa_canary_kernel.{h,cc}` (new, test-only): four planted "kernels" —
  `canaryok` (clean), `canaryonepast` (writes `out[num_points]`), `canaryunwritten`
  (leaves the last element unwritten), `canaryfarpast` (contiguous over-write into
  the ASan redzone, ASan-build-only). Never registered in the production kernel list.
- `lib/test_correctness.cc`: `HARNESS_CANARY` toggle, a hard 3-way negative control,
  a best-effort per-kernel sweep, and an `HARNESS_CANARY_ASAN_DEMO` path (gated to
  ASan builds via a compile-time `__SANITIZE_ADDRESS__`/`__has_feature` macro).
- `lib/CMakeLists.txt`: `qa_canary_kernel.cc` added to `volk_test_correctness` (both
  static branches).

### A deliberate design point reviewers should note
Reduction/index/accumulator kernels (`dot_prod`, `index_max/min`, `accumulator`,
`stddev`, `sum_of_poly`, …) write a **fixed-size scalar** output, not `num_points`
elements, so they legitimately leave `[1, num_points)` unwritten. A kernel's output
cardinality cannot be derived from its signature, and a per-kernel registry is out
of scope for this child. So the canary treats a **guard violation as a hard FAIL**
(the real over-run, valid for every kernel) and an **unwritten-only finding as
`partial`** (surfaced for triage, not a failure). The `canaryunwritten` planted
control proves the unwritten detector still fires on a genuine map kernel.

## Related issues

- Closes mtibbits/volk#89
- Part of epic mtibbits/volk#85 (kernel-correctness harness); stacked on #88
  (`feat/88-independent-double-precision-reference`).

## Testing

- **Negative control (any build):** `canaryok` is clean, `canaryonepast` trips the
  guard (byte offset 508 = 127 floats, the trailing-guard start), `canaryunwritten`
  trips the unwritten check. All three are hard-asserted (exit 2 if the canary is
  ever blind or over-reports).
- **Per-kernel sweep (`HARNESS_CANARY=1`, vlens 1–40, 131071, 1000003):** 0
  over-runs, 91 ok, 22 `partial` (the reduction/index kernels described above), 15
  skip (puppets). Exit 0.
- **Default qa byte-identical (toggle off):** `ctest -R qa_` → 154/154.
- **Sanitizers (full `ctest`):** ASan 254/254, UBSan 254/254, TSan 254/254.
- **ASan demonstration:** `HARNESS_CANARY_ASAN_DEMO=1` under `build-asan` →
  `AddressSanitizer: heap-buffer-overflow` in `volk_32f_canaryfarpast_32f`,
  confirming the guarded path's own-`malloc`'d buffers are ASan-bracketed. The
  one-past write is in-allocation and is caught by the canary (ASan best-effort).
- **Static analysis (changed-line scope):** clang-tidy clean, clang-format clean,
  compiler clean; cppcheck findings are all the existing harness's C-style
  function-pointer-cast / by-value `volk_func_desc_t` idiom.
- **Adversarial review:** a multi-agent correctness review (memory safety, detector
  soundness, dispatch, driver integration, edge cases) found 0 confirmed bugs.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest` — 154/154 default qa; 254/254 under each sanitizer)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in


## Update 2026-06-09

- Amended in place (`615e126` → `68e4976`, rebased onto amended #88): the two
  "canary guard touched" prints moved to `std::cerr` so a real guard violation's
  arch/byte-offset detail survives the sweep's stdout muting. Guard violations are
  never expected (0/112 in the sweep) — unlike the unwritten "partials" (expected
  reduction noise), which stay on muted stdout by design. Negative control re-verified.
- The toggle-off `free(): invalid pointer` abort observable on this branch is **#96**
  (conv_k7 puppet static-buffer overflow), pre-existing and independent of this PR.
