### PR TITLE
ref-mode fail-closed on unsupported shape

### DIFF
--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -134,6 +134,16 @@ With `HARNESS_REPORT=path` every mode writes
 kernel-level (skips, or failures not attributable to one impl, e.g. an
 exception mid-run). `failed_vlens` is space-separated.
 
+Reference mode (`ref`) reports `skip` — **not** a silent `ok` — when the oracle
+cannot evaluate a registered kernel's shape (`#133`): a
+`<kernel>,-,ref,skip,<reason>` row whose `failed_vlens` column carries the
+reason (`unsupported-scalar-signature`, `unsupported-arity`, or
+`ref-setup-failed`) instead of vlens. This makes a kernel the oracle could not
+run distinguishable from one it ran and passed — important as the reference
+registry grows (each Class-B adjudication adds an oracle, and a newly-registered
+unsupported shape must surface as a coverage gap, not a false `ok`). The CI
+combined negative control asserts this path stays a `skip`.
+
 `tools/run_harness_triage.py` drives the full catalog — one process per
 (kernel, mode) via the argv filter, so a kernel that hard-aborts becomes an
 `abort` finding row instead of killing the run — and merges everything into

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -1656,6 +1656,10 @@ bool run_volk_reference_test(volk_func_desc_t desc,
     qa_test_data d = setup_test_data(
         desc, name, vlen_alloc, true, float_edge_cases, complex_edge_cases, mem_pool);
     if (!d.ok) {
+        // #133: tri-state skip, not a silent ok. setup couldn't produce data for
+        // this kernel — a coverage gap to surface, not a defect and not a pass.
+        results->back().applied = false;
+        results->back().skip_reason = "ref-setup-failed";
         return false;
     }
 
@@ -1664,6 +1668,9 @@ bool run_volk_reference_test(volk_func_desc_t desc,
     if (d.inputsc.size() != 0 && !s32f) {
         std::cerr << "reference mode: unsupported scalar signature for " << name
                   << std::endl;
+        // #133: report skip — the oracle path can't drive this scalar shape.
+        results->back().applied = false;
+        results->back().skip_reason = "unsupported-scalar-signature";
         return false;
     }
 
@@ -1709,6 +1716,9 @@ bool run_volk_reference_test(volk_func_desc_t desc,
             break;
         default:
             std::cerr << "reference mode: unsupported arity for " << name << std::endl;
+            // #133: report skip — the oracle path has no caster for this arity.
+            results->back().applied = false;
+            results->back().skip_reason = "unsupported-arity";
             return false;
         }
     }

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -57,6 +57,13 @@ public:
     std::map<std::string, volk_test_time_t> results;
     std::string best_arch_a;
     std::string best_arch_u;
+    // #133: reference-mode tri-state. `applied` is false when the oracle could
+    // not evaluate this kernel (unsupported scalar signature / arity / setup
+    // failure) — the driver then reports `skip`, not a silent `ok`. Mirrors the
+    // canary/immutability summaries' `applied` flag. Stays true for impl mode and
+    // for supported ref kernels, so every other producer/consumer is unaffected.
+    bool applied = true;
+    std::string skip_reason;
 };
 
 class volk_test_params_t

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -119,7 +119,9 @@ quiet_run(volk_test_case_t& tc,
           const std::vector<float>& fedges = kFloatEdges,
           const std::vector<lv_32fc_t>& cedges = kComplexEdges,
           std::set<std::string>* impls_seen = nullptr,
-          std::map<std::string, std::vector<unsigned int>>* impl_fails = nullptr)
+          std::map<std::string, std::vector<unsigned int>>* impl_fails = nullptr,
+          bool* ref_applied = nullptr,
+          std::string* ref_skip_reason = nullptr)
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
@@ -174,6 +176,16 @@ quiet_run(volk_test_case_t& tc,
             if (impl_fails && !kv.second.pass)
                 (*impl_fails)[kv.first].push_back(v);
         }
+    }
+    // #133 ref-mode tri-state: surface whether the oracle could evaluate this
+    // kernel so the driver reports `skip` (not a silent `ok`) on an unsupported
+    // shape. Set unconditionally (not gated on a report) — the human skip line
+    // prints with or without HARNESS_REPORT.
+    if (!results.empty()) {
+        if (ref_applied)
+            *ref_applied = results.back().applied;
+        if (ref_skip_reason)
+            *ref_skip_reason = results.back().skip_reason;
     }
     std::fflush(stdout);
     std::cout.flush();
@@ -1051,6 +1063,53 @@ int main(int argc, char* argv[])
                 lost = true;
             }
         }
