### PR TITLE
conv_k7 puppet decision buffer overflow

### DIFF
--- a/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
+++ b/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
@@ -126,8 +126,6 @@ static inline void volk_8u_conv_k7_r2puppet_8u_spiral(unsigned char* dec,
         Y = X + d_numstates;
         Branchtab =
             (unsigned char*)volk_malloc(d_numstates / 2 * rate, volk_get_alignment());
-        D = (unsigned char*)volk_malloc((d_numstates / 8) * (framebits + 6),
-                                        volk_get_alignment());
         int state, i;
 
         /*  Initialize the branch table */
@@ -144,8 +142,17 @@ static inline void volk_8u_conv_k7_r2puppet_8u_spiral(unsigned char* dec,
     // unbias the old_metrics
     memset(X, 31, d_numstates);
 
+    // (re)size the decision buffer to the current framebits; grows monotonically
+    static size_t D_size = 0;
+    size_t d_decisions_size = (size_t)(d_numstates / 8) * ((size_t)framebits + 6);
+    if (d_decisions_size > D_size) {
+        volk_free(D); /* volk_free(NULL) is safe on the first call */
+        D = (unsigned char*)volk_malloc(d_decisions_size, volk_get_alignment());
+        D_size = D ? d_decisions_size : 0; /* don't record size if alloc failed */
+    }
+
     // initialize decisions
-    memset(D, 0, (d_numstates / 8) * (framebits + 6));
+    memset(D, 0, d_decisions_size);
 
     volk_8u_x4_conv_k7_r2_8u_spiral(
         Y, X, syms, D, framebits / 2 - excess, excess, Branchtab);
@@ -195,8 +202,6 @@ static inline void volk_8u_conv_k7_r2puppet_8u_neonspiral(unsigned char* dec,
         Y = X + d_numstates;
         Branchtab =
             (unsigned char*)volk_malloc(d_numstates / 2 * rate, volk_get_alignment());
-        D = (unsigned char*)volk_malloc((d_numstates / 8) * (framebits + 6),
-                                        volk_get_alignment());
         int state, i;
 
         /*  Initialize the branch table */
@@ -213,8 +218,17 @@ static inline void volk_8u_conv_k7_r2puppet_8u_neonspiral(unsigned char* dec,
     // unbias the old_metrics
     memset(X, 31, d_numstates);
 
+    // (re)size the decision buffer to the current framebits; grows monotonically
+    static size_t D_size = 0;
+    size_t d_decisions_size = (size_t)(d_numstates / 8) * ((size_t)framebits + 6);
+    if (d_decisions_size > D_size) {
+        volk_free(D); /* volk_free(NULL) is safe on the first call */
+        D = (unsigned char*)volk_malloc(d_decisions_size, volk_get_alignment());
+        D_size = D ? d_decisions_size : 0; /* don't record size if alloc failed */
+    }
+
     // initialize decisions
-    memset(D, 0, (d_numstates / 8) * (framebits + 6));
+    memset(D, 0, d_decisions_size);
 
     volk_8u_x4_conv_k7_r2_8u_neonspiral(
         Y, X, syms, D, framebits / 2 - excess, excess, Branchtab);
@@ -267,8 +281,6 @@ static inline void volk_8u_conv_k7_r2puppet_8u_avx2(unsigned char* dec,
         Y = X + d_numstates;
         Branchtab =
             (unsigned char*)volk_malloc(d_numstates / 2 * rate, volk_get_alignment());
-        D = (unsigned char*)volk_malloc((d_numstates / 8) * (framebits + 6),
-                                        volk_get_alignment());
         int state, i;
 
         /*  Initialize the branch table */
@@ -285,8 +297,17 @@ static inline void volk_8u_conv_k7_r2puppet_8u_avx2(unsigned char* dec,
     // unbias the old_metrics
     memset(X, 31, d_numstates);
 
+    // (re)size the decision buffer to the current framebits; grows monotonically
+    static size_t D_size = 0;
+    size_t d_decisions_size = (size_t)(d_numstates / 8) * ((size_t)framebits + 6);
+    if (d_decisions_size > D_size) {
+        volk_free(D); /* volk_free(NULL) is safe on the first call */
+        D = (unsigned char*)volk_malloc(d_decisions_size, volk_get_alignment());
+        D_size = D ? d_decisions_size : 0; /* don't record size if alloc failed */
+    }
+
     // initialize decisions
-    memset(D, 0, (d_numstates / 8) * (framebits + 6));
+    memset(D, 0, d_decisions_size);
 
     volk_8u_x4_conv_k7_r2_8u_avx2(
         Y, X, syms, D, framebits / 2 - excess, excess, Branchtab);
@@ -337,8 +358,6 @@ static inline void volk_8u_conv_k7_r2puppet_8u_generic(unsigned char* dec,
         Y = X + d_numstates;
         Branchtab =
             (unsigned char*)volk_malloc(d_numstates / 2 * rate, volk_get_alignment());
-        D = (unsigned char*)volk_malloc((d_numstates / 8) * (framebits + 6),
-                                        volk_get_alignment());
 
         int state, i;
 
@@ -356,8 +375,17 @@ static inline void volk_8u_conv_k7_r2puppet_8u_generic(unsigned char* dec,
     // unbias the old_metrics
     memset(X, 31, d_numstates);
 
+    // (re)size the decision buffer to the current framebits; grows monotonically
+    static size_t D_size = 0;
+    size_t d_decisions_size = (size_t)(d_numstates / 8) * ((size_t)framebits + 6);
+    if (d_decisions_size > D_size) {
+        volk_free(D); /* volk_free(NULL) is safe on the first call */
+        D = (unsigned char*)volk_malloc(d_decisions_size, volk_get_alignment());
+        D_size = D ? d_decisions_size : 0; /* don't record size if alloc failed */
+    }
+
     // initialize decisions
-    memset(D, 0, (d_numstates / 8) * (framebits + 6));
+    memset(D, 0, d_decisions_size);
 
     volk_8u_x4_conv_k7_r2_8u_generic(
         Y, X, syms, D, framebits / 2 - excess, excess, Branchtab);
@@ -402,8 +430,6 @@ static inline void volk_8u_conv_k7_r2puppet_8u_rvv(unsigned char* dec,
         X = (unsigned char*)volk_malloc(3 * d_numstates, volk_get_alignment());
         Y = X + d_numstates;
         Branchtab = Y + d_numstates;
-        D = (unsigned char*)volk_malloc((d_numstates / 8) * (framebits + 6),
-                                        volk_get_alignment());
 
         /*  Initialize the branch table */
         for (size_t state = 0; state < d_numstates / 2; state++) {
@@ -412,8 +438,18 @@ static inline void volk_8u_conv_k7_r2puppet_8u_rvv(unsigned char* dec,
         }
     }
 
-    memset(X, 31, d_numstates);                        // unbias the old_metrics
-    memset(D, 0, (d_numstates / 8) * (framebits + 6)); // initialize decisions
+    memset(X, 31, d_numstates); // unbias the old_metrics
+
+    // (re)size the decision buffer to the current framebits; grows monotonically
+    static size_t D_size = 0;
+    size_t d_decisions_size = (size_t)(d_numstates / 8) * ((size_t)framebits + 6);
+    if (d_decisions_size > D_size) {
+        volk_free(D); /* volk_free(NULL) is safe on the first call */
+        D = (unsigned char*)volk_malloc(d_decisions_size, volk_get_alignment());
+        D_size = D ? d_decisions_size : 0; /* don't record size if alloc failed */
+    }
+
+    memset(D, 0, d_decisions_size); // initialize decisions
 
     volk_8u_x4_conv_k7_r2_8u_rvv(
         Y, X, syms, D, framebits / 2 - excess, excess, Branchtab);


### PR DESCRIPTION
## Summary

Fixes a heap-buffer-overflow in `volk_8u_conv_k7_r2puppet_8u`. In all five impl variants
(spiral / neonspiral / avx2 / generic / rvv) the Viterbi decision buffer `D` was allocated
exactly once under a `static int once` latch, sized from the **first** guard-passing call's
`framebits` — but every subsequent call `memset`s and writes `(d_numstates/8)*(framebits+6)`
bytes using the **current** call's `framebits`. Any call sequence with a larger `framebits`
than the first overflows the heap. The fix pulls `D` out of the `once` latch and sizes it
**grow-on-demand**: a per-variant `static size_t D_size` tracks the allocated byte count and
`D` is reallocated only when the current call needs more than is allocated. This preserves the
original allocate-and-reuse caching (buffer grows monotonically, never reallocates on the common
fixed-`framebits` path) while guaranteeing the write target is always large enough. No
signature/ABI change; the worker kernels and `chainback_viterbi` are untouched.

## Related issues

Closes #96.

Distinct from #44 (same kernel family, different defect: `BFLY` over-indexing `decision_t::w`).
Two pre-existing, out-of-scope items were surfaced during this work and captured as follow-ups
(see `imPlan-potentialFutureEnhancements.md`): a `chainback_viterbi` uninitialized-`retval`
path, and a hard SEGV in `volk_32fc_s32fc_rotator2puppet_32fc_u_avx512f` that aborts the full
ASan correctness sweep independently of this kernel.

## Testing

Verified with the #87 multi-vlen `volk_test_correctness` harness on a 64-byte-alignment x86-64 host
(RED on the unfixed tree, GREEN after the fix copied in; same tree, controlled comparison):

- **AddressSanitizer, single-kernel sweep (vlens 1..40, 131071, 1000003):**
  - Before: deterministic `heap-buffer-overflow`, `WRITE of size 200 … 0 bytes after 192-byte
    region` in `memset`; the overflowing write **and** the allocation are both inside the same
    `volk_8u_conv_k7_r2puppet_8u_generic` (two different `framebits`, one once-latched buffer).
  - After: exit 0, **0 ASan reports**, reaches the largest vlen 1000003, `0 / 1 kernels failed`.
- **No behavioral regression:** non-ASan build, `ctest -R qa_volk_8u_conv_k7_r2puppet_8u` →
  **Passed**. The fix grows the buffer (it does not reject/no-op larger sizes), so decoded output
  is unchanged at every `framebits`.
- **All five variants:** generic/spiral/avx2 built and ASan-exercised on x86-64. **neonspiral
  cross-compile PASS** (`arm-linux-gnueabihf-gcc -march=armv7-a -mfpu=neon`, `nm` resolves the
  symbol). **rvv** grow-block compiles clean for `riscv64 -march=rv64gcv -Wall -Wextra` in
  isolation and is byte-identical to the validated variants by inspection (full rvv-path
  cross-compile is blocked only by the untouched worker header's GCC-13-unsupported RVV
  intrinsics — pre-existing).
- **Static analysis (changed-line scope):** gcc + clang `-Wall -Wextra -Wconversion
  -Wsign-conversion` → **0 warnings originate from the added code**; the change net-reduces the
  strict-flag warning count 31 → 29.

## Size-math hardening (note for reviewers)

The size is computed entirely in `size_t`: `(size_t)(d_numstates / 8) * ((size_t)framebits + 6)`.
Casting `framebits` **before** the `+ 6` (not just before the multiply) is deliberate — in
32-bit `unsigned int` a near-`UINT_MAX` `framebits` would wrap on the `+ 6`, under-allocate, and
let the worker overflow, reopening the very bug this fixes. On allocation failure `D_size` is left
at `0` (`D_size = D ? d_decisions_size : 0;`) so an OOM cannot falsely record the buffer as
allocated and poison every later call; VOLK does not check `volk_malloc` returns elsewhere, so no
new error return is introduced — only the persistent-state poisoning is avoided.

## Coverage (honest scope)

The bug only manifests across a **growing-`framebits` call sequence within one process**. The
upstream `qa_volk_8u_conv_k7_r2puppet_8u` drives the puppet at a **single fixed vlen**, so it
passes both before and after and **cannot trigger or guard this bug** — it is cited only as a
no-behavioral-regression check, not as coverage of the fix. The actual RED→GREEN proof is the
fork's #87 multi-vlen `volk_test_correctness` harness, which lives in the fork integration branch
this change merges into (`dev/all-prs`), not in this diff. Adding an in-tree multi-vlen regression
test to the qa infrastructure is tracked as a follow-up (`imPlan-potentialFutureEnhancements.md`)
rather than bundled here, to keep this diff surgical.

Acceptance criterion 2 (full default-mode sweep "runs past this kernel") could **not** be
demonstrated end-to-end: the full ASan sweep aborts on an unrelated, pre-existing
`volk_32fc_s32fc_rotator2puppet_32fc_u_avx512f` SEGV *before* reaching conv_k7 (identical abort on
the unfixed tree). No ASan report originates in the puppet header. That blocker is captured as a
separate follow-up; conv_k7's heap-cleanliness is fully proven by the single-kernel sweep above.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
