### PR TITLE
Align rotator2 SIMD phase_Ptr scratch arrays to vector width

### DIFF
--- a/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
@@ -302,7 +302,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx(lv_32fc_t* outVector,
     lv_32fc_t incr = lv_cmake((float)cos(delta4), (float)sin(delta4));
 
     __m256 aVal, phase_Val, z;
-    lv_32fc_t phase_Ptr[4];
+    __VOLK_ATTR_ALIGNED(32) lv_32fc_t phase_Ptr[4];
 
     const __m256 inc_Val = _mm256_set_ps(lv_cimag(incr),
                                          lv_creal(incr),
@@ -449,7 +449,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx(lv_32fc_t* outVector,
     lv_32fc_t incr = lv_cmake((float)cos(delta4), (float)sin(delta4));
 
     __m256 aVal, phase_Val, z;
-    lv_32fc_t phase_Ptr[4];
+    __VOLK_ATTR_ALIGNED(32) lv_32fc_t phase_Ptr[4];
 
     const __m256 inc_Val = _mm256_set_ps(lv_cimag(incr),
                                          lv_creal(incr),
@@ -730,7 +730,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx512f(lv_32fc_t* outVect
     lv_32fc_t incr = lv_cmake((float)cos(delta8), (float)sin(delta8));
 
     __m512 aVal, phase_Val, z;
-    lv_32fc_t phase_Ptr[8];
+    __VOLK_ATTR_ALIGNED(64) lv_32fc_t phase_Ptr[8];
 
     const __m512 inc_Val = _mm512_set_ps(lv_cimag(incr),
                                          lv_creal(incr),


### PR DESCRIPTION
## Summary

Fixes #101. The unaligned AVX/AVX-512 variants of `volk_32fc_s32fc_x2_rotator2_32fc` declare the local scratch array `phase_Ptr` without an alignment attribute and load it via `_mmN_loadu_ps`. At `-O2`/`-O3` GCC lowers that unaligned intrinsic to an **aligned** `vmovaps`; when the stack places `phase_Ptr` below the vector-width alignment the aligned 512/256-bit load `#GP`-faults → SIGSEGV. It is **deterministic under AddressSanitizer** (its stack-frame instrumentation under-aligns the array, aborting the correctness sweep at this kernel) and a latent fault otherwise.

## Fix

Add `__VOLK_ATTR_ALIGNED` to all four `phase_Ptr` declarations so storage alignment matches the access width regardless of stack layout:
- `_a_avx` / `_u_avx` (256-bit, `phase_Ptr[4]`) → `ALIGNED(32)`
- `_u_avx512f` (512-bit, `phase_Ptr[8]`) → `ALIGNED(64)`
- `_a_avx512f` already had `ALIGNED(64)` (unchanged)

No ABI/signature/precision change — `phase_Ptr` is a function-local scratch array; alignment changes only its address, never its contents.

## Verification

- **ASan isolation repro** (exact-size buffers, `-O2 -fsanitize=address`): both `_u` variants now run clean for vlens 1..40 — was a deterministic SIGSEGV at vlen=1 (`vmovaps` on a 32-byte-aligned address).
- `ctest -R qa_volk_32fc_s32fc_rotator2puppet_32fc` passes (no precision regression).
- A new static lint (separate PR) for `loadu`-of-under-aligned-local-array reports zero findings after this change.

## Note on coverage

A stock `ctest` passes with or without this fix (the fault is stack-layout dependent); the effective regression gate is the AddressSanitizer correctness sweep.