### PR TITLE
input immutability canary

### DIFF
--- a/lib/qa_canary_kernel.cc
+++ b/lib/qa_canary_kernel.cc
@@ -9,6 +9,8 @@
 
 #include "qa_canary_kernel.h"
 
+#include <cstdint> // for uint32_t (input-immutability scribble, #90)
+
 // Each planted impl first copies the in-bounds region [0,num_points) correctly,
 // so the only thing distinguishing the negative controls is the write past the
 // end -- the canary's guard/two-sentinel check is what flags it. `arch` is
@@ -48,6 +50,27 @@ void volk_32f_canaryunwritten_32f(void* out,
     // is invisible to value comparison but caught by the two-sentinel check.
     for (unsigned int n = 0; n + 1 < num_points; ++n) {
         o[n] = i[n];
+    }
+}
+
+void volk_32f_inputscribble_32f(void* out, void* in, unsigned int num_points, const char*)
+{
+    float* o = static_cast<float*>(out);
+    const float* i = static_cast<const float*>(in);
+    for (unsigned int n = 0; n < num_points; ++n) {
+        o[n] = i[n]; // copy in -> out FIRST, so out[0] keeps the original value
+    }
+    // The planted defect (#90): scribble on the INPUT buffer. A correct
+    // out-of-place kernel never writes its input; this one does, so the
+    // input-immutability check (post-run byte compare vs the pristine pre-image)
+    // must flag it. Write a bitwise complement of element 0 rather than a fixed
+    // constant: ~x != x for every uint32_t, so the input byte is GUARANTEED to
+    // change regardless of the (possibly edge-case-seeded) pristine value -- a
+    // fixed constant could coincide with the seed and let the negative control
+    // pass silently. Guarded so it is safe at num_points == 0.
+    if (num_points > 0) {
+        uint32_t* w = static_cast<uint32_t*>(in);
+        w[0] = ~w[0];
     }
 }
 