+
+        // #133: ref mode must report an oracle shape it cannot evaluate as a
+        // SKIP (applied=false), never a silent `ok [ref]` (the fail-open
+        // regression). Drive the unsupported-scalar-signature path with a real
+        // complex-scalar (s32fc) kernel name so get_signatures_from_name parses
+        // a complex scalar; the stub oracle is never reached (the guard returns
+        // first). volk_canary_desc supplies a 1-impl arch list, exactly as the
+        // power/tanh planted cases above use it with a 32fc name.
+        {
+            std::vector<volk_test_results_t> uns_results;
+            const volk_reference_entry unsupported_ref{
+                "volk_32fc_s32fc_multiply_32fc",
+                +[](const std::vector<const void*>&,
+                    const std::vector<void*>&,
+                    lv_32fc_t,
+                    unsigned int) {},
+                1e-6f,
+                false
+            };
+            const bool uns_fail =
+                run_volk_reference_test(volk_canary_desc(),
+                                        (void (*)())(&volk_32f_canaryok_32f),
+                                        "volk_32fc_s32fc_multiply_32fc",
+                                        unsupported_ref,
+                                        power_scalar,
+                                        127u,
+                                        &uns_results,
+                                        kFloatEdges,
+                                        kComplexEdges);
+            const bool uns_skipped =
+                !uns_results.empty() && !uns_results.back().applied &&
+                uns_results.back().skip_reason == "unsupported-scalar-signature";
+            if (uns_fail || !uns_skipped) {
+                std::cout << "LOST  [combined-nc] ref-mode unsupported shape "
+                             "reported "
+                          << (uns_fail ? "FAIL" : "ok") << ", expected skip\n";
+                std::cerr << "NEGATIVE CONTROL LOST: reference mode no longer "
+                             "reports an unsupported oracle shape as skip — the "
+                             "#133 fail-open regression has returned (a silent "
+                             "ok [ref] hides an unevaluated kernel).\n";
+                lost = true;
+            } else {
+                std::cout << "ok    [combined-nc] ref-mode unsupported shape → "
+                             "skip (applied=false, "
+                          << uns_results.back().skip_reason << ")\n";
+            }
+        }
         if (lost)
             return 2;
         std::cerr << "combined negative control OK: power flagged by the independent "
@@ -1062,7 +1121,7 @@ int main(int argc, char* argv[])
     std::cout << "# kernel-correctness remainder sweep: vlens 1..40, 131071, 1000003\n";
     std::cout.flush();
 
-    int tested = 0, failed = 0;
+    int tested = 0, failed = 0, skipped = 0; // #133: skipped = ref oracle couldn't run
     // Negative-control tracking: power_seen = power_32fc was in the (filtered) sweep
     // at all; power_ref_tested = it ran in reference mode. The two together detect a
     // dropped/renamed registration (the likelier regression), not just a broken oracle.
@@ -1070,7 +1129,8 @@ int main(int argc, char* argv[])
     for (auto& tc : test_cases) {
         if (!filter.empty() && tc.name() != filter)
             continue;
-        ++tested;
+        // #133: ++tested moved below the skip check — a ref kernel the oracle
+        // cannot evaluate is `skip`, not a tested kernel.
         // Registered kernels run against the independent double reference (#88);
         // the rest fall back to the impl-vs-impl comparison.
         const volk_reference_entry* ref = volk_reference_lookup(tc.name());
@@ -1086,6 +1146,8 @@ int main(int argc, char* argv[])
         std::vector<unsigned int> bad;
         std::set<std::string> impls_seen;
         std::map<std::string, std::vector<unsigned int>> impl_fails;
+        bool ref_applied = true; // #133: did the oracle evaluate this kernel?
+        std::string ref_skip_reason;
         for (unsigned int v : vlens) {
             // Per-impl collection is only consumed by the CSV report; skip the
             // per-(kernel,vlen) map building when no report was requested.
@@ -1099,9 +1161,31 @@ int main(int argc, char* argv[])
                           kFloatEdges,
                           kComplexEdges,
                           report ? &impls_seen : nullptr,
-                          report ? &impl_fails : nullptr))
+                          report ? &impl_fails : nullptr,
+                          &ref_applied,
+                          &ref_skip_reason))
                 bad.push_back(v);
+            // #133: an unsupported oracle shape is vlen-independent — detect it on
+            // the first run and stop, so we emit ONE skip row (not one per vlen)
+            // and don't waste 41 further runs.
+            if (!ref_applied)
+                break;
         }
+        // #133: a ref kernel the oracle could not evaluate (unsupported scalar
+        // signature / arity / setup failure) is `skip`, NOT a silent `ok [ref]`.
+        // Emit exactly one skip row carrying the reason; don't count it tested.
+        if (ref && !ref_applied) {
+            ++skipped;
+            std::cout << "skip  [ref] " << tc.name() << "  (" << ref_skip_reason << ")\n";
+            if (report)
+                std::fprintf(report,
+                             "%s,-,ref,skip,%s\n",
+                             tc.name().c_str(),
+                             ref_skip_reason.c_str());
+            std::cout.flush();
+            continue;
+        }
+        ++tested;
         if (tc.name() == "volk_32fc_s32f_power_32fc") {
             power_seen = true;
             power_ref_tested = (ref != nullptr);
@@ -1134,8 +1218,9 @@ int main(int argc, char* argv[])
     }
     if (report)
         std::fclose(report);
