### PR TITLE
fix: advance input pointer every iteration in tanh series (#108)

### DIFF
--- a/kernels/volk/volk_32f_tanh_32f.h
+++ b/kernels/volk/volk_32f_tanh_32f.h
@@ -94,8 +94,8 @@ volk_32f_tanh_32f_series(float* cVector, const float* aVector, unsigned int num_
             float a = (*aPtr) * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
             float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
             *cPtr++ = a / b;
-            aPtr++;
         }
+        aPtr++; /* #108: advance every iteration, not only in the else branch */
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #108 — stale input pointer in `volk_32f_tanh_32f_series`.

## Bug
`aPtr++` lived only in the `else` branch, so every clamped element (`|x| > 4.97`) advanced the output but **not** the input → all subsequent elements read stale input (catastrophic, max_err ~1.2e6). The series is also the scalar tail of the SSE/AVX impls, so it corrupted their tails too.

## Fix
One-line change: advance `aPtr` once per iteration (after the if/else), removing the misplaced advance from the `else`.

## Verification
`volk_test_correctness volk_32f_tanh_32f` → **all 8 impls ok** (generic/series + a_sse/u_sse/a_avx/u_avx/a_avx_fma/u_avx_fma), max_err ≤ 0.0027 (was FAIL across the board). Verified on **origin/main**.

**Base:** `origin/main`.
