### PR TITLE
misaligned u variant runs

### DIFF
--- a/lib/qa_canary_kernel.cc
+++ b/lib/qa_canary_kernel.cc
@@ -9,7 +9,12 @@
 
 #include "qa_canary_kernel.h"
 
+#include <csignal> // for raise (misaligned-fault portable fallback, #91)
 #include <cstdint> // for uint32_t (input-immutability scribble, #90)
+#if defined(__SSE2__)
+#include <emmintrin.h> // SSE2 umbrella; provides the SSE1 _mm_load_ps/_mm_storeu_ps
+                       // used by the #91 planted misaligned-fault control
+#endif
 
 // Each planted impl first copies the in-bounds region [0,num_points) correctly,
 // so the only thing distinguishing the negative controls is the write past the
@@ -71,6 +76,44 @@ void volk_32f_inputscribble_32f(void* out, void* in, unsigned int num_points, co
     if (num_points > 0) {
         uint32_t* w = static_cast<uint32_t*>(in);
         w[0] = ~w[0];
+    }
+}
+
+void volk_32f_misalignedfault_32f(void* out,
+                                  void* in,
+                                  unsigned int num_points,
+                                  const char*)
+{
+    float* o = static_cast<float*>(out);
+    const float* i = static_cast<const float*>(in);
+    // The planted defect (#91): an ALIGNED load inside an impl whose dispatch
+    // metadata says unaligned -- the movaps-in-a-_u_-kernel class. Under __SSE2__
+    // (any x86-64 build) this is a genuine alignment-checked 16-byte load that
+    // raises SIGSEGV iff `in` is not 16-byte aligned; elsewhere we simulate the
+    // same hardware fault with raise(SIGSEGV). On ALIGNED input it must run
+    // correctly (proves the detector doesn't over-report on the aligned path).
+#if defined(__SSE2__)
+    if (num_points >= 4) {
+        // NOTE: relies on the compiler emitting an alignment-checked load
+        // ((v)movaps) for _mm_load_ps, which GCC/clang do at every -O level for
+        // this TU. Under LTO/cross-TU inlining a compiler that can PROVE the
+        // pointer misaligned may legally lower it to movups and the fault
+        // vanishes (negative control catches that as NC LOST, exit 2 -- fail
+        // loud). Do not build the harness with LTO.
+        __m128 v = _mm_load_ps(i); // movaps: faults on misalignment
+        _mm_storeu_ps(o, v);
+        for (unsigned int n = 4; n < num_points; ++n) {
+            o[n] = i[n];
+        }
+        return;
+    }
+#else
+    if (reinterpret_cast<uintptr_t>(in) % 16 != 0 && num_points >= 4) {
+        raise(SIGSEGV);
+    }
+#endif
+    for (unsigned int n = 0; n < num_points; ++n) {
+        o[n] = i[n];
     }
 }
 

--- a/lib/qa_canary_kernel.h
+++ b/lib/qa_canary_kernel.h
@@ -48,6 +48,12 @@
  *                               out-of-place kernel treats its input as const;
  *                               this one violates that, proving the detector
  *                               fires. Guarded by num_points > 0 (safe at vlen 0).
