### PR TITLE
harness-report max-err column

### DIFF
--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -128,16 +128,30 @@ either defect class, CI breaks here.
 ## Triage report format and snapshots
 
 With `HARNESS_REPORT=path` every mode writes
-`kernel,impl,mode,result,failed_vlens` — one row per kernel × impl. `mode` is
-`ref`/`impl` (sweep), `canary`, `immutable`, or `misaligned`. `result` is
-`ok`, `FAIL`, `partial` (canary unwritten), or `skip`; rows with impl `-` are
-kernel-level (skips, or failures not attributable to one impl, e.g. an
-exception mid-run). `failed_vlens` is space-separated.
+`kernel,impl,mode,result,failed_vlens,max_err` — one row per kernel × impl,
+preceded by a `# volk-harness-report v2` version-marker line (`#`-prefixed so
+readers skip it). `mode` is `ref`/`impl` (sweep), `canary`, `immutable`, or
+`misaligned`. `result` is `ok`, `FAIL`, `partial` (canary unwritten), or `skip`;
+rows with impl `-` are kernel-level (skips, or failures not attributable to one
+impl, e.g. an exception mid-run). `failed_vlens` is space-separated.
+
+`max_err` (`#135`) is the per-impl worst-case divergence magnitude across all
+swept vlens — formatted `%.3g` (e.g. `4e+04`, `1.2e-06`, `inf`) — so a triager
+can rank `FAIL`s by severity instead of treating a `4e+04` and a `1.2e-06` error
+as the same bare `FAIL`. It is populated for the `ref`/`impl` sweep and **empty**
+for `canary`/`immutable`/`misaligned` (no numeric divergence) and for every
+kernel-level `-` row (including ref `skip`). Note: an `ok` row still carries its
+worst *within-tolerance* divergence (it is the largest observed, not zero), so
+rank on `result == FAIL` first. A literal `0` means zero observed divergence,
+not necessarily the baseline — a swept impl bit-identical to `generic` also
+reads `0` (distinct from the *empty* field on skip / non-sweep rows). In `impl`
+mode `generic` is the baseline and reads `0`; in `ref` mode `generic` is itself
+compared against the oracle, so its `max_err` is a real value.
 
 Reference mode (`ref`) reports `skip` — **not** a silent `ok` — when the oracle
 cannot evaluate a registered kernel's shape (`#133`): a