--- a/lib/qa_canary_kernel.h
+++ b/lib/qa_canary_kernel.h
@@ -41,6 +41,13 @@
  *                               (HARNESS_CANARY_ASAN_DEMO); it demonstrates that
  *                               the guarded path's own-malloc buffers are
  *                               bracketed by ASan redzones (acceptance #89-2).
+ *   volk_32f_inputscribble_32f  copies [0,num_points) to the output correctly,
+ *                               then writes one element of its INPUT buffer
+ *                               (a bitwise complement of in[0]) -> MUST trip the
+ *                               input-immutability check (#90). A correct
+ *                               out-of-place kernel treats its input as const;
+ *                               this one violates that, proving the detector
+ *                               fires. Guarded by num_points > 0 (safe at vlen 0).
  */
 
 #ifndef INCLUDED_VOLK_QA_CANARY_KERNEL_H
@@ -72,6 +79,11 @@ void volk_32f_canaryunwritten_32f(void* out,
                                   unsigned int num_points,
                                   const char* arch);
 void volk_32f_canaryfarpast_32f(void* out,
+                                void* in,
+                                unsigned int num_points,
+                                const char* arch);
+// #90 input-immutability negative control: writes one element of its INPUT.
+void volk_32f_inputscribble_32f(void* out,
                                 void* in,
                                 unsigned int num_points,
                                 const char* arch);

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -19,6 +19,7 @@
 #include <stdint.h>    // for uint16_t, uint64_t
 #include <sys/time.h>  // for CLOCKS_PER_SEC
 #include <sys/types.h> // for int16_t, int32_t
+#include <cassert>     // for assert (#90 immutability index invariant)
 #include <chrono>
 #include <cmath>    // for sqrt, fabs, abs
 #include <cstdint>  // for uint8_t, uintptr_t (#89 canary)
@@ -2066,5 +2067,164 @@ volk_canary_summary run_volk_canary_test(volk_func_desc_t desc,
         summary.guard_violation = summary.guard_violation || arch_guard;
         summary.unwritten = summary.unwritten || arch_unwritten;
     }
+    return summary;
+}
+
+volk_immutability_summary
+run_volk_immutability_test(volk_func_desc_t desc,
+                           void (*manual_func)(),
+                           std::string name,
+                           lv_32fc_t scalar,
+                           unsigned int vlen,
+                           std::vector<volk_test_results_t>* results,
+                           const std::vector<float>& float_edge_cases,
+                           const std::vector<lv_32fc_t>& complex_edge_cases)
+{
+    volk_immutability_summary summary;
+
+    results->push_back(volk_test_results_t());
+    results->back().name = name;
+    results->back().vlen = vlen;
+    results->back().iter = 1;
+    results->back().config_name = name;
+    fmt::print("\nRUN_VOLK_IMMUTABILITY_TEST: {}(vlen={})\n", name, vlen);
+
+    volk_qa_aligned_mem_pool mem_pool;
+    qa_test_data d = setup_test_data(
+        desc, name, vlen, true, float_edge_cases, complex_edge_cases, mem_pool);
+    if (!d.ok) {
+        return summary;
+    }
+
+    const bool s32f =
+        (d.inputsc.size() == 1) && d.inputsc[0].is_float && !d.inputsc[0].is_complex;
+    const bool s32fc =
+        (d.inputsc.size() == 1) && d.inputsc[0].is_float && d.inputsc[0].is_complex;
+    // These "cannot check this kernel" cases leave summary.applied == false so the
+    // driver reports the kernel as skipped (NOT ok). Diagnostics go to stdout so the
+    // driver's per-(kernel,vlen) stdout muting suppresses them during the sweep.
+    if (d.inputsc.size() != 0 && !s32f && !s32fc) {
+        std::cout << "immutability mode: unsupported scalar signature for " << name
+                  << std::endl;
+        return summary;
+    }
+    // An in-place kernel (no separate output buffer) legitimately rewrites its single
+    // buffer -- that is its contract, not a defect. Only out-of-place kernels have
+    // input buffers the contract marks read-only, so immutability applies only when
+    // there IS a distinct output buffer.
+    if (d.outputsig.empty()) {
+        std::cout << "immutability mode: in-place kernel (no separate output), input "
+                     "write is by contract: "
+                  << name << std::endl;
+        return summary;
+    }
+    if (d.inputsig.empty()) {
+        std::cout << "immutability mode: kernel has no input buffer to protect: " << name
+                  << std::endl;
+        return summary;
+    }
+    if (d.both_sigs.size() > 4 || (d.both_sigs.size() == 4 && d.inputsc.size() != 0)) {
+        std::cout << "immutability mode: unsupported arity for " << name << std::endl;
+        return summary;
+    }
+
+    // Invariant the per-input compare below relies on: scalars are erased from
+    // inputsig into inputsc by setup_test_data, so d.inbuffs (the pristine pre-image,
+    // built from the post-erasure non-scalar inputsig) is index-aligned with the
+    // input buffers in d.test_data[i] at offset d.outputsig.size(). Assert it so a
+    // future change to scalar handling fails loudly instead of comparing the wrong
+    // buffers.
+    assert(d.inbuffs.size() == d.inputsig.size());
+
+    for (size_t i = 0; i < d.arch_list.size(); i++) {
+        const std::string arch = d.arch_list[i];
+        summary.applied = true; // we are about to check at least one impl
+
+        // buffs layout matches setup_test_data: outputs first, then inputs. Inputs
+        // are arch i's own pool copy (seeded from the pristine d.inbuffs[k], which the
+        // kernel never receives).
+        std::vector<void*> buffs;
+        for (size_t j = 0; j < d.outputsig.size(); j++) {
+            buffs.push_back(d.test_data[i][j]);
+        }
+        for (size_t k = 0; k < d.inputsig.size(); k++) {
+            buffs.push_back(d.test_data[i][d.outputsig.size() + k]);
+        }
+
+        switch (d.both_sigs.size()) {
+        case 1:
+            if (s32fc)
+                run_cast_test1_s32fc(
+                    (volk_fn_1arg_s32fc)(manual_func), buffs, scalar, vlen, 1, arch);
+            else if (s32f)
+                run_cast_test1_s32f((volk_fn_1arg_s32f)(manual_func),
+                                    buffs,
+                                    scalar.real(),
+                                    vlen,
+                                    1,
+                                    arch);
+            else
+                run_cast_test1((volk_fn_1arg)(manual_func), buffs, vlen, 1, arch);
+            break;
+        case 2:
+            if (s32fc)
+                run_cast_test2_s32fc(
+                    (volk_fn_2arg_s32fc)(manual_func), buffs, scalar, vlen, 1, arch);
+            else if (s32f)
+                run_cast_test2_s32f((volk_fn_2arg_s32f)(manual_func),
+                                    buffs,
+                                    scalar.real(),
+                                    vlen,
+                                    1,
+                                    arch);
+            else
+                run_cast_test2((volk_fn_2arg)(manual_func), buffs, vlen, 1, arch);
+            break;
+        case 3:
+            if (s32fc)
+                run_cast_test3_s32fc(
+                    (volk_fn_3arg_s32fc)(manual_func), buffs, scalar, vlen, 1, arch);
+            else if (s32f)
+                run_cast_test3_s32f((volk_fn_3arg_s32f)(manual_func),
+                                    buffs,
+                                    scalar.real(),
+                                    vlen,
+                                    1,
+                                    arch);
+            else
+                run_cast_test3((volk_fn_3arg)(manual_func), buffs, vlen, 1, arch);
+            break;
+        case 4:
+            run_cast_test4((volk_fn_4arg)(manual_func), buffs, vlen, 1, arch);
+            break;
+        default:
+            break;
+        }
+
+        // Post-run compare of each input against its pristine pre-image. Exact
+        // std::memcmp (not a hash) so a mutation cannot hide behind a checksum
+        // collision (acceptance #90-1); on mismatch, locate the first differing byte
+        // for triage. The finding goes to std::cerr (NOT std::cout) so it survives the
+        // sweep's per-(kernel,vlen) stdout muting -- unlike #89's canary, which has
+        // expected reduction "partials" to suppress, immutability has no expected
+        // findings, so a real mutation should always be loud and actionable.
+        for (size_t k = 0; k < d.inputsig.size(); k++) {
+            const size_t in_bytes = static_cast<size_t>(vlen) * d.inputsig[k].size *
+                                    (d.inputsig[k].is_complex ? 2 : 1);
+            const uint8_t* pre = static_cast<const uint8_t*>(d.inbuffs[k]);
+            const uint8_t* post =
+                static_cast<const uint8_t*>(d.test_data[i][d.outputsig.size() + k]);
+            if (std::memcmp(pre, post, in_bytes) != 0) {
+                summary.mutated = true;
+                size_t off = 0;
+                while (off < in_bytes && pre[off] == post[off]) {
+                    ++off;
+                }
+                std::cerr << name << ": input mutated on arch " << arch << " (input " << k
+                          << ", byte offset " << off << ")\n";
+            }
+        }
+    }
+
     return summary;
 }

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -253,6 +253,33 @@ volk_canary_summary run_volk_canary_test(
     const std::vector<float>& float_edge_cases = std::vector<float>(),
     const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
 
+// #90: outcome of run_volk_immutability_test. A kernel that writes any byte of an
+// input buffer (which an out-of-place kernel's contract forbids) sets `mutated`.
+// `applied` is false when the kernel has no separate input to protect: an in-place
+// kernel (no output buffer -> its single buffer is the input it legitimately
+// rewrites) or an unsupported signature -- such kernels are reported skipped, not
+// ok, so an unchecked kernel never masquerades as covered.
+struct volk_immutability_summary {
+    bool mutated = false; // an input buffer differed after the call (always a defect)
+    bool applied = false; // false => no separate input buffer to protect / unsupported
+};
+
+// #90: input-immutability canary. For every impl, byte-compares each input buffer
+// after the call against its pristine pre-image (qa_test_data::inbuffs, a separate
+// allocation the kernel never receives). An exact compare -- not a hash -- so a
+// mutation cannot hide behind a checksum collision. Delivers the one defensible
+// value of the abandoned const-input-signature sweep without touching any
+// signature. Toggle is in the driver; run_volk_tests / default qa are untouched.
+volk_immutability_summary run_volk_immutability_test(
+    volk_func_desc_t,
+    void (*)(),
+    std::string,
+    lv_32fc_t,
+    unsigned int,
+    std::vector<volk_test_results_t>* results = NULL,
+    const std::vector<float>& float_edge_cases = std::vector<float>(),
+    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
+
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \
                    (void (*)())func##_manual,    \

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -205,6 +205,55 @@ static volk_canary_summary quiet_canary_run(volk_test_case_t& tc, unsigned int v
     return summary;
 }
 
+// #90: run the input-immutability check for one (kernel, vlen) with stdout muted
+// (mirrors quiet_canary_run). On an exception the run did not complete, so we cannot
+// conclude anything about input immutability -- report it skipped (applied stays
+// false) with a note, rather than mislabeling a crash as a mutation.
+static volk_immutability_summary quiet_immutability_run(volk_test_case_t& tc,
+                                                        unsigned int v)
+{
+    std::vector<volk_test_results_t> results;
+    const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
+    std::fflush(stdout);
+    std::cout.flush();
+    int saved = -1, devnull = -1;
+    if (!verbose) {
+        saved = dup(STDOUT_FILENO);
+        devnull = open(VOLK_DEVNULL, O_WRONLY);
+        if (saved >= 0 && devnull >= 0)
+            dup2(devnull, STDOUT_FILENO);
+    }
+    volk_immutability_summary summary;
+    bool threw = false;
+    try {
+        summary = run_volk_immutability_test(tc.desc(),
+                                             tc.kernel_ptr(),
+                                             tc.name(),
+                                             tc.test_parameters().scalar(),
+                                             v /*vlen*/,
+                                             &results,
+                                             kFloatEdges,
+                                             kComplexEdges);
+    } catch (...) {
+        threw = true;
+        summary = volk_immutability_summary(); // applied=false, mutated=false -> skip
+    }
+    std::fflush(stdout);
+    std::cout.flush();
+    if (!verbose) {
+        if (saved >= 0) {
+            dup2(saved, STDOUT_FILENO);
+            close(saved);
+        }
+        if (devnull >= 0)
+            close(devnull);
+    }
+    if (threw)
+        std::cerr << "note  [immutable] " << tc.name() << " threw at vlen " << v
+                  << " (skipped; crashes are out of #90 scope)\n";
+    return summary;
+}
+
 int main(int argc, char* argv[])
 {
     const float tol = 1e-6f;
@@ -423,6 +472,127 @@ int main(int argc, char* argv[])
                   << " left in-bounds elements unwritten (reduction/index kernels — "
                      "triage)\n";
         return c_failed > 0 ? 1 : 0;
+    }
+
+    // #90 input-immutability mode (opt-in via HARNESS_IMMUTABLE). Like the #89
+    // canary it is a distinct mode that replaces the correctness sweep; the default
+    // qa suite and the toggle-off correctness sweep are entirely unaffected.
+    const bool immutable_mode = (std::getenv("HARNESS_IMMUTABLE") != nullptr);
+    if (immutable_mode) {
+        // Hard negative control (any build), exercising the SAME
+        // run_volk_immutability_test path real kernels use. Two planted kernels:
+        //   ok        -> input untouched         (must NOT be flagged)
+        //   scribble  -> writes in[0]            (must trip the mutation check)
+        // Any deviation means the detector is broken -- fail hard (exit 2), per #88.
+        const unsigned int nc_vlen = 127;
+        std::vector<volk_test_results_t> nc;
+        const volk_immutability_summary ok_sum =
+            run_volk_immutability_test(volk_canary_desc(),
+                                       (void (*)())(&volk_32f_canaryok_32f),
+                                       "volk_32f_canaryok_32f",
+                                       scalar,
+                                       nc_vlen,
+                                       &nc,
+                                       kFloatEdges,
+                                       kComplexEdges);
+        nc.clear();
+        const volk_immutability_summary scribble_sum =
+            run_volk_immutability_test(volk_canary_desc(),
+                                       (void (*)())(&volk_32f_inputscribble_32f),
+                                       "volk_32f_inputscribble_32f",
+                                       scalar,
+                                       nc_vlen,
+                                       &nc,
+                                       kFloatEdges,
+                                       kComplexEdges);
+        nc.clear();
+        const char* nc_err = nullptr;
+        if (ok_sum.mutated) {
+            nc_err = "the correct planted kernel volk_32f_canaryok_32f was flagged — "
+                     "the immutability check over-reports";
+        } else if (!scribble_sum.mutated) {
+            nc_err = "the planted kernel volk_32f_inputscribble_32f did not trip the "
+                     "immutability check — the detector is blind to input writes";
+        }
+        if (nc_err) {
+            std::cerr << "NEGATIVE CONTROL LOST: " << nc_err << ". Aborting.\n";
+            if (report)
+                std::fclose(report);
+            return 2;
+        }
+        std::cerr << "immutability negative control OK: ok-kernel clean, scribble "
+                     "trips the input-immutability check.\n";
+
+        // Best-effort per-kernel immutability sweep over the real kernels.
+        //   FAIL -> the kernel wrote a byte of an input buffer (always a defect).
+        //   skip -> in-place / unsupported signature / no impl observed (fail closed).
+        // Puppets are skipped: their buffer plumbing differs from a plain kernel call.
+        std::cout << "# input-immutability sweep: vlens 1..40, 131071, 1000003\n";
+        std::cout.flush();
+        int m_tested = 0, m_failed = 0;
+        for (auto& tc : test_cases) {
+            if (!filter.empty() && tc.name() != filter)
+                continue;
+            if (tc.puppet_master_name() != "NULL") {
+                std::cout << "skip  [immutable] " << tc.name() << " (puppet)\n";
+                if (report)
+                    std::fprintf(report, "%s,immutable,skip,\n", tc.name().c_str());
+                std::cout.flush();
+                continue;
+            }
+            std::vector<unsigned int> mutated;
+            bool any_applied = false;
+            for (unsigned int v : vlens) {
+                const volk_immutability_summary s = quiet_immutability_run(tc, v);
+                if (s.applied)
+                    any_applied = true;
+                if (s.mutated)
+                    mutated.push_back(v);
+            }
+            // A kernel no impl could check (in-place / unsupported) is SKIPPED, not ok
+            // -- an unchecked kernel must not masquerade as covered. Fail closed: skip
+            // only when nothing was observed at all.
+            if (!any_applied && mutated.empty()) {
+                std::cout << "skip  [immutable] " << tc.name()
+                          << " (no protectable input buffer)\n";
+                if (report)
+                    std::fprintf(report, "%s,immutable,skip,\n", tc.name().c_str());
+                std::cout.flush();
+                continue;
+            }
+            ++m_tested;
+            const char* status;
+            if (!mutated.empty()) {
+                ++m_failed;
+                status = "FAIL";
+                std::cout << "FAIL  [immutable] " << tc.name()
+                          << "  mutated-input vlens:";
+                for (unsigned int v : mutated)
+                    std::cout << " " << v;
+            } else {
+                status = "ok";
+                std::cout << "ok    [immutable] " << tc.name();
+            }
+            std::cout << "\n";
+            if (report) {
+                std::string vs;
+                for (unsigned int v : mutated) {
+                    vs += std::to_string(v);
+                    vs += ' ';
+                }
+                std::fprintf(report,
+                             "%s,immutable,%s,%s\n",
+                             tc.name().c_str(),
+                             status,
+                             vs.c_str());
+            }
+            std::cout.flush();
+        }
+        if (report)
+            std::fclose(report);
+        std::cerr << "\ninput-immutability sweep: " << m_failed << " / " << m_tested
+                  << " kernels wrote a byte of an input buffer\n";
+        return m_failed > 0 ? 1 : 0;
     }
 
     std::cout << "# kernel-correctness remainder sweep: vlens 1..40, 131071, 1000003\n";


### PR DESCRIPTION
## Summary

Adds an opt-in **input-immutability canary** to the kernel-correctness harness
(epic #85, child 4). A VOLK out-of-place kernel must treat its input buffers as
read-only, but nothing in qa checked that — a kernel that scribbles on an input
passed silently. This adds a `HARNESS_IMMUTABLE` mode that, for every registered
kernel and impl, byte-compares each input buffer after the call against its
pristine pre-image and fails if any input changed. It delivers the one defensible
value of the abandoned `const`-input-signature idea (input read-only enforcement)
**without touching a single kernel signature** — the check lives entirely in the
test harness. A planted negative-control kernel proves the detector fires. The new
behavior is a toggle, **default off**, so the default qa suite is byte-identical.
Five test-only files; no kernel source, signature, ABI, or CMake change.

## Related issues

- Closes mtibbits/volk#90 (epic mtibbits/volk#85, child 4 of 6).
- **Stacked on #89** (`feat/89-output-canary-and-asan`); the input-side mirror of
  #89's output canary. Predecessors #87 (foundation) and #88 (independent reference)
  already landed on `dev/all-prs`. Review the diff against `feat/89`, not `main`.
- Fork-local issue numbers; re-link on any upstream submission.

## Testing

- **Negative control (hard gate, any build):** with the stub detector → `NEGATIVE
  CONTROL LOST … detector is blind to input writes`, exit 2 (RED, proving the
  control has signal). With the real detector → `negative control OK: ok-kernel
  clean, scribble trips the input-immutability check`, the planted
  `volk_32f_inputscribble_32f` flagged at `input 0, byte offset 0` (GREEN).
- **Full sweep** (`HARNESS_IMMUTABLE=1`, vlens 1–40 + 131071 + 1000003):
  **0 / 112 kernels wrote an input buffer** (112 ok, 16 skip = puppets/in-place,
  0 FAIL), exit 0. No kernel currently violates input immutability; this is the
  standing regression guard.
- **Default qa byte-identical:** `ctest -R qa_` = **154/154 passed** (toggle is
  `getenv`-gated and never set by the default suite).
- **Sanitizers — #90 code path:** `HARNESS_IMMUTABLE=1` under AddressSanitizer
  (0 errors) and UBSan (0 runtime errors); the `float*`→`uint32_t*` scribble write
  is properly aligned.
- **Sanitizers — full qa suite (analyze step):** ASan / UBSan / TSan each pass the
  `qa_` suite with 0 findings, exit 0.
- **Static analysis:** `cppcheck` on the 5 changed files — **0 findings in new
  code** (the only hits are pre-existing `passedByValue` / a `result.time` uninit at
  qa_utils.cc:1760, identical on `feat/89`).
- **clang-format:** clean.

## Reviewer notes

- **Mechanism:** no separate snapshot is allocated — `setup_test_data` already keeps
  the pristine input in `qa_test_data::inbuffs[k]` (a buffer the kernel never
  receives), so the check is an exact `memcmp` of the post-run input against it.
  Exact compare, not a hash, so a mutation cannot hide behind a checksum collision.
- **In-place kernels** (no separate output buffer) legitimately rewrite their single
  buffer and are reported `skip`, never `FAIL` (guarded by `outputsig.empty()`).
- **Findings go to `std::cerr`:** a detected mutation prints `input mutated on arch …
  (input k, byte offset N)` to **stderr** (unmuted), so a real FAIL stays visible and
  actionable through the sweep's per-(kernel,vlen) stdout muting. #89's canary now does
  the same — its amend (documented in PR #95) moved its two guard prints to
  `std::cerr` (`lib/qa_utils.cc:2019`/`2040` on `feat/89`); the remaining
  difference is that #89 additionally mutes its *expected* reduction "partials"
  on stdout, while immutability has no expected findings, so every finding is
  loud. Equality uses `std::memcmp`; the
  byte loop runs only on mismatch to locate the offset.
- **Style:** the `run_cast_testN` dispatch and fd-muting helper deliberately mirror
  #89's `run_volk_canary_test` / `quiet_canary_run` (brace-free `if/else` dispatch,
  `std::cout` for routine skip diagnostics). Deduping the shared dispatch into one
  helper is tracked as a follow-up (`imPlan-potentialFutureEnhancements.md`) rather
  than done here, because it touches #89's already-landed code (surgical-diff); doing
  it now would mix a #89 refactor into a #90 feature PR.
- **Pre-existing, NOT introduced here:** a *toggle-off* run of `volk_test_correctness`
  aborts with `free(): invalid pointer` after `volk_32fc_s32fc_rotator2puppet_32fc`
  — this reproduces identically on `feat/89`'s own build, so it is a latent
  #87-foundation bug independent of #90 (#90's code never runs when the toggle is
  off). Flagged for a separate issue.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest -R qa_` 154/154; `HARNESS_IMMUTABLE` negative control + sweep)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in (5 test-only files, additive toggle)

