### PR TITLE
qa: HARNESS_SEED pins harness data for reproducible triage snapshots

### DIFF
--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -163,3 +163,24 @@ Retention: latest snapshot only — a new snapshot replaces the old files
 - **Default qa:** `volk_test_all` and the per-kernel `qa_volk_*` ctests are
   byte-for-byte unaffected by every capability here; all harness behavior is
   opt-in via the env toggles.
+
+## Reproducibility (`HARNESS_SEED`)
+
+`tools/run_harness_triage.py --seed N` (or an exported `HARNESS_SEED`)
+pins the qa input data: the runner derives a distinct deterministic
+seed per (kernel, mode) child process (`crc32`-mixed), and
+`load_random_data` then draws from one per-process seeded stream, so
+identical seeds reproduce identical rows — including the
+`failed_vlens` lists that otherwise flicker at tolerance margins.
+Unset (the default, including everything ctest runs) the data is
+re-randomized per run, exactly as before. Because `load_random_data`
+is shared, an exported `HARNESS_SEED` also pins default-qa
+(`volk_test_all`) and `volk_profile` input data — a side effect, by
+design. Snapshot summaries must record the seed used. Caveat: kernels
+that read memory outside their seeded buffers (e.g. the #98
+`sum_of_poly` defect) can still vary between identical-seed runs —
+that variance is itself evidence of an out-of-bounds read.
+(The shared `load_random_data` also serves `volk_ulp_profile` and the
+per-kernel `qa_volk_*` ctests: an exported seed pins those too, and
+in multi-kernel loops the per-process stream makes results
+deterministic but iteration-order-coupled.)

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -62,8 +62,23 @@ void load_random_data(void* data,
                       const std::vector<float>& float_edge_cases,
                       const std::vector<lv_32fc_t>& complex_edge_cases)
 {
-    std::random_device rnd_device;
-    std::default_random_engine rnd_engine(rnd_device());
+    // #134: HARNESS_SEED pins the data for reproducible triage snapshots.
+    // The triage runner exports a distinct per-(kernel,mode) value derived
+    // from the user's seed; the engine is static so successive
+    // per-(kernel,vlen) fills continue one stream instead of restarting it.
+    // Unset (the default, including all of testqa): a fresh random_device
+    // draw per call — behavior unchanged.
+    std::default_random_engine unseeded;
+    std::default_random_engine* engine_ptr = &unseeded;
+    if (const char* seed_env = std::getenv("HARNESS_SEED")) {
+        static std::default_random_engine seeded(
+            static_cast<unsigned long>(std::strtoul(seed_env, nullptr, 10)));
+        engine_ptr = &seeded;
+    } else {
+        std::random_device rnd_device;
+        unseeded.seed(rnd_device());
+    }
+    std::default_random_engine& rnd_engine = *engine_ptr;
 
     unsigned int edge_case_count = 0;
 

--- a/tools/run_harness_triage.py
+++ b/tools/run_harness_triage.py
@@ -32,6 +32,7 @@ import os
 import signal
 import subprocess
 import sys
+import zlib
 
 MODES = {
     "sweep": {},  # default correctness sweep (ref|impl per registration)
@@ -69,7 +70,7 @@ def read_report_rows(report):
     return rows
 
 
-def run_one(binary, libdir, kernel, mode, timeout, tmpdir):
+def run_one(binary, libdir, kernel, mode, timeout, tmpdir, base_seed=None):
     report = os.path.join(tmpdir, f"{kernel}.{mode}.csv")
     # A process killed before fopen would otherwise merge a PRIOR invocation's
     # rows for this (kernel, mode).
@@ -80,6 +81,13 @@ def run_one(binary, libdir, kernel, mode, timeout, tmpdir):
     env = dict(os.environ)
     env["LD_LIBRARY_PATH"] = libdir + os.pathsep + env.get("LD_LIBRARY_PATH", "")
     env["HARNESS_REPORT"] = report
+    # #134: derive a distinct deterministic seed per (kernel, mode) child;
+    # zlib.crc32 is stable across runs/platforms (Python's hash() is salted).
+    if base_seed is not None:
+        child = (base_seed * 1000003 ^ zlib.crc32(f"{kernel}.{mode}".encode())) & 0x7FFFFFFF
+        env["HARNESS_SEED"] = str(child)
+    else:
+        env.pop("HARNESS_SEED", None)  # ambient export must not half-seed a run
     env.update(MODES[mode])
     if mode == "misaligned":
         # the misaligned mode's own SIGSEGV handler must win over ASan's
@@ -126,7 +134,20 @@ def main():
     ap.add_argument("--jobs", type=int, default=os.cpu_count() or 4)
     ap.add_argument("--timeout", type=int, default=900)
     ap.add_argument("--only", default="")
+    ap.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="pin qa data deterministically; per-(kernel,mode) child seeds are "
+        "derived from this value (falls back to HARNESS_SEED in the env)",
+    )
     args = ap.parse_args()
+    base_seed = args.seed
+    if base_seed is None and os.environ.get("HARNESS_SEED"):
+        try:
+            base_seed = int(os.environ["HARNESS_SEED"])
+        except ValueError:
+            sys.exit(f"HARNESS_SEED must be an integer, got: {os.environ['HARNESS_SEED']!r}")
 
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     libdir = os.path.join(os.path.abspath(args.build_dir), "lib")
@@ -153,7 +174,7 @@ def main():
     all_rows = []
     with cf.ThreadPoolExecutor(max_workers=args.jobs) as ex:
         futs = [
-            ex.submit(run_one, binary, libdir, k, m, args.timeout, tmpdir)
+            ex.submit(run_one, binary, libdir, k, m, args.timeout, tmpdir, base_seed)
             for (k, m) in jobs
         ]
         done = 0
@@ -173,6 +194,8 @@ def main():
         w.writerow(HEADER)
         w.writerows(all_rows)
     n_find = sum(1 for r in all_rows if r[3] in ("FAIL", "abort"))
+    seed_desc = base_seed if base_seed is not None else "none (re-randomized)"
+    print(f"# seed={seed_desc}", file=sys.stderr)
     print(
         f"# wrote {args.out}: {len(all_rows)} rows, "
         f"{n_find} FAIL/abort finding rows",


### PR DESCRIPTION
# Issue-Fork-134 — MR draft

**Branch:** `feat/134-harness-seed-reproducible-snapshots`
(one commit, based on `dev/all-prs`). **PR base:**
`dev/all-prs` (same as #49/#50/#140). **Title:**

> qa: HARNESS_SEED pins harness data for reproducible triage snapshots

## Body

Closes #134 (manual close after merge — non-default base branch).
Phase-B gate companion 1 of 3 for #106 (with #133, #135).

`load_random_data` seeded every call from `std::random_device`, so
each triage run drew fresh data and near-tolerance findings flickered
between runs — the checked-in snapshot is one unrepeatable sample, and
the #105 campaign is about to adjudicate ~23 children against it.

**Change** (3 files, +59/−4):
- `lib/qa_utils.cc`: with `HARNESS_SEED` set, draws from a per-process
  static engine seeded once from the env value (streams continue
  across per-(kernel,vlen) fills, so vlens get distinct data). Unset —
  the default, including everything ctest runs — keeps the per-call
  `random_device` engine byte-for-byte.
- `tools/run_harness_triage.py`: `--seed N` (env fallback, clear error
  on garbage); derives a distinct deterministic child seed per
  (kernel, mode) process (`crc32`-mixed — Python's `hash()` is
  salted); scrubs ambient `HARNESS_SEED` when unseeded so a shell
  export can't half-seed a run; prints the seed for provenance.
- `docs/kernel_correctness_harness/README.md`: reproducibility
  paragraph, incl. the shared-`load_random_data` side effect (an
  exported seed also pins `volk_test_all`/`volk_profile` inputs) and
  the OOB-read caveat below.

**Evidence** (issue record, provenance-headed):
- seed 42 ×2 → **tan + x2_dot_prod rows byte-identical** incl. the
  `failed_vlens` lists that flicker today.
- **sum_of_poly's misaligned rows still flicker under identical
  seeds** — inputs pinned, so the variance comes from the kernel's #98
  out-of-bounds read of *unseeded adjacent memory*. Not a defect of
  this change: it is the sharpest #98 evidence yet (noted on #98).
- child seeds are distinct **by construction** (crc32 derivation;
  row-level projection can't demonstrate stream difference — the only
  sensitive rows are the #98 flickerers); garbage `HARNESS_SEED` →
  clean error; NC 1/1; full ctest 255/255 env-unset; ASan/TSan
  255/255; UBSan 254/255 = the known pre-existing log2 tolerance
  flake (non-causal: env-unset path is behavior-identical).

CSV format untouched (#135 owns format changes); the seed reaches the
snapshot summary as prose + runner stdout.

## Ship mechanics
- [ ] push branch; PR base dev/all-prs; title above
- [ ] comment on #98 citing determinism-note.md (identical-seed
      flicker isolates the OOB read) — one line, fork-side
- [ ] do NOT auto-close #134; close after mergetoall with commit refs

