### PR TITLE
qa: impl-mode sweep judges kernels against their registered QA contracts

### DIFF
--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -113,6 +113,7 @@ quiet_run(volk_test_case_t& tc,
           const volk_reference_entry* ref,
           float tol,
           lv_32fc_t scalar,
+          bool absolute_mode,
           int iter,
           unsigned int v,
           const std::vector<float>& fedges = kFloatEdges,
@@ -155,7 +156,7 @@ quiet_run(volk_test_case_t& tc,
                                   iter,
                                   &results,
                                   tc.puppet_master_name(),
-                                  false /*absolute_mode*/,
+                                  absolute_mode,
                                   false /*benchmark_mode*/,
                                   fedges,
                                   cedges);
@@ -987,7 +988,8 @@ int main(int argc, char* argv[])
                             const std::vector<lv_32fc_t>& ce) {
             bool flagged = false;
             for (unsigned int v : nc_vlens)
-                flagged |= quiet_run(tc, ref, tol_, power_scalar, 1, v, fe, ce);
+                flagged |= quiet_run(
+                    tc, ref, tol_, power_scalar, false /*absolute_mode*/, 1, v, fe, ce);
             return flagged;
         };
 
@@ -1073,10 +1075,14 @@ int main(int argc, char* argv[])
         // the rest fall back to the impl-vs-impl comparison.
         const volk_reference_entry* ref = volk_reference_lookup(tc.name());
         const char* mode = ref ? "ref" : "impl";
-        // Reference mode needs the kernel's OWN scalar (e.g. power exponent 2.5, not
-        // the driver default 327 — which would overflow |x|^327 to inf and mask the
-        // defect). Impl mode keeps the driver default to preserve #87's sweep.
-        const lv_32fc_t kscalar = ref ? tc.test_parameters().scalar() : scalar;
+        // The sweep judges each kernel against its OWN registered QA contract
+        // (#106): scalar always (driver-default 327 turns power into inf and
+        // clamp into an inverted range), tol/absolute_mode in impl mode only —
+        // ref mode ignores them (the oracle applies the registry entry's bound).
+        volk_test_params_t kp = tc.test_parameters(); // accessors are non-const
+        const lv_32fc_t kscalar = kp.scalar();
+        const float ktol = ref ? tol : kp.tol();
+        const bool kabs = ref ? false : kp.absolute_mode();
         std::vector<unsigned int> bad;
         std::set<std::string> impls_seen;
         std::map<std::string, std::vector<unsigned int>> impl_fails;
@@ -1085,8 +1091,9 @@ int main(int argc, char* argv[])
             // per-(kernel,vlen) map building when no report was requested.
             if (quiet_run(tc,
                           ref,
-                          tol,
+                          ktol,
                           kscalar,
+                          kabs,
                           iter,
                           v,
                           kFloatEdges,


### PR DESCRIPTION
# Issue-Fork-106 — MR draft (Phase A)

**Branch:** `fix/106-impl-mode-sweep-per-kernel-params`
(one commit, based on `dev/all-prs`)
**PR base:** `dev/all-prs` (one-commit reviewable diff; same base as
PRs #49 and #50). **Title:**

> qa: impl-mode sweep judges kernels against their registered QA contracts

## Body

Fixes #106 (issue closes manually after the Phase B snapshot regen).

The #87 correctness sweep's impl-vs-impl mode applied the driver's
file-scope defaults — `tol = 1e-6`, `scalar = 327`,
`absolute_mode = false` — instead of each kernel's own QA
registration. Consequences in the checked-in 2026-06-11 triage
snapshot: reciprocal's `rcp14` impls judged at 1e-6 against their
**registered 6.15e-5 contract** (the bound QA had already
adjudicated), expfast at 1e-6 vs its registered 1e-1, and
scalar-parameterized kernels ran degenerate inputs (clamp:
`min=327 > max=-327`, an inverted range; rotator2puppet normalizes the
driver's 327+0i to a **zero-angle rotation** — its pre-fix `ok` row
was vacuous, and the registered `polar(1, 0.1)` makes the sweep test
it for real for the first time). Ref mode already used the
kernel's own scalar; this brings impl mode to parity with it and with
the misaligned mode (which consumes `tol`/`absolute_mode`/`scalar`
per-kernel since #91).

**Change** (one file, +14/−7, `lib/test_correctness.cc`):
- the sweep loop derives `tol`/`scalar`/`absolute_mode` from
  `tc.test_parameters()` in impl mode (ref mode ignores
  tol/absolute_mode by design — the oracle applies the registry
  entry's own bound);
- `quiet_run()` gains an explicit **no-default** `absolute_mode`
  parameter, so every call site states its choice; the negative
  control's lambda keeps its deliberate self-contained literals.

**Evidence** (archived in the issue record, exemplar runs pre/post):
| Kernel (registered contract) | Pre-fix | Post-fix |
|---|---|---|
| reciprocal (6.15e-5, the rcp14 bound) | 2 FAIL rows | **cleared** |
| expfast (1e-1) | 6 FAIL | **cleared** |
| atan (1e-6 baseline — control) | 8 FAIL | **8 FAIL — survives**, proving no blanket loosening |
| tan (1e-2) | 6 FAIL | **6 FAIL — survives its own contract**: #110 reclassified genuine, not artifact |
| x2_dot_prod (**absolute** 1.5e-2 — exercises the `absolute_mode` flip) | 12 FAIL (snapshot) | **cleared** — first executed evidence of the kabs path; 8 absolute-mode kernels hold 53/104 of the snapshot's impl FAILs, Phase B adjudicates the rest |

`qa_harness_negative_control` 1/1 (planted controls are
self-contained); full ctest 255/255; default qa (`volk_test_all`)
untouched — it does not link this driver.

**What this does NOT do:** regenerate the snapshot. That happens once,
after #133 (ref-mode fail-open), #134 (HARNESS_SEED — so the new
snapshot is reproducible), and #135 (max_err column) land, followed by
the three-bucket re-triage of campaign children #107–#128 (cleared /
survived / NEW-under-stricter-contracts).

Caveats: (1) qa data re-randomizes per run (snapshot docs), so the
exemplar evidence compares kernel/impl FAIL *sets*, not exact vlen
lists; (2) contract parity here covers tol/scalar/absolute_mode — the
sweep still injects its own adversarial `kFloatEdges`/`kComplexEdges`
rather than registered edge cases, by design (#87's edge capability).

## Ship mechanics
- [ ] push branch to fork; open PR base `dev/all-prs`, title above
- [ ] do NOT close #106 (Phase B owns the close)
- [ ] after ship: Phase B gate check (#133/#134/#135) → park if unmet