+ *   volk_32f_misalignedfault_32f copies in -> out but performs an ALIGNED 16-byte
+ *                               load on its input when num_points >= 4 -- the
+ *                               movaps-in-a-_u_-kernel defect class (#91). On a
+ *                               misaligned input it raises SIGSEGV (real aligned
+ *                               load under __SSE2__; raise(SIGSEGV) fallback
+ *                               elsewhere); on aligned input it runs correctly.
  */
 
 #ifndef INCLUDED_VOLK_QA_CANARY_KERNEL_H
@@ -87,6 +93,11 @@ void volk_32f_inputscribble_32f(void* out,
                                 void* in,
                                 unsigned int num_points,
                                 const char* arch);
+// #91 misaligned negative control: aligned load inside an "unaligned" impl.
+void volk_32f_misalignedfault_32f(void* out,
+                                  void* in,
+                                  unsigned int num_points,
+                                  const char* arch);
 
 // A synthetic single-impl ("generic") descriptor so the planted kernels flow
 // through the SAME run_volk_canary_test path as real kernels. impl_alignment is

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -22,6 +22,8 @@
 #include <cassert>     // for assert (#90 immutability index invariant)
 #include <chrono>
 #include <cmath>    // for sqrt, fabs, abs
+#include <csetjmp>  // for sigsetjmp/siglongjmp (#91 misaligned fault isolation)
+#include <csignal>  // for sigaction, SIGSEGV/SIGBUS/SIGILL (#91)
 #include <cstdint>  // for uint8_t, uintptr_t (#89 canary)
 #include <cstdlib>  // for malloc, free (#89 canary)
 #include <cstring>  // for memcpy, memset
@@ -2228,3 +2230,470 @@ run_volk_immutability_test(volk_func_desc_t desc,
 
     return summary;
 }
+
+// #91 is POSIX-only: MSVC has no sigaction/sigsetjmp/SIGBUS, and qa_utils.cc is
+// compiled into volk_test_all too, so an unconditional use would break the
+// Windows build of the DEFAULT qa suite. On _WIN32 the function compiles to an
+// explicit "unsupported" skip (applied=false): the driver's negative control
+// then fails closed with a clear stderr trail instead of the tree failing to
+// build.
+#ifdef _WIN32
+volk_misaligned_summary
+run_volk_misaligned_test(volk_func_desc_t /*desc*/,
+                         void (* /*manual_func*/)(),
+                         std::string name,
+                         lv_32fc_t /*scalar*/,
+                         float /*tol*/,
+                         bool /*absolute_mode*/,
+                         unsigned int /*vlen*/,
+                         std::vector<volk_test_results_t>* /*results*/,
+                         const std::vector<float>& /*float_edge_cases*/,
+                         const std::vector<lv_32fc_t>& /*complex_edge_cases*/)
+{
+    std::cerr << "misaligned mode: unsupported on this platform (POSIX signal "
+                 "isolation required): "
+              << name << "\n";
+    return volk_misaligned_summary();
+}
+#else
+
+namespace {
+// #91: SIGSEGV/SIGBUS/SIGILL isolation for misaligned-impl runs. An aligned SIMD
+// load on a misaligned address raises a hardware signal, not a C++ exception, so
+// catch(...) cannot trap it. sigsetjmp/siglongjmp is sound HERE because every
+// exercised impl is a pure computational loop over harness-owned buffers (the
+// driver skips puppets): no locks, allocations, or unwind-relevant state can be
+// in flight at the faulting instruction, and the dispatch deliberately uses
+// direct casted calls so no C++ frame with a non-trivial destructor sits between
+// the sigsetjmp and the fault.
+// Single-threaded qa binary by design: process-wide handlers + globals are safe
+// (the faults are synchronous; there is no second thread to race).
+sigjmp_buf g_misaligned_jmp;
+volatile sig_atomic_t g_misaligned_sig = 0;
+// Armed ONLY inside a sigsetjmp window. A fault while the handlers are installed
+// but no window is open (buffer setup, compare, I/O) is a HARNESS bug, not a
+// kernel defect -- jumping would misattribute it (or, before the first window,
+// longjmp through a never-set jmp_buf: UB). Re-raise with default disposition so
+// such a fault crashes loudly at its true location.
+volatile sig_atomic_t g_misaligned_window_open = 0;
+extern "C" void misaligned_fault_handler(int sig)
+{
+    if (!g_misaligned_window_open) {
+        signal(sig, SIG_DFL);
+        raise(sig);
+        return;
+    }
+    g_misaligned_window_open = 0;
+    g_misaligned_sig = sig;
+    siglongjmp(g_misaligned_jmp, 1);
+}
+// Installs the handlers on construction, restores the previous ones on scope exit.
+class scoped_fault_isolation
+{
+public:
+    scoped_fault_isolation()
+    {
+        struct sigaction sa;
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = misaligned_fault_handler;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGSEGV, &sa, &old_segv_);
+        sigaction(SIGBUS, &sa, &old_bus_);
+        sigaction(SIGILL, &sa, &old_ill_);
+    }
+    ~scoped_fault_isolation()
+    {
+        sigaction(SIGSEGV, &old_segv_, nullptr);
+        sigaction(SIGBUS, &old_bus_, nullptr);
+        sigaction(SIGILL, &old_ill_, nullptr);
+    }
+    scoped_fault_isolation(const scoped_fault_isolation&) = delete;
+    scoped_fault_isolation& operator=(const scoped_fault_isolation&) = delete;
+
+private:
+    struct sigaction old_segv_, old_bus_, old_ill_;
+};
+
+// #91: an own-malloc buffer whose data pointer is element-aligned but deliberately
+// NOT volk_get_alignment()-aligned: one element past an alignment boundary --
+// exactly the shape of a GNU Radio sub-buffer slice.
+class misaligned_buffer
+{
+public:
+    misaligned_buffer(size_t data_bytes, size_t alignment, size_t elem_bytes)
+    {
+        // Tail slack (8 elements) so a small over-WRITE -- the #89 defect class --
+        // lands in our slack instead of corrupting malloc metadata mid-sweep; the
+        // canary mode, not this one, is what detects such writes.
+        raw_ = static_cast<uint8_t*>(malloc(data_bytes + alignment + elem_bytes * 9));
+        if (raw_ == nullptr) {
+            // Fail loud: continuing would fault OUTSIDE a sigsetjmp window and be
+            // misattributed by the fault handler (or jump to a stale env).
+            std::cerr << "misaligned_buffer: allocation failed\n";
+            abort();
+        }
+        const uintptr_t base =
+            (reinterpret_cast<uintptr_t>(raw_) + alignment - 1) & ~(alignment - 1);
+        ptr_ = reinterpret_cast<void*>(base + elem_bytes);
+        // Caller guarantees elem_bytes % alignment != 0 (the degenerate-platform
+        // guard in run_volk_misaligned_test), so base+elem is off-boundary.
+    }
+    ~misaligned_buffer() { free(raw_); }
+    misaligned_buffer(const misaligned_buffer&) = delete;
+    misaligned_buffer& operator=(const misaligned_buffer&) = delete;
+    void* data() const { return ptr_; }
+
+private:
+    uint8_t* raw_;
+    void* ptr_;
+};
+} // namespace
+
+volk_misaligned_summary
+run_volk_misaligned_test(volk_func_desc_t desc,
+                         void (*manual_func)(),
+                         std::string name,
+                         lv_32fc_t scalar,
+                         float tol,
+                         bool absolute_mode,
+                         unsigned int vlen,
+                         std::vector<volk_test_results_t>* results,
+                         const std::vector<float>& float_edge_cases,
+                         const std::vector<lv_32fc_t>& complex_edge_cases)
+{
+    volk_misaligned_summary summary;
+
+    results->push_back(volk_test_results_t());
+    results->back().name = name;
+    results->back().vlen = vlen;
+    results->back().iter = 1;
+    results->back().config_name = name;
+    fmt::print("\nRUN_VOLK_MISALIGNED_TEST: {}(vlen={})\n", name, vlen);
+
+    volk_qa_aligned_mem_pool mem_pool;
+    qa_test_data d = setup_test_data(
+        desc, name, vlen, true, float_edge_cases, complex_edge_cases, mem_pool);
+    if (!d.ok) {
+        return summary;
+    }
+
+    const bool s32f =
+        (d.inputsc.size() == 1) && d.inputsc[0].is_float && !d.inputsc[0].is_complex;
+    const bool s32fc =
+        (d.inputsc.size() == 1) && d.inputsc[0].is_float && d.inputsc[0].is_complex;
+    // "Cannot check" cases leave summary.applied == false so the driver reports the
+    // kernel as skipped (NOT ok). Diagnostics go to stdout so the driver's
+    // per-(kernel,vlen) stdout muting suppresses them during the sweep.
+    if (d.inputsc.size() != 0 && !s32f && !s32fc) {
+        std::cout << "misaligned mode: unsupported scalar signature for " << name
+                  << std::endl;
+        return summary;
+    }
+    if (d.both_sigs.size() > 4 || (d.both_sigs.size() == 4 && d.inputsc.size() != 0)) {
+        std::cout << "misaligned mode: unsupported arity for " << name << std::endl;
+        return summary;
+    }
+
+    const size_t alignment = volk_get_alignment();
+    // The kernel's own comparison parameters (mirrors run_volk_tests' derivation).
+    const float tol_f = tol;
+    const unsigned int tol_i = static_cast<unsigned int>(tol);
+
+    // Degenerate-platform guard: if volk_get_alignment() does not exceed an element
+    // size, an element offset can land back on an alignment boundary -- the
+    // "misaligned" pointer would be aligned and the mode would silently test
+    // nothing. Skip (applied=false -> reported skip, fail closed) instead.
+    for (size_t j = 0; j < d.both_sigs.size(); j++) {
+        const size_t elem = d.both_sigs[j].size * (d.both_sigs[j].is_complex ? 2 : 1);
+        if (elem % alignment == 0) {
+            std::cout << "misaligned mode: alignment " << alignment
+                      << " too small to misalign element size " << elem << " for " << name
+                      << std::endl;
+            return summary;
+        }
+    }
+
+    // Direct casted calls -- deliberately NOT the run_cast_testN wrappers, whose
+    // by-value std::string parameter would sit on a frame the fault path longjmps
+    // over (skipping a non-trivial destructor is UB). arch_cstr is materialized by
+    // the caller before sigsetjmp. Single iteration. NOTE the s32fc forms take the
+    // scalar BY POINTER (matching the volk_fn_*_s32fc typedefs).
+    auto run_impl_direct = [&](std::vector<void*>& buffs, const char* arch_cstr) {
+        switch (d.both_sigs.size()) {
+        case 1:
+            if (s32fc)
+                ((volk_fn_1arg_s32fc)(manual_func))(buffs[0], &scalar, vlen, arch_cstr);
+            else if (s32f)
+                ((volk_fn_1arg_s32f)(manual_func))(
+                    buffs[0], scalar.real(), vlen, arch_cstr);
+            else
+                ((volk_fn_1arg)(manual_func))(buffs[0], vlen, arch_cstr);
+            break;
+        case 2:
+            if (s32fc)
+                ((volk_fn_2arg_s32fc)(manual_func))(
+                    buffs[0], buffs[1], &scalar, vlen, arch_cstr);
+            else if (s32f)
+                ((volk_fn_2arg_s32f)(manual_func))(
+                    buffs[0], buffs[1], scalar.real(), vlen, arch_cstr);
+            else
+                ((volk_fn_2arg)(manual_func))(buffs[0], buffs[1], vlen, arch_cstr);
+            break;
+        case 3:
+            if (s32fc)
+                ((volk_fn_3arg_s32fc)(manual_func))(
+                    buffs[0], buffs[1], buffs[2], &scalar, vlen, arch_cstr);
+            else if (s32f)
+                ((volk_fn_3arg_s32f)(manual_func))(
+                    buffs[0], buffs[1], buffs[2], scalar.real(), vlen, arch_cstr);
+            else
+                ((volk_fn_3arg)(manual_func))(
+                    buffs[0], buffs[1], buffs[2], vlen, arch_cstr);
+            break;
+        case 4:
+            ((volk_fn_4arg)(manual_func))(
+                buffs[0], buffs[1], buffs[2], buffs[3], vlen, arch_cstr);
+            break;
+        default:
+            break;
+        }
+    };
+
+    // Compare one both_sigs buffer against the generic aligned baseline, the same
+    // per-type dispatch run_volk_tests uses. Comparing inputs as well as outputs is
+    // what gives IN-PLACE kernels divergence coverage (their "output" IS the mutated
+    // input buffer); for out-of-place kernels the input compare is a free no-op
+    // (#90 guarantees inputs are unmutated, so both sides equal the pre-image).
+    auto compare_buffer = [&](size_t j, void* expected, void* actual, double& max_err) {
+        std::vector<unsigned int> fail_indices;
+        max_err = 0.0;
+        bool fail = false;
+        const volk_type_t& t = d.both_sigs[j];
+        const unsigned int n_ints = vlen * (t.is_complex ? 2 : 1);
+        if (t.is_float) {
+            if (t.size == 8) {
+                if (t.is_complex)
+                    fail = ccompare((double*)expected,
+                                    (double*)actual,
+                                    vlen,
+                                    tol_f,
+                                    absolute_mode,
+                                    fail_indices,
+                                    max_err);
+                else
+                    fail = fcompare((double*)expected,
+                                    (double*)actual,
+                                    vlen,
+                                    tol_f,
+                                    absolute_mode,
+                                    fail_indices,
+                                    max_err);
+            } else {
+                if (t.is_complex)
+                    fail = ccompare((float*)expected,
+                                    (float*)actual,
+                                    vlen,
+                                    tol_f,
+                                    absolute_mode,
+                                    fail_indices,
+                                    max_err);
+                else
+                    fail = fcompare((float*)expected,
+                                    (float*)actual,
+                                    vlen,
+                                    tol_f,
+                                    absolute_mode,
+                                    fail_indices,
+                                    max_err);
+            }
+        } else {
+            switch (t.size) {
+            case 8:
+                if (t.is_signed)
+                    fail = icompare((int64_t*)expected,
+                                    (int64_t*)actual,
+                                    n_ints,
+                                    tol_i,
+                                    fail_indices,
+                                    max_err);
+                else
+                    fail = icompare((uint64_t*)expected,
+                                    (uint64_t*)actual,
+                                    n_ints,
+                                    tol_i,
+                                    fail_indices,
+                                    max_err);
+                break;
+            case 4:
+                if (t.is_complex) {
+                    // complex size-4 = pairs of 16-bit halves (run_volk_tests does
+                    // the same): compare as int16/uint16.
+                    if (t.is_signed)
+                        fail = icompare((int16_t*)expected,
+                                        (int16_t*)actual,
+                                        n_ints,
+                                        tol_i,
+                                        fail_indices,
+                                        max_err);
+                    else
+                        fail = icompare((uint16_t*)expected,
+                                        (uint16_t*)actual,
+                                        n_ints,
+                                        tol_i,
+                                        fail_indices,
+                                        max_err);
+                } else {
+                    if (t.is_signed)
+                        fail = icompare((int32_t*)expected,
+                                        (int32_t*)actual,
+                                        n_ints,
+                                        tol_i,
+                                        fail_indices,
+                                        max_err);
+                    else
+                        fail = icompare((uint32_t*)expected,
+                                        (uint32_t*)actual,
+                                        n_ints,
+                                        tol_i,
+                                        fail_indices,
+                                        max_err);
+                }
+                break;
+            case 2:
+                if (t.is_signed)
+                    fail = icompare((int16_t*)expected,
+                                    (int16_t*)actual,
+                                    n_ints,
+                                    tol_i,
+                                    fail_indices,
+                                    max_err);
+                else
+                    fail = icompare((uint16_t*)expected,
+                                    (uint16_t*)actual,
+                                    n_ints,
+                                    tol_i,
+                                    fail_indices,
+                                    max_err);
+                break;
+            case 1:
+                if (t.is_signed)
+                    fail = icompare((int8_t*)expected,
+                                    (int8_t*)actual,
+                                    n_ints,
+                                    tol_i,
+                                    fail_indices,
+                                    max_err);
+                else
+                    fail = icompare((uint8_t*)expected,
+                                    (uint8_t*)actual,
+                                    n_ints,
+                                    tol_i,
+                                    fail_indices,
+                                    max_err);
+                break;
+            default:
+                fail = true;
+            }
+        }
+        return fail;
+    };
+
+    // Comparison design: SAME impl, aligned vs misaligned. Comparing a misaligned
+    // u_impl against the generic baseline would conflate impl-vs-generic accuracy
+    // (already #87's sweep, where edge-data precision differences legitimately
+    // exceed tol for approximate kernels and large-vlen accumulations) with the
+    // #91 question -- does MISALIGNMENT change this impl's output? Running the
+    // same impl twice with identical inputs isolates alignment as the only
+    // variable; the kernel's own tol absorbs legitimate reordering by impls that
+    // peel to an alignment boundary.
+    //
+    // Output buffers on BOTH sides are zero-prefilled: reduction/index kernels
+    // write only a fixed-size scalar into out[0..k), and output cardinality
+    // cannot be derived from the signature (#89 lesson). With a common prefill,
+    // never-written regions are 0 == 0 and only kernel-written elements compare.
+    scoped_fault_isolation guard_signals;
+
+    for (size_t i = 0; i < d.arch_list.size(); i++) {
+        const std::string arch = d.arch_list[i];
+        const size_t orig_idx = d.arch_to_orig_idx[arch];
+        if (desc.impl_alignment[orig_idx]) {
+            continue; // aligned-only impl: allowed to assume alignment, not under test
+        }
+        summary.applied = true;
+
+        // ---- Reference run: this impl on its ALIGNED pool buffers ----
+        std::vector<void*> abuffs;
+        for (size_t j = 0; j < d.both_sigs.size(); j++) {
+            abuffs.push_back(d.test_data[i][j]);
+        }
+        for (size_t j = 0; j < d.outputsig.size(); j++) {
+            const size_t out_bytes = static_cast<size_t>(vlen) * d.outputsig[j].size *
+                                     (d.outputsig[j].is_complex ? 2 : 1);
+            memset(abuffs[j], 0, out_bytes);
+        }
+        const char* arch_cstr = arch.c_str(); // materialized BEFORE sigsetjmp
+        g_misaligned_sig = 0;
+        // setjmp-clobber discipline: NOTHING may be modified between a sigsetjmp
+        // and its kernel call -- locals changed inside that window are
+        // indeterminate after the longjmp. Each window holds exactly one call.
+        if (sigsetjmp(g_misaligned_jmp, 1) == 0) {
+            g_misaligned_window_open = 1; // volatile global: setjmp-clobber safe
+            run_impl_direct(abuffs, arch_cstr);
+            g_misaligned_window_open = 0;
+        } else {
+            // An "unaligned" impl crashing on ALIGNED buffers is a worse defect
+            // than the one under test -- record it the same way and move on.
+            summary.crashed = true;
+            std::cerr << name << ": impl crashed on ALIGNED buffers on arch " << arch
+                      << " (signal " << static_cast<int>(g_misaligned_sig) << ", vlen "
+                      << vlen << ")\n";
+            continue;
+        }
+
+        // ---- Test run: the SAME impl on misaligned buffers, identical inputs ----
+        std::vector<std::unique_ptr<misaligned_buffer>> mbufs;
+        std::vector<void*> buffs;
+        for (size_t j = 0; j < d.both_sigs.size(); j++) {
+            const size_t elem = d.both_sigs[j].size * (d.both_sigs[j].is_complex ? 2 : 1);
+            const size_t bytes = static_cast<size_t>(vlen) * elem;
+            mbufs.push_back(std::make_unique<misaligned_buffer>(bytes, alignment, elem));
+            buffs.push_back(mbufs.back()->data());
+        }
+        for (size_t j = 0; j < d.outputsig.size(); j++) {
+            const size_t out_bytes = static_cast<size_t>(vlen) * d.outputsig[j].size *
+                                     (d.outputsig[j].is_complex ? 2 : 1);
+            memset(buffs[j], 0, out_bytes);
+        }
+        for (size_t k = 0; k < d.inputsig.size(); k++) {
+            const size_t in_bytes = static_cast<size_t>(vlen) * d.inputsig[k].size *
+                                    (d.inputsig[k].is_complex ? 2 : 1);
+            memcpy(buffs[d.outputsig.size() + k], d.inbuffs[k], in_bytes);
+        }
+
+        g_misaligned_sig = 0;
+        if (sigsetjmp(g_misaligned_jmp, 1) == 0) {
+            g_misaligned_window_open = 1; // volatile global: setjmp-clobber safe
+            run_impl_direct(buffs, arch_cstr);
+            g_misaligned_window_open = 0;
+        } else {
+            summary.crashed = true;
+            std::cerr << name << ": impl crashed on misaligned buffers on arch " << arch
+                      << " (signal " << static_cast<int>(g_misaligned_sig) << ", vlen "
+                      << vlen << ")\n";
+            continue; // recorded FAIL; next impl runs with its own fresh buffers
+        }
+
+        for (size_t j = 0; j < d.both_sigs.size(); j++) {
+            double max_err = 0.0;
+            if (compare_buffer(j, abuffs[j], buffs[j], max_err)) {
+                summary.diverged = true;
+                std::cerr << name << ": output diverged between aligned and "
+                          << "misaligned runs on arch " << arch << " (buffer " << j
+                          << ", vlen " << vlen << ", max_err " << max_err << ")\n";
+            }
+        }
+    }
+
+    return summary;
+}
+#endif // !_WIN32 (POSIX signal isolation, #91)

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -280,6 +280,42 @@ volk_immutability_summary run_volk_immutability_test(
     const std::vector<float>& float_edge_cases = std::vector<float>(),
     const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
 
+// #91: outcome of run_volk_misaligned_test. For every impl the dispatch metadata
+// marks unaligned (impl_alignment == false), the harness runs it on deliberately
+// misaligned (element-aligned, non-volk_get_alignment()-aligned) buffers.
+// `crashed` => the impl raised SIGSEGV/SIGBUS/SIGILL (e.g. movaps on a misaligned
+// address) -- trapped and recorded, the run continues. `diverged` => the SAME
+// impl produced different output on misaligned vs aligned buffers with identical
+// inputs (beyond the kernel's own tol -- alignment is the only variable; the
+// impl-vs-generic accuracy question belongs to the #87 sweep). `applied` is false
+// when no impl could be exercised (unsupported signature / degenerate alignment)
+// -- reported skip, never ok.
+struct volk_misaligned_summary {
+    bool crashed = false;
+    bool diverged = false;
+    bool applied = false;
+};
+
+// #91: misaligned-run check. The fault path (a hardware signal, not a C++
+// exception) is trapped with a scoped SIGSEGV/SIGBUS/SIGILL handler +
+// sigsetjmp/siglongjmp so one crashing impl becomes one recorded FAIL while the
+// run continues. Toggle is in the driver; run_volk_tests / default qa untouched.
+// tol/absolute_mode are the KERNEL'S own comparison parameters (from its
+// volk_test_params_t) -- approximate kernels (log2, expfast, tan, ...) carry
+// looser tolerances than the harness default, and using anything else
+// false-positives them.
+volk_misaligned_summary run_volk_misaligned_test(
+    volk_func_desc_t,
+    void (*)(),
+    std::string,
+    lv_32fc_t,
+    float tol,
+    bool absolute_mode,
+    unsigned int,
+    std::vector<volk_test_results_t>* results = NULL,
+    const std::vector<float>& float_edge_cases = std::vector<float>(),
+    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
+
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \
                    (void (*)())func##_manual,    \

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -254,6 +254,57 @@ static volk_immutability_summary quiet_immutability_run(volk_test_case_t& tc,
     return summary;
 }
 
+// #91: run the misaligned check for one (kernel, vlen) with stdout muted (mirrors
+// quiet_immutability_run). Hardware faults are handled INSIDE
+// run_volk_misaligned_test by the signal path (-> summary.crashed); a C++
+// exception here is non-signal harness plumbing, out of #91 scope -- report it
+// skipped (applied stays false) with a note rather than mislabeling it.
+static volk_misaligned_summary quiet_misaligned_run(volk_test_case_t& tc, unsigned int v)
+{
+    std::vector<volk_test_results_t> results;
+    const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
+    std::fflush(stdout);
+    std::cout.flush();
+    int saved = -1, devnull = -1;
+    if (!verbose) {
+        saved = dup(STDOUT_FILENO);
+        devnull = open(VOLK_DEVNULL, O_WRONLY);
+        if (saved >= 0 && devnull >= 0)
+            dup2(devnull, STDOUT_FILENO);
+    }
+    volk_misaligned_summary summary;
+    bool threw = false;
+    try {
+        summary = run_volk_misaligned_test(tc.desc(),
+                                           tc.kernel_ptr(),
+                                           tc.name(),
+                                           tc.test_parameters().scalar(),
+                                           tc.test_parameters().tol(),
+                                           tc.test_parameters().absolute_mode(),
+                                           v /*vlen*/,
+                                           &results,
+                                           kFloatEdges,
+                                           kComplexEdges);
+    } catch (...) {
+        threw = true;
+        summary = volk_misaligned_summary(); // applied=false -> skip
+    }
+    std::fflush(stdout);
+    std::cout.flush();
+    if (!verbose) {
+        if (saved >= 0) {
+            dup2(saved, STDOUT_FILENO);
+            close(saved);
+        }
+        if (devnull >= 0)
+            close(devnull);
+    }
+    if (threw)
+        std::cerr << "note  [misaligned] " << tc.name() << " threw at vlen " << v
+                  << " (skipped; non-signal exceptions are out of #91 scope)\n";
+    return summary;
+}
+
 int main(int argc, char* argv[])
 {
     const float tol = 1e-6f;
@@ -593,6 +644,157 @@ int main(int argc, char* argv[])
         std::cerr << "\ninput-immutability sweep: " << m_failed << " / " << m_tested
                   << " kernels wrote a byte of an input buffer\n";
         return m_failed > 0 ? 1 : 0;
+    }
+
+    // #91 misaligned-run mode (opt-in via HARNESS_MISALIGNED). Distinct mode like
+    // the #89/#90 siblings; default qa and the toggle-off sweep are untouched.
+    // NOTE (ASan): this mode installs its own SIGSEGV handler inside
+    // run_volk_misaligned_test; under AddressSanitizer run with
+    // ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1
+    // or ASan's handler wins and aborts the run on the first planted fault.
+    const bool misaligned_mode = (std::getenv("HARNESS_MISALIGNED") != nullptr);
+    if (misaligned_mode) {
+        // Hard negative control: ok-kernel must pass misaligned (no over-report);
+        // the planted aligned-load kernel must produce a RECORDED crash while this
+        // process continues to this very check (fault isolation works). Any
+        // deviation = broken detector, exit 2.
+        const unsigned int nc_vlen = 127;
+        std::vector<volk_test_results_t> nc;
+        const volk_misaligned_summary ok_sum =
+            run_volk_misaligned_test(volk_canary_desc(),
+                                     (void (*)())(&volk_32f_canaryok_32f),
+                                     "volk_32f_canaryok_32f",
+                                     scalar,
+                                     tol,
+                                     false /*absolute_mode*/,
+                                     nc_vlen,
+                                     &nc,
+                                     kFloatEdges,
+                                     kComplexEdges);
+        nc.clear();
+        const volk_misaligned_summary fault_sum =
+            run_volk_misaligned_test(volk_canary_desc(),
+                                     (void (*)())(&volk_32f_misalignedfault_32f),
+                                     "volk_32f_misalignedfault_32f",
+                                     scalar,
+                                     tol,
+                                     false /*absolute_mode*/,
+                                     nc_vlen,
+                                     &nc,
+                                     kFloatEdges,
+                                     kComplexEdges);
+        nc.clear();
+        const char* nc_err = nullptr;
+        if (ok_sum.crashed || ok_sum.diverged) {
+            nc_err = "the correct planted kernel volk_32f_canaryok_32f was flagged "
+                     "on misaligned buffers — the detector over-reports";
+        } else if (!fault_sum.applied) {
+            nc_err = "the misaligned mode could not run at all (unsupported "
+                     "platform — POSIX signals required — or unsupported "
+                     "signature/alignment); refusing to report coverage";
+        } else if (!fault_sum.crashed) {
+            nc_err = "the planted aligned-load kernel volk_32f_misalignedfault_32f "
+                     "did not produce a recorded crash — fault isolation is broken "
+                     "or the misalignment never reached the impl";
+        }
+        if (nc_err) {
+            std::cerr << "NEGATIVE CONTROL LOST: " << nc_err << ". Aborting.\n";
+            if (report)
+                std::fclose(report);
+            return 2;
+        }
+        std::cerr << "misaligned negative control OK: ok-kernel clean, aligned-load "
+                     "kernel crash recorded and the run continued.\n";
+
+        // Per-kernel misaligned sweep over the real kernels (unaligned impls only).
+        //   FAIL -> an impl crashed on misaligned buffers or diverged from the
+        //           the SAME impl's aligned run (both always defects).
+        //   skip -> puppet / unsupported signature / nothing observed (fail closed).
+        // Puppets are skipped -- load-bearing here: it is what keeps the longjmp
+        // safety argument airtight (no impl with internal allocation runs under the
+        // signal guard) and keeps #96's conv_k7 out of this mode.
+        std::cout << "# misaligned sweep: vlens 1..40, 131071, 1000003\n";
+        std::cout.flush();
+        int a_tested = 0, a_failed = 0, a_crashed = 0, a_diverged = 0;
+        for (auto& tc : test_cases) {
+            if (!filter.empty() && tc.name() != filter)
+                continue;
+            if (tc.puppet_master_name() != "NULL") {
+                std::cout << "skip  [misaligned] " << tc.name() << " (puppet)\n";
+                if (report)
+                    std::fprintf(report, "%s,misaligned,skip,\n", tc.name().c_str());
+                std::cout.flush();
+                continue;
+            }
+            std::vector<unsigned int> crash_vlens;
+            std::vector<unsigned int> diverge_vlens;
+            bool any_applied = false;
+            for (unsigned int v : vlens) {
+                const volk_misaligned_summary s = quiet_misaligned_run(tc, v);
+                if (s.applied)
+                    any_applied = true;
+                if (s.crashed)
+                    crash_vlens.push_back(v);
+                if (s.diverged)
+                    diverge_vlens.push_back(v);
+            }
+            if (!any_applied && crash_vlens.empty() && diverge_vlens.empty()) {
+                std::cout << "skip  [misaligned] " << tc.name()
+                          << " (no checkable unaligned impl)\n";
+                if (report)
+                    std::fprintf(report, "%s,misaligned,skip,\n", tc.name().c_str());
+                std::cout.flush();
+                continue;
+            }
+            ++a_tested;
+            const char* status;
+            if (!crash_vlens.empty() || !diverge_vlens.empty()) {
+                ++a_failed;
+                if (!crash_vlens.empty())
+                    ++a_crashed;
+                if (!diverge_vlens.empty())
+                    ++a_diverged;
+                status = "FAIL";
+                std::cout << "FAIL  [misaligned] " << tc.name();
+                if (!crash_vlens.empty()) {
+                    std::cout << "  crash vlens:";
+                    for (unsigned int v : crash_vlens)
+                        std::cout << " " << v;
+                }
+                if (!diverge_vlens.empty()) {
+                    std::cout << "  diverge vlens:";
+                    for (unsigned int v : diverge_vlens)
+                        std::cout << " " << v;
+                }
+            } else {
+                status = "ok";
+                std::cout << "ok    [misaligned] " << tc.name();
+            }
+            std::cout << "\n";
+            if (report) {
+                std::string vs;
+                for (unsigned int v : crash_vlens) {
+                    vs += std::to_string(v);
+                    vs += ' ';
+                }
+                for (unsigned int v : diverge_vlens) {
+                    vs += std::to_string(v);
+                    vs += ' ';
+                }
+                std::fprintf(report,
+                             "%s,misaligned,%s,%s\n",
+                             tc.name().c_str(),
+                             status,
+                             vs.c_str());
+            }
+            std::cout.flush();
+        }
+        if (report)
+            std::fclose(report);
+        std::cerr << "\nmisaligned sweep: " << a_crashed << " kernels crashed, "
+                  << a_diverged << " diverged, of " << a_tested
+                  << " tested (unaligned impls only)\n";
+        return a_failed > 0 ? 1 : 0;
     }
 
     std::cout << "# kernel-correctness remainder sweep: vlens 1..40, 131071, 1000003\n";


### PR DESCRIPTION
## Summary

Adds an opt-in **misaligned-run mode** to the kernel-correctness harness (epic #85,
child 5). VOLK qa runs every impl on aligned buffers, so a `_u_` variant that
mistakenly uses an aligned load (`movaps` in a `movups` kernel — a class the first
cleanup pass actually found) never faults in test, then crashes the moment GNU Radio
hands it a sub-buffer slice. `HARNESS_MISALIGNED=1` runs **every impl the dispatch
metadata marks unaligned** (`impl_alignment == false`, not name-matching) on buffers
deliberately offset one element past an alignment boundary — element-aligned but
never `volk_get_alignment()`-aligned, exactly the GNU Radio slice shape — and FAILs
if the impl **crashes** or its output **diverges from the same impl run on aligned
buffers** with identical inputs (alignment is the only variable; the kernel's own
qa tolerance absorbs legitimate peel-reordering).

The fault path is the novel part: a `movaps` on a misaligned address raises
**SIGSEGV — a hardware signal `catch(...)` cannot trap**. A scoped
SIGSEGV/SIGBUS/SIGILL handler + `sigsetjmp`/`siglongjmp` around each impl
invocation turns one crash into one **recorded FAIL while the run continues**
(sound because puppets are skipped, every guarded impl is a pure loop over
harness-owned buffers, the dispatch uses direct casted calls so no C++ frame with
a non-trivial destructor sits inside the jump window, and the handler is **armed
only inside each jump window** — a fault anywhere else re-raises with default
disposition so a harness bug crashes loudly at its true location instead of being
misattributed to a kernel). Toggle **default off**; default qa byte-identical.
Five test-only files; no kernel/signature/ABI/CMake change.

**Platform scope:** the isolation mechanism is POSIX-only (MSVC has no
`sigaction`/`sigsetjmp`/`SIGBUS`). On `_WIN32` the detector compiles to an explicit
"unsupported on this platform" stub (skip, fail-closed): the negative control then
reports that the mode could not run and exits 2 rather than the tree failing to
build — `qa_utils.cc` also compiles into `volk_test_all`, so an unconditional use
would have broken the Windows build of the default qa suite. Two related usage
constraints are documented in-code: do not build the harness with LTO (a compiler
that can prove the planted pointer misaligned may legally lower `_mm_load_ps` to
`movups`; the negative control fails loud if that ever happens), and misaligned
buffers carry 8 elements of tail slack plus a fail-loud malloc check so an
over-writing kernel corrupts our slack, not malloc metadata.

## Related issues

- Closes mtibbits/volk#91 (epic mtibbits/volk#85, child 5 of 6).
- **Stacked on #90** (`feat/90-input-immutability-canary`, PR #97); siblings #87/#88/#89
  (PRs #93/#94/#95) below it. Review the diff against `feat/90`, not `main`.
- Companion to #86 (build-time `_a_`/`_u_` twin completeness): #86 proves the twin
  *exists*, this proves it is *unaligned-safe*.
- Fork-local issue numbers; re-link on any upstream submission.

## Testing

- **Negative control (hard gate):** stub detector → `NEGATIVE CONTROL LOST … did not
  produce a recorded crash`, exit 2 (RED — the control has signal). Real detector →
  the planted `volk_32f_misalignedfault_32f` (genuine `_mm_load_ps` under `__SSE2__`;
  `raise(SIGSEGV)` fallback elsewhere) crashes with **signal 11, recorded on stderr,
  and the process continues** to `negative control OK`, exit 0 — the issue's central
  contract, proven end-to-end. The ok-control runs misaligned without being flagged.
- **Full sweep (113 kernels, puppets skipped):** **0 crashed** — the cleanup pass's
  `_a`-intrinsics-in-`_u`-kernels fixes hold; this mode is now their standing
  regression guard. **1 real finding, filed as #98:** `volk_32f_x3_sum_of_poly_32f`
  diverges **nondeterministically** at vlen 1–4 on every impl *including generic* —
  the kernel reads its fixed 5-coefficient `center_point_array[0..4]` (its
  documented contract), but the newer harness modes (#89/#90/#91) bypass the
  `vlen_twiddle = 5` over-allocation `run_volk_tests` uses, so at vlen<5 the reads
  land on in-allocation-but-unseeded bytes and this mode's two-allocation
  comparison sees two different garbage sources. **As shipped, the sweep's exit
  code flips with allocator state on that kernel (observed both 0 and 1 across
  runs); green is expected once #98 lands.** Fix out of scope here (harness
  modeling, not this mode).
- **Default qa byte-identical:** `ctest -R qa_` = **154/154**.
- **ASan** (needs `ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1`,
  documented in the driver — ASan's own SEGV handler otherwise wins): 0 errors,
  negative control OK, exit 0.
- **UBSan:** exactly one report — `load of misaligned address … requires 16 byte
  alignment` **inside the planted defect kernel**, i.e. UBSan independently
  confirming the control does what it claims (recoverable; run completes; no
  findings in harness code). Analogous to #89's deliberate-UB ASan demo.
- **Analyze step:** ASan/UBSan ctest suites exit 0; TSan 253/254 with the one
  failure being the known pre-existing `qa_volk_32f_log2_32f` flake (no
  ThreadSanitizer reports). cppcheck: **0 findings in new code**.
- **clang-format:** clean.

## Reviewer notes

- **Comparison design — same impl, aligned vs misaligned:** an earlier draft compared
  misaligned impls against the aligned *generic* baseline; the sweep immediately
  showed why that's wrong (30 false FAILs: reduction-output garbage, approximate-
  kernel tolerances, summation-order spreads at vlen=10⁶ — all impl-vs-generic
  questions that belong to #87's sweep). Running the **same impl twice** isolates
  alignment as the only variable. Output buffers are zero-prefilled on both sides
  (output cardinality is signature-underivable — #89's lesson), and the comparison
  uses the kernel's own qa tolerance via new `tol`/`absolute_mode` parameters.
- **The dispatch inside the jump window uses direct casted function-pointer calls**
  (`run_impl_direct`), deliberately NOT the `run_cast_testN` wrappers whose by-value
  `std::string` would be longjmp'd over (UB). The `_s32fc` forms pass the scalar by
  pointer, matching the typedefs. Don't "harmonize" this back during any future dedup.
- **Knowingly the 4th copy** of the sibling scaffolding (signature guards, fd-mute
  wrapper, sweep skeleton; the per-type compare replicates `run_volk_tests`').
  Consolidation is tracked in `Issue-Fork-90/imPlan-potentialFutureEnhancements.md`
  (shared dispatch + RAII mute, natural trigger = the #92 closeout) — with the
  constraint that this mode's dispatch must stay destructor-free per the previous
  note.
- **MSVC portability:** the fd-muting `VOLK_DEVNULL`/`_dup` mapping now lives at the
  #87 layer (where the muting helpers were born) so the whole stack builds on
  Windows bottom-up; this PR's helper simply uses it. (Relocated from an earlier
  draft of this PR per red-team review; build-windows was red from PR #93 onward
  until the relocation.)
- **Pre-existing, NOT introduced here:** the *toggle-off* full-catalog run still
  aborts at conv_k7 (#96); this mode skips puppets and is unaffected.

## Checklist
- [x] Builds cleanly (`cmake --build`) — release, ASan, UBSan, TSan
- [x] Tests pass (`ctest -R qa_` 154/154; negative control RED→GREEN; sweep recorded)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — opt-in misaligned-run mode, test-only files
