### PR TITLE
fix: correct power_32fc complex-power — swapped atan2 args + spurious -cos (#107)

### DIFF
--- a/kernels/volk/volk_32fc_s32f_power_32fc.h
+++ b/kernels/volk/volk_32fc_s32f_power_32fc.h
@@ -50,10 +50,10 @@
 static inline lv_32fc_t __volk_s32fc_s32f_power_s32fc_a(const lv_32fc_t exp,
                                                         const float power)
 {
-    const float arg = power * atan2f(lv_creal(exp), lv_cimag(exp));
+    const float arg = power * atan2f(lv_cimag(exp), lv_creal(exp));
     const float mag =
         powf(lv_creal(exp) * lv_creal(exp) + lv_cimag(exp) * lv_cimag(exp), power / 2);
-    return mag * lv_cmake(-cosf(arg), sinf(arg));
+    return mag * lv_cmake(cosf(arg), sinf(arg));
 }
 
 #ifdef LV_HAVE_GENERIC


### PR DESCRIPTION
## Summary
Fixes #107 — corrects the complex-power computation in `volk_32fc_s32f_power_32fc`.

## Bug
The shared helper `__volk_s32fc_s32f_power_s32fc_a` had two errors:
- **`atan2f` args swapped** — the phase of a complex `z = re + i·im` is `atan2(im, re)`, not `atan2(re, im)`.
- **spurious negative on the cosine** — `z^p = mag·(cos θ + i·sin θ)`; the code returned `-cos`.

## Fix
Two-line change: correct the `atan2f` argument order and drop the negative. Generic-only kernel (the SIMD impls share this helper).

## Verification
`volk_test_correctness volk_32fc_s32f_power_32fc` → `generic ref ok, max_err 8.81e-07` (was FAIL at 1.85). Verified on both dev/all-prs and **origin/main** (the affected lines are identical on both).

**Base:** `origin/main` (pure upstream-kernel fix, no fork dependency).

---
*Fork-integration note:* the fork's correctness harness carries a `#88` bug-gated negative control for this exact defect (`lib/test_correctness.cc`). It is flipped from expect-fail to expect-pass as part of the **dev/all-prs** integration — it's a fork-only file, deliberately kept out of this upstream-clean branch.
