### PR TITLE
fix: guard NEONv8 FMA complex-multiply helper behind LV_HAVE_NEONV8 (#146)

### DIFF
--- a/include/volk/volk_neon_intrinsics.h
+++ b/include/volk/volk_neon_intrinsics.h
@@ -197,7 +197,12 @@ static inline float32x4x2_t _vmultiply_complexq_f32(float32x4x2_t a_val,
  * Four ops total (vs six in _vmultiply_complexq_f32): 2x vmulq + 1x vfmsq + 1x vfmaq.
  * Each FMA does a single rounding step vs two for the mul+add pair; net precision
  * is strictly better than the non-FMA sibling.
+ *
+ * Guarded on LV_HAVE_NEONV8: vfmaq_f32/vfmsq_f32 are unavailable on plain ARMv7
+ * NEON (e.g. armeabi-v7a), and a static-inline body is type-checked even where no
+ * caller is compiled in, so an unguarded definition breaks the v7 build.
  */
+#ifdef LV_HAVE_NEONV8
 static inline float32x4x2_t _vmultiply_complexq_fma_f32(float32x4x2_t a_val,
                                                         float32x4x2_t b_val)
 {
@@ -210,6 +215,7 @@ static inline float32x4x2_t _vmultiply_complexq_fma_f32(float32x4x2_t a_val,
     c_val.val[1] = vfmaq_f32(c_val.val[1], a_val.val[1], b_val.val[0]);
     return c_val;
 }
+#endif /* LV_HAVE_NEONV8 */
 
 /* From ARM Compute Library, MIT license */
 static inline float32x4_t _vtaylor_polyq_f32(float32x4_t x, const float32x4_t coeffs[8])


### PR DESCRIPTION
## Summary
`_vmultiply_complexq_fma_f32` in `volk_neon_intrinsics.h` used `vfmaq_f32`/`vfmsq_f32` outside any feature guard. Those intrinsics don't exist on plain ARMv7 NEON (armeabi-v7a), and a `static inline` body is type-checked even when no caller is compiled in — so the unguarded definition broke the Android `armeabi-v7a` build under clang. Wrapped it in `#ifdef LV_HAVE_NEONV8`, matching every other NEONv8 helper in this header.

## Verification
- Reproduced the exact CI error with clang armv7 (`--target=arm-linux-gnueabihf -march=armv7-a -mfpu=neon`): `call to undeclared function 'vfmsq_f32'` at lines 207/210.
- After the guard: armv7 NEON compiles clean (exit 0).
- AArch64 NEONv8 still compiles **and** the helper is still defined/usable (compiled a TU that calls it).
- Audited the header: all other `vfmaq_f32` uses are already inside `LV_HAVE_NEONV8` blocks; this was the only stray.
- `git clang-format`: no changes.

Call sites were already `#ifdef LV_HAVE_NEONV8`, so AArch64/NEONv8 codegen is unchanged.

Fixes #146