-`<kernel>,-,ref,skip,<reason>` row whose `failed_vlens` column carries the
-reason (`unsupported-scalar-signature`, `unsupported-arity`, or
+`<kernel>,-,ref,skip,<reason>,` row (empty `max_err`) whose `failed_vlens` column
+carries the reason (`unsupported-scalar-signature`, `unsupported-arity`, or
 `ref-setup-failed`) instead of vlens. This makes a kernel the oracle could not
 run distinguishable from one it ran and passed — important as the reference
 registry grows (each Class-B adjudication adds an oracle, and a newly-registered
@@ -151,6 +165,7 @@ one CSV. Runner-synthesized rows use the runner's mode label `sweep` for the
 default mode (in-binary rows say `ref`/`impl`) and carry a detail string
 instead of vlens in `failed_vlens`: `timeout`, `signal=<NAME>`, `exit=<N>`,
 `runner-error: <msg>` (result `abort`), or `no-qa-entry` (result `skip`).
+`max_err` is empty on all runner-synthesized rows.
 
 Checked-in snapshots (the per-kernel fix backlog):
 
@@ -158,7 +173,9 @@ Checked-in snapshots (the per-kernel fix backlog):
   [`triage-2026-06-11-summary.md`](triage-2026-06-11-summary.md) — the epic-#85
   closeout snapshot: 154 kernels × 4 mode legs, 2,796 rows, 113 finding rows
   (112 FAIL across 22 kernels, plus 1 abort on a 23rd), headlined by the two
-  live motivating defects.
+  live motivating defects. (This snapshot predates `#135` and is still in the
+  v1 5-column format; the next regeneration under `#106` produces the v2
+  `max_err` format.)
 
 Retention: latest snapshot only — a new snapshot replaces the old files
 (history stays in git), so the directory does not accumulate dated CSVs.

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -1453,6 +1453,16 @@ bool run_volk_tests(volk_func_desc_t desc,
         arch_results.push_back(!fail);
     }
 
+    // #135: carry each arch's worst-case divergence onto its per-impl record so
+    // the driver can emit it to the HARNESS_REPORT max_err column. Done in this
+    // follow-up loop (not at the result's creation in the timing loop) because
+    // arch_max_err is only populated by the compare loop above. Generic stays 0.0
+    // (the compare loop skips it via i != generic_offset), matching the human
+    // table's "-" for generic.
+    for (size_t i = 0; i < arch_list.size(); i++) {
+        results->back().results[arch_list[i]].max_err = arch_max_err[i];
+    }
+
     double best_time_a = std::numeric_limits<double>::max();
     double best_time_u = std::numeric_limits<double>::max();
     std::string best_arch_a = "generic";
@@ -1787,6 +1797,8 @@ bool run_volk_reference_test(volk_func_desc_t desc,
                            // uninitialized read when the result is consumed
         result.units = "ref";
         result.pass = !arch_fail;
+        result.max_err = arch_max_err; // #135: per-impl oracle divergence; in ref
+                                       // mode generic IS compared (real value).
         results->back().results[d.arch_list[i]] = result;
         if (arch_fail) {
             fail_global = true;

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -45,6 +45,12 @@ public:
     double time;
     std::string units;
     bool pass;
+    // #135: worst-case divergence magnitude this impl showed vs the comparison
+    // baseline (impl-vs-generic in impl mode; impl-vs-oracle in ref mode),
+    // absolute or relative per the kernel's mode. Carried out to the
+    // HARNESS_REPORT max_err column. Default 0.0 so every other producer/consumer
+    // (default qa, volk_profile) is unaffected; only the sweep emit path reads it.
+    double max_err = 0.0;
 };
 
 class volk_test_results_t

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -121,7 +121,8 @@ quiet_run(volk_test_case_t& tc,
           std::set<std::string>* impls_seen = nullptr,
           std::map<std::string, std::vector<unsigned int>>* impl_fails = nullptr,
           bool* ref_applied = nullptr,
-          std::string* ref_skip_reason = nullptr)
+          std::string* ref_skip_reason = nullptr,
+          std::map<std::string, double>* impl_max_err = nullptr)
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
@@ -169,12 +170,20 @@ quiet_run(volk_test_case_t& tc,
     // #92 triage detail: both run_volk_tests and run_volk_reference_test fill
     // results.back().results with one entry per impl (generic included), each
     // carrying the impl's pass flag for this (kernel, vlen) run.
-    if ((impls_seen || impl_fails) && !results.empty()) {
+    if ((impls_seen || impl_fails || impl_max_err) && !results.empty()) {
         for (const auto& kv : results.back().results) {
             if (impls_seen)
                 impls_seen->insert(kv.first);
             if (impl_fails && !kv.second.pass)
                 (*impl_fails)[kv.first].push_back(v);
+            // #135: track the worst-case divergence per impl across all vlens
+            // (plain compare — <algorithm> is not included in this TU; max_err
+            // is always >= 0 so the value-initialised 0.0 is the correct floor).
+            if (impl_max_err) {
+                double& cur = (*impl_max_err)[kv.first];
+                if (kv.second.max_err > cur)
+                    cur = kv.second.max_err;
+            }
         }
     }
     // #133 ref-mode tri-state: surface whether the oracle could evaluate this
@@ -390,7 +399,8 @@ static void emit_impl_rows(FILE* report,
                            const std::string& kernel,
                            const char* mode,
                            const std::set<std::string>& impls_seen,
-                           const std::vector<impl_row_category>& categories)
+                           const std::vector<impl_row_category>& categories,
+                           const std::map<std::string, double>* max_err = nullptr)
 {
     for (const std::string& impl : impls_seen) {
         const char* status = nullptr;
@@ -404,13 +414,25 @@ static void emit_impl_rows(FILE* report,
             if (std::string(status) == cat.status)
                 vs += vlens_str(it->second);
         }
+        // #135: 6th column = worst-case divergence magnitude for this impl.
+        // %.3g is compact, comma-free (C locale) and magnitude-preserving
+        // (4e+04, 1.2e-06, or inf for catastrophic divergence); empty when no
+        // max_err map is supplied (canary/immutable/misaligned modes, where
+        // divergence is meaningless).
+        char eb[32] = "";
+        if (max_err) {
+            const auto me = max_err->find(impl);
+            if (me != max_err->end())
+                std::snprintf(eb, sizeof eb, "%.3g", me->second);
+        }
         std::fprintf(report,
-                     "%s,%s,%s,%s,%s\n",
+                     "%s,%s,%s,%s,%s,%s\n",
                      kernel.c_str(),
                      impl.c_str(),
                      mode,
                      status ? status : "ok",
-                     vs.c_str());
+                     vs.c_str(),
+                     eb);
     }
 }
 
@@ -442,11 +464,17 @@ int main(int argc, char* argv[])
     FILE* report = nullptr;
     if (const char* rp = std::getenv("HARNESS_REPORT")) {
         report = std::fopen(rp, "w");
-        if (report)
-            std::fprintf(report, "kernel,impl,mode,result,failed_vlens\n");
-        else
+        if (report) {
+            // #135: a version-marker comment line FIRST (lets the runner/readers
+            // detect the schema; '#'-prefixed so it is trivially skippable), then
+            // the 6-column header. Braced so the marker+header both stay under
+            // `if (report)` and the `else` does not dangle.
+            std::fprintf(report, "# volk-harness-report v2\n");
+            std::fprintf(report, "kernel,impl,mode,result,failed_vlens,max_err\n");
+        } else {
             std::cerr << "HARNESS_REPORT: cannot open '" << rp
                       << "' — human output only\n";
+        }
     }
 
     // #89 output-buffer canary mode (opt-in via HARNESS_CANARY). This is a
@@ -562,7 +590,7 @@ int main(int argc, char* argv[])
             if (tc.puppet_master_name() != "NULL") {
                 std::cout << "skip  [canary] " << tc.name() << " (puppet)\n";
                 if (report)
-                    std::fprintf(report, "%s,-,canary,skip,\n", tc.name().c_str());
+                    std::fprintf(report, "%s,-,canary,skip,,\n", tc.name().c_str());
                 std::cout.flush();
                 continue;
             }
@@ -597,7 +625,7 @@ int main(int argc, char* argv[])
                 std::cout << "skip  [canary] " << tc.name()
                           << " (no guardable output buffer)\n";
                 if (report)
-                    std::fprintf(report, "%s,-,canary,skip,\n", tc.name().c_str());
+                    std::fprintf(report, "%s,-,canary,skip,,\n", tc.name().c_str());
                 std::cout.flush();
                 continue;
             }
@@ -635,7 +663,7 @@ int main(int argc, char* argv[])
                     unattributed_vlens(over_run, guard_fails);
                 if (!unattr.empty()) {
                     std::fprintf(report,
-                                 "%s,-,canary,FAIL,%s\n",
+                                 "%s,-,canary,FAIL,%s,\n",
                                  tc.name().c_str(),
                                  vlens_str(unattr).c_str());
                 }
@@ -713,7 +741,7 @@ int main(int argc, char* argv[])
             if (tc.puppet_master_name() != "NULL") {
                 std::cout << "skip  [immutable] " << tc.name() << " (puppet)\n";
                 if (report)
-                    std::fprintf(report, "%s,-,immutable,skip,\n", tc.name().c_str());
+                    std::fprintf(report, "%s,-,immutable,skip,,\n", tc.name().c_str());
                 std::cout.flush();
                 continue;
             }
@@ -739,7 +767,7 @@ int main(int argc, char* argv[])
                 std::cout << "skip  [immutable] " << tc.name()
                           << " (no protectable input buffer)\n";
                 if (report)
-                    std::fprintf(report, "%s,-,immutable,skip,\n", tc.name().c_str());
+                    std::fprintf(report, "%s,-,immutable,skip,,\n", tc.name().c_str());
                 std::cout.flush();
                 continue;
             }