-    std::cerr << "\ncorrectness remainder sweep: " << failed << " / " << tested
-              << " kernels failed\n";
+    std::cerr << "\ncorrectness remainder sweep: " << skipped
+              << " ref kernels skipped (oracle could not evaluate); " << failed << " / "
+              << tested << " kernels failed\n";
 
     // #88 coverage guard: volk_32fc_s32f_power_32fc is the harness's motivating
     // escaped defect (swapped atan2f; it has no SIMD impl, so the impl-vs-impl


### PR DESCRIPTION
## Summary

QA harness reference mode no longer **fails open** on an oracle shape it cannot
evaluate. `run_volk_reference_test` previously fixed three input-side problems by
printing to stderr and `return false` — the unsupported-scalar-signature path
(`qa_utils.cc`), the unsupported-arity path, and a test-data setup failure. The
driver reads `false` as "no failure," so the kernel printed `ok [ref]`, emitted
**zero** CSV rows, and `run_harness_triage.py` then relabeled it
`skip,no-qa-entry` — "nothing to test" rather than "the oracle could not run." A
silent false-negative.

This makes those three paths report a **tri-state skip**, mirroring the
`applied`-flag pattern the canary/immutability modes already use:

- `volk_test_results_t` gains `applied` (default `true`) + `skip_reason`.
- `run_volk_reference_test` sets `applied=false` + a reason
  (`unsupported-scalar-signature`, `unsupported-arity`, `ref-setup-failed`) on
  the three input-side paths; the output-side `throw`s (fail-closed) are
  unchanged.
- The sweep driver surfaces the flag, short-circuits the vlen loop (the shape is
  vlen-independent), prints `skip [ref] <name> (<reason>)`, and emits one
  `<name>,-,ref,skip,<reason>` row instead of a false `ok` — and does not count
  the skip as `tested`.

Latent today (all 5 registered oracles have supported shapes); becomes a real
false-negative source as the reference registry grows — each Class-B adjudication
in the #105 campaign adds an oracle, and a newly-registered unsupported shape
must surface as a coverage gap, not a false `ok`. Lands before the #106 snapshot
regeneration.

## Related issues

- Fixes mtibbits/volk#133.
- Companion to mtibbits/volk#106 (lands before the seeded snapshot regen) and the
  #135 max-error column (separate PR; orthogonal — this changes a `result`, that
  adds a column).

## Testing

- **Combined negative control** (`HARNESS_COMBINED_NC`, ctest
  `qa_harness_negative_control`): a new 7th assertion drives the
  unsupported-scalar path with a real complex-scalar kernel name and asserts the
  result is `skip` (`applied=false`, reason `unsupported-scalar-signature`) and
  **never** `ok`/`FAIL`. The existing 6 assertions stay green. This is the
  CI-enforced regression guard.
- **Full seeded sweep** (`HARNESS_SEED=42`, 128 kernels): **0 ref kernels
  skipped** (no over-skip); the 5 supported oracles behave normally
  (log2/atan2/magnitude `ok`; power/tanh `FAIL` = the known live #107/#108
  defects); no crash.
- **Default qa unaffected:** `qa_volk_32f_tanh_32f` + `qa_volk_32fc_s32f_power_32fc`
  pass — the new fields are additive and default `true`, so impl mode and
  `volk_profile` are untouched.
- **Static analysis** (changed-line scope, testing-enabled build): compiler /
  clang-format / iwyu / cmake-lint / codespell / mypy clean; asan+ubsan pass;
  tsan pass. (cpplint's 80-col nits are non-actionable — the project
  `.clang-format` ColumnLimit is 90.)

**Coverage note (honest scope):** the driver-side skip branch is not reachable
end-to-end by any *currently registered* oracle (all 5 are supported), so it is
exercised by inspection + the combined NC proving the load-bearing signal
(`run_volk_reference_test` sets `applied=false`). It activates the moment the
registry gains an unsupported shape. One disclosed edge: the sweep's skip
branch runs *before* the in-sweep power negative-control bookkeeping, so a
(non-realistic) `ref-setup-failed` on `power_32fc` itself would skip it before
that control fires — still strictly more honest than the pre-fix silent `ok`.

## Checklist

- [x] Tests pass (`ctest -R qa_harness_negative_control`; default qa spot-checks)
- [x] Negative control extended to guard the fixed behavior
- [x] Docs updated (`docs/kernel_correctness_harness/README.md`)
- [x] DCO sign-off
- [ ] Reviewer (Fable) check pending — deferred per current access; amend if it
      surfaces anything.