@@ -849,7 +877,7 @@ int main(int argc, char* argv[])
             if (tc.puppet_master_name() != "NULL") {
                 std::cout << "skip  [misaligned] " << tc.name() << " (puppet)\n";
                 if (report)
-                    std::fprintf(report, "%s,-,misaligned,skip,\n", tc.name().c_str());
+                    std::fprintf(report, "%s,-,misaligned,skip,,\n", tc.name().c_str());
                 std::cout.flush();
                 continue;
             }
@@ -878,7 +906,7 @@ int main(int argc, char* argv[])
                 std::cout << "skip  [misaligned] " << tc.name()
                           << " (no checkable unaligned impl)\n";
                 if (report)
-                    std::fprintf(report, "%s,-,misaligned,skip,\n", tc.name().c_str());
+                    std::fprintf(report, "%s,-,misaligned,skip,,\n", tc.name().c_str());
                 std::cout.flush();
                 continue;
             }
@@ -1146,6 +1174,7 @@ int main(int argc, char* argv[])
         std::vector<unsigned int> bad;
         std::set<std::string> impls_seen;
         std::map<std::string, std::vector<unsigned int>> impl_fails;
+        std::map<std::string, double> impl_max_err; // #135: worst divergence per impl
         bool ref_applied = true; // #133: did the oracle evaluate this kernel?
         std::string ref_skip_reason;
         for (unsigned int v : vlens) {
@@ -1163,7 +1192,8 @@ int main(int argc, char* argv[])
                           report ? &impls_seen : nullptr,
                           report ? &impl_fails : nullptr,
                           &ref_applied,
-                          &ref_skip_reason))
+                          &ref_skip_reason,
+                          report ? &impl_max_err : nullptr))
                 bad.push_back(v);
             // #133: an unsupported oracle shape is vlen-independent — detect it on
             // the first run and stop, so we emit ONE skip row (not one per vlen)
@@ -1179,7 +1209,7 @@ int main(int argc, char* argv[])
             std::cout << "skip  [ref] " << tc.name() << "  (" << ref_skip_reason << ")\n";
             if (report)
                 std::fprintf(report,
-                             "%s,-,ref,skip,%s\n",
+                             "%s,-,ref,skip,%s,\n",
                              tc.name().c_str(),
                              ref_skip_reason.c_str());
             std::cout.flush();
@@ -1201,14 +1231,18 @@ int main(int argc, char* argv[])
         }
         if (report) {
             // `mode` is ref|impl per the kernel's reference registration (#92).
-            emit_impl_rows(
-                report, tc.name(), mode, impls_seen, { { &impl_fails, "FAIL" } });
+            emit_impl_rows(report,
+                           tc.name(),
+                           mode,
+                           impls_seen,
+                           { { &impl_fails, "FAIL" } },
+                           &impl_max_err); // #135: sweep rows carry max_err
             // Failures with no impl attribution (an exception during the run,
             // or nothing observed at all) stay visible on a "-" row.
             const std::vector<unsigned int> unattr = unattributed_vlens(bad, impl_fails);
             if (!unattr.empty()) {
                 std::fprintf(report,
-                             "%s,-,%s,FAIL,%s\n",
+                             "%s,-,%s,FAIL,%s,\n",
                              tc.name().c_str(),
                              mode,
                              vlens_str(unattr).c_str());

--- a/tools/run_harness_triage.py
+++ b/tools/run_harness_triage.py
@@ -40,7 +40,7 @@ MODES = {
     "immutable": {"HARNESS_IMMUTABLE": "1"},
     "misaligned": {"HARNESS_MISALIGNED": "1"},
 }
-HEADER = ["kernel", "impl", "mode", "result", "failed_vlens"]
+HEADER = ["kernel", "impl", "mode", "result", "failed_vlens", "max_err"]
 
 
 def kernel_names(repo_root):
@@ -63,9 +63,15 @@ def read_report_rows(report):
     if os.path.exists(report):
         with open(report, newline="") as f:
             for row in csv.reader(f):
-                # Skip the header and any truncated trailing line (a crash can
+                # Skip the version-marker/comment line (#135: '# volk-harness-report
+                # v2'), the header, and any truncated trailing line (a crash can
                 # cut the final stdio flush mid-row).
-                if row and row[0] != "kernel" and len(row) == len(HEADER):
+                if (
+                    row
+                    and not row[0].startswith("#")
+                    and row[0] != "kernel"
+                    and len(row) == len(HEADER)
+                ):
                     rows.append(row)
     return rows
 
@@ -107,22 +113,22 @@ def run_one(binary, libdir, kernel, mode, timeout, tmpdir, base_seed=None):
     except subprocess.TimeoutExpired:
         # Keep whatever was written before the kill, consistent with rc<0.
         rows = read_report_rows(report)
-        rows.append([kernel, "-", mode, "abort", "timeout"])
+        rows.append([kernel, "-", mode, "abort", "timeout", ""])
         return rows
     rows = read_report_rows(report)
     # rc<0 => died on a signal; rows written before the crash are kept and the
     # abort itself becomes a finding row (tiny-vlen aborts are findings).
     if rc < 0:
-        rows.append([kernel, "-", mode, "abort", f"signal={signal_name(-rc)}"])
+        rows.append([kernel, "-", mode, "abort", f"signal={signal_name(-rc)}", ""])
     elif rc not in (0, 1):  # 0=clean, 1=FAILs recorded in rows; else abnormal
-        rows.append([kernel, "-", mode, "abort", f"exit={rc}"])
+        rows.append([kernel, "-", mode, "abort", f"exit={rc}", ""])
     elif rc == 1 and not any(r[3] in ("FAIL", "partial") for r in rows):
         # Fail closed: the binary reported failure but no finding row was
         # captured (e.g. its HARNESS_REPORT fopen failed and it degraded to
         # human output) -- record the inconsistency rather than skipping.
-        rows.append([kernel, "-", mode, "abort", "exit=1-without-finding-rows"])
+        rows.append([kernel, "-", mode, "abort", "exit=1-without-finding-rows", ""])
     if not rows:
-        rows.append([kernel, "-", mode, "skip", "no-qa-entry"])
+        rows.append([kernel, "-", mode, "skip", "no-qa-entry", ""])
     return rows
 
 
@@ -184,12 +190,15 @@ def main():
             try:
                 all_rows.extend(fut.result())
             except Exception as e:  # noqa: BLE001 -- synthesize a finding row
-                all_rows.append([k, "-", m, "abort", f"runner-error: {e}"])
+                all_rows.append([k, "-", m, "abort", f"runner-error: {e}", ""])
             done += 1
             if done % 50 == 0:
                 print(f"# {done}/{len(jobs)}", file=sys.stderr)
     all_rows.sort(key=lambda r: (r[0], r[2], r[1]))
     with open(args.out, "w", newline="") as f:
+        # #135: self-describing version marker first (matches the in-binary child
+        # reports; read_report_rows skips '#'-prefixed lines), then the header.
+        f.write("# volk-harness-report v2\n")
         w = csv.writer(f, lineterminator="\n")
         w.writerow(HEADER)
         w.writerows(all_rows)


### PR DESCRIPTION
## Summary

Add a 6th `HARNESS_REPORT` CSV column, `max_err`, so triagers can rank harness
failures by **magnitude** instead of treating a `4e+04` divergence and a
`1.2e-06` divergence as the same bare `FAIL`. The harness already computed
`arch_max_err` per impl (and printed it to the human table) but dropped it from
the machine-readable CSV; this plumbs it out. A `# volk-harness-report v2`
version-marker line is added so the C++ writer and the Python runner can't
silently drift, and the runner is updated in lockstep.

Concretely: `arch_max_err` is stored onto `volk_test_time_t.max_err` in both the
`run_volk_tests` sweep/impl path and `run_volk_reference_test`; `quiet_run`
accumulates a per-impl running max across vlens; `emit_impl_rows` emits it as a
`%.3g` field. The column is populated for the `ref`/`impl` sweep and **empty**
for `canary`/`immutable`/`misaligned` and for every kernel-level `-`/skip row
(magnitude is meaningless there). `tools/run_harness_triage.py` gains the column
in its `HEADER`, skips the `#` marker line, and extends its synthesized rows —
so no row is dropped by its `len(row) == len(HEADER)` guard.

Lands before the #106 snapshot regeneration (so the re-triage of #107–#128 can
rank by magnitude); the checked-in v1 snapshot is intentionally left unchanged
(it's #106's job).

## Related issues
- Fixes mtibbits/volk#135.
- Builds on #133 (shipped first into the same files; this PR re-anchored against
  it and added the trailing 6th field to #133's ref-skip row).
- Unblocks #106's regen + the #107–#128 severity-ranked re-triage.

## Testing
- **max_err ranks real defects** (the whole point): tanh ref-mode shows
  `series` = 8.39e+05 (the #108 stale-pointer defect), `a_avx` = 16.9,
  `a_sse` = 2, `generic` = 2.08e-07 — previously indistinguishable bare `FAIL`s.
  `invsqrt` impls show `inf`.
- **Row-arity (the load-bearing hazard):** full sweep **812/812 rows = 6
  fields**; canary 755 (16 skip rows) + misaligned 433 (15) all 6 fields;
  immutable rows carry an empty `max_err`. Every `fprintf(report,…)` data site
  was updated.
- **Runner lockstep:** `run_harness_triage.py --only … --modes sweep,immutable`
  round-trips — merged CSV has the marker + 6-col header and no rows are dropped.
- **No regression:** `qa_harness_negative_control` ctest passes; full sweep
  still 9/128 failed (matches the pre-#135 baseline), 0 ref kernels spuriously
  skipped.
- **Default qa unaffected:** `qa_volk_32f_tanh_32f` passes — the new
  `volk_test_time_t` field is additive (default `0.0`), read only by the sweep
  emit path; `volk_profile`/`testqa` serializers don't touch it.
- Static analysis (changed-line scope): clang-format / iwyu / compiler clean;
  asan+ubsan + tsan pass.

## Review
Verified by two adversarial multi-agent workflows: a pre-implementation
**plan-verification** (5 lenses, caught a dangling-`else` trap in the header
edit before coding) and a **diff code-review** (3 lenses + adjudicator, verdict
SHIP, 0 blocking/major; 3 doc/comment nits applied).

## Checklist
- [x] Tests pass (`ctest -R qa_harness_negative_control`; default qa spot)
- [x] Row-arity verified across all 4 modes (no dropped rows)
- [x] Runner updated in lockstep; version marker added
- [x] Docs updated (`docs/kernel_correctness_harness/README.md`)
- [x] DCO sign-off
- [ ] Reviewer (Fable) check pending — deferred per current access; amend if it
      surfaces anything.
