### PR TITLE
codegen-check cross-compiler hardening

### DIFF
--- a/cmake/CodegenEquivalence.cmake
+++ b/cmake/CodegenEquivalence.cmake
@@ -23,13 +23,17 @@
 set_property(GLOBAL PROPERTY CODEGEN_EQUIVALENCE_TUPLES "")
 
 function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
-    set(one_value
+    set(required_args
         KERNEL ISA ALIGNMENT CRITERION
         IMPL_A_SYMBOL IMPL_A_MACHINE_O
         IMPL_B_SYMBOL IMPL_B_MACHINE_O)
-    cmake_parse_arguments(CGE "" "${one_value}" "" ${ARGN})
+    # REQUIRE_MNEMONIC is OPTIONAL: parsed but NOT in required_args, so existing
+    # call sites without it are unaffected. When set, the harness additionally
+    # asserts the compared function contains >=1 instruction whose mnemonic
+    # matches the regex (scalar-fallback guard).
+    cmake_parse_arguments(CGE "" "${required_args};REQUIRE_MNEMONIC" "" ${ARGN})
 
-    foreach(required IN LISTS one_value)
+    foreach(required IN LISTS required_args)
         if(NOT DEFINED CGE_${required})
             message(FATAL_ERROR
                 "ADD_CODEGEN_EQUIVALENCE_TUPLE: missing required arg ${required}")
@@ -41,7 +45,14 @@ function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
             "or within_noise (got '${CGE_CRITERION}')")
     endif()
 
-    set(frag "{\"kernel\":\"${CGE_KERNEL}\",\"isa\":\"${CGE_ISA}\",\"alignment\":\"${CGE_ALIGNMENT}\",\"criterion\":\"${CGE_CRITERION}\",\"impl_a\":{\"symbol\":\"${CGE_IMPL_A_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_A_MACHINE_O}\"},\"impl_b\":{\"symbol\":\"${CGE_IMPL_B_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_B_MACHINE_O}\"}}")
+    # Emit require_mnemonic only when set, so tuples without it produce
+    # byte-identical JSON to before this change.
+    set(_extra "")
+    if(DEFINED CGE_REQUIRE_MNEMONIC)
+        set(_extra ",\"require_mnemonic\":\"${CGE_REQUIRE_MNEMONIC}\"")
+    endif()
+
+    set(frag "{\"kernel\":\"${CGE_KERNEL}\",\"isa\":\"${CGE_ISA}\",\"alignment\":\"${CGE_ALIGNMENT}\",\"criterion\":\"${CGE_CRITERION}\",\"impl_a\":{\"symbol\":\"${CGE_IMPL_A_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_A_MACHINE_O}\"},\"impl_b\":{\"symbol\":\"${CGE_IMPL_B_SYMBOL}\",\"machine_o\":\"${CGE_IMPL_B_MACHINE_O}\"}${_extra}}")
     set_property(GLOBAL APPEND PROPERTY CODEGEN_EQUIVALENCE_TUPLES "${frag}")
 endfunction()
 

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -85,6 +85,19 @@ def parse_manifest(path: Path) -> list:
             print(f"error: unknown criterion {t['criterion']!r} (must be "
                   f"byte_identical or within_noise)", file=sys.stderr)
             sys.exit(2)
+        # Optional opt-in field: a regex the compared function must match at
+        # least one instruction mnemonic against (scalar-fallback guard).
+        if "require_mnemonic" in t:
+            if not isinstance(t["require_mnemonic"], str):
+                print(f"error: require_mnemonic must be a string regex: {t}",
+                      file=sys.stderr)
+                sys.exit(2)
+            try:
+                re.compile(t["require_mnemonic"])
+            except re.error as e:
+                print(f"error: require_mnemonic is not a valid regex "
+                      f"({t['require_mnemonic']!r}): {e}", file=sys.stderr)
+                sys.exit(2)
     return tuples
 
 
@@ -320,6 +333,21 @@ def compare_within_noise(a: list, b: list):
     return True, ""
 
 
+def check_require_mnemonic(body: list, pattern: str):
+    """Assert at least one instruction in `body` has a mnemonic matching the
+    regex `pattern`. Returns (ok, diff). Equivalence to a reference does not
+    prove an impl emits the intended ISA -- a scalar fallback could be
+    byte-identical to a scalar reference and pass; this guards against that. On
+    failure, diff names the pattern and the sorted set of mnemonics present.
+    """
+    rx = re.compile(pattern)
+    if any(rx.search(instr["mnemonic"]) for instr in body):
+        return True, ""
+    seen = sorted({instr["mnemonic"] for instr in body})
+    return False, (f"required-mnemonic assertion FAILED: no instruction "
+                   f"mnemonic matches /{pattern}/.\n  mnemonics present: {seen}")
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -375,6 +403,15 @@ def main():
             ok, diff = compare_byte_identical(a_instrs, b_instrs)
         else:
             ok, diff = compare_within_noise(a_instrs, b_instrs)
+        # Optional required-mnemonic assertion: only meaningful once the pair is
+        # otherwise equivalent. Checked against each impl independently.
+        if ok and "require_mnemonic" in t:
+            for label, instrs in (("impl_a", a_instrs), ("impl_b", b_instrs)):
+                mok, mdiff = check_require_mnemonic(instrs, t["require_mnemonic"])
+                if not mok:
+                    ok = False
+                    diff = f"[{label}] {mdiff}"
+                    break
         if not ok:
             failures.append((tuple_id(t), diff))
 

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -219,18 +219,33 @@ def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
     return result.stdout
 
 
-def _is_trailing_padding(mnemonic: str) -> bool:
-    """Mnemonics that, when trailing the final control-flow terminator, are
-    inter-function alignment padding (belong to no function): the NOP family
-    and the lone `data16` prefix some toolchains/disassemblers emit as a pad
-    filler (e.g. GNU objdump renders a multi-byte NOP as `data16 cs nopw ...`).
-    Mid-body alignment NOPs are NOT stripped here -- only the trailing run.
+def _is_trailing_padding(instr: dict) -> bool:
+    """True if `instr`, sitting after the function's final control-flow
+    terminator, is inter-function alignment padding (belongs to no function).
+    Covers every x86 inter-function pad filler observed across the CI matrix:
+
+      - the NOP family (`nop`, `nopw`, `nopl`, `nopq`, ...),
+      - the lone `data16` prefix some disassemblers print for a multi-byte NOP
+        (GNU objdump renders it `data16 cs nopw ...`),
+      - `int3` (0xcc) gap fill,
+      - the legacy `xchg %ax,%ax` (0x66 0x90) two-byte NOP -- but ONLY the
+        self-exchange idiom (same src/dst); a real register `xchg` is never
+        stripped.
+
+    Mid-body alignment NOPs are NOT stripped -- only the trailing run.
 
     Invariant: this set MUST stay a superset of the mnemonics `_padding_line`
     accepts, so any pad the fallback absorbs is guaranteed to be stripped here
     and never reaches the comparison.
     """
-    return mnemonic.startswith("nop") or mnemonic == "data16"
+    m = instr["mnemonic"]
+    if m.startswith("nop") or m == "data16" or m == "int3":
+        return True
+    if m == "xchg":
+        # Strip only `xchg %reg,%reg` (the NOP idiom), never a real exchange.
+        ops = [o for o in instr["operands"].replace(" ", "").split(",") if o]
+        return len(ops) == 2 and ops[0] == ops[1]
+    return False
 
 
 def _instr_from_match(m) -> dict:
@@ -324,7 +339,7 @@ def extract_function_body_from_text(text: str, symbol: str,
     # belong to no function and vary with inter-function layout, so they are not
     # part of this function's codegen. Internal alignment nops (e.g. before a
     # hot loop) are mid-body and are preserved.
-    while instrs and _is_trailing_padding(instrs[-1]["mnemonic"]):
+    while instrs and _is_trailing_padding(instrs[-1]):
         instrs.pop()
     if not instrs:
         raise RuntimeError(

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -25,10 +25,19 @@ the criterion evaluated.
 Invoked by lib/CMakeLists.txt as a dependency of the volk shared-lib target
 so it runs after volk_obj compiles but before linking.
 
+Cross-compiler robustness (mtibbits/volk#145): benign codegen noise that differs
+by compiler is normalized away -- trailing alignment NOPs of any encoding and
+trailing `data16` padding are stripped (they pad the next function and belong to
+no function), and a symbol the compiler inlined rather than emitting standalone
+is skipped-with-warning (exit 0) since there is nothing to compare. A genuine
+post-normalization divergence still fails (exit 1); a genuinely unparsable
+non-padding line still errors (exit 2).
+
 Exit codes:
-    0  all declared tuples pass (or manifest is empty)
-    1  one or more tuples fail (per-tuple diff printed to stderr)
-    2  internal error (missing manifest, missing .o, symbol not found, parse)
+    0  all declared tuples pass (or are skipped/empty); skips warn on stderr
+    1  one or more tuples fail their criterion (per-tuple diff on stderr)
+    2  internal error: missing manifest/.o, ambiguous .o, unparsable
+       non-padding line, or empty function body
 
 See mtibbits/volk#78 for context. Mirrors
 the dispatch-table integrity check (mtibbits/volk#58) for shape and reporting.
@@ -52,6 +61,16 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+
+class SymbolNotEmittedError(RuntimeError):
+    """The compared symbol is absent from the object file because the compiler
+    inlined it rather than emitting it standalone (e.g. macOS clang on some
+    impls). There is nothing to compare, so main() skips the tuple with a
+    warning rather than failing the build. Distinct from the other RuntimeError
+    cases (missing/ambiguous .o, unparsable line) which remain hard errors
+    (mtibbits/volk#145).
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +153,24 @@ _continuation_line = re.compile(
     r'^\s*[0-9a-fA-F]+:\s+((?:[0-9a-fA-F]{2}[ \t]*)+)$'
 )
 
+# A NOP/padding instruction line that _disasm_line above fails to capture across
+# objdump variants. _disasm_line needs >=2 whitespace chars between the last byte
+# and the mnemonic (its byte-group [ \t]+ plus a separate mandatory [ \t]+
+# separator), but the long multi-byte alignment NOPs that clang-15+/gcc-11/14
+# emit as trailing pad render with a single tab, e.g.
+#     21656: 66 2e 0f 1f 84 00 00 00 00 00\tnopw\t%cs:(%rax,%rax)
+# This fallback drops the separate separator and anchors the padding mnemonic
+# directly after the byte column, so it matches the single-tab form. It is tried
+# ONLY when _disasm_line fails, so the passing path is unchanged; it matches only
+# the NOP family and the lone data16 prefix, both of which the trailing-strip
+# below removes when they are inter-function padding (mtibbits/volk#145).
+_padding_line = re.compile(
+    r'^\s*([0-9a-fA-F]+):\s+'
+    r'((?:[0-9a-fA-F]{2}[ \t]+)+?)'
+    r'(nop[a-z]*|data16)\b'
+    r'(?:[ \t]+(.*))?$'
+)
+
 
 def resolve_object(build_lib_dir: Path, machine_o: str) -> Path:
     """Resolve a manifest machine_o entry to an actual object-file path.
@@ -182,14 +219,56 @@ def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
     return result.stdout
 
 
+def _is_trailing_padding(mnemonic: str) -> bool:
+    """Mnemonics that, when trailing the final control-flow terminator, are
+    inter-function alignment padding (belong to no function): the NOP family
+    and the lone `data16` prefix some toolchains/disassemblers emit as a pad
+    filler (e.g. GNU objdump renders a multi-byte NOP as `data16 cs nopw ...`).
+    Mid-body alignment NOPs are NOT stripped here -- only the trailing run.
+
+    Invariant: this set MUST stay a superset of the mnemonics `_padding_line`
+    accepts, so any pad the fallback absorbs is guaranteed to be stripped here
+    and never reaches the comparison.
+    """
+    return mnemonic.startswith("nop") or mnemonic == "data16"
+
+
+def _instr_from_match(m) -> dict:
+    """Build an instruction record from a _disasm_line OR _padding_line match.
+    Both regexes capture the same four groups in the same order -- address,
+    bytes, mnemonic, operands -- and this is the single source of truth for the
+    record shape the comparison consumes.
+    """
+    addr_hex, bytes_str, mnemonic, operands = m.groups()
+    return {
+        "address": addr_hex,
+        "bytes": bytes_str.split(),
+        "mnemonic": mnemonic,
+        "operands": (operands or "").strip(),
+    }
+
+
 def extract_function_body(o_file: Path, symbol: str,
                           objdump: str = "llvm-objdump") -> list:
-    """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
-    `symbol` in the disassembly of o_file: every instruction line from the
-    `<symbol>:` header up to (exclusive) the next symbol header or a blank line
-    that ends the function's block. Raises RuntimeError if the symbol is absent.
+    """Disassemble `symbol` in o_file and return its whole-body instruction list.
+    Thin wrapper over extract_function_body_from_text (see it for the parse
+    contract); kept so callers and tests can pass a file path + objdump.
     """
     text = _disassemble(o_file, objdump, symbol=symbol)
+    return extract_function_body_from_text(text, symbol, source_label=str(o_file))
+
+
+def extract_function_body_from_text(text: str, symbol: str,
+                                    source_label: str = "<disassembly>") -> list:
+    """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
+    `symbol` in `text`: every instruction line from the `<symbol>:` header up to
+    (exclusive) the next symbol header or a blank line that ends the block.
+    Trailing inter-function padding (alignment NOPs / data16) is stripped.
+
+    Raises SymbolNotEmittedError if the symbol is absent (inlined, not emitted
+    standalone) and RuntimeError if an in-body line is unparsable and not
+    recognizable padding, or if the body is empty.
+    """
     in_body = False
     saw_symbol = False
     instrs = []
@@ -219,35 +298,37 @@ def extract_function_body(o_file: Path, symbol: str,
                     # trailing bytes to the instruction they belong to.
                     instrs[-1]["bytes"].extend(ci.group(1).split())
                     continue
+                # Lenient fallback for NOP/data16 padding lines whose single-tab
+                # byte/mnemonic spacing _disasm_line cannot match. Padding is
+                # removed by the trailing-strip below, so absorbing it here is
+                # safe and keeps the build green on clang-15+/gcc-11/14.
+                pm = _padding_line.match(line)
+                if pm:
+                    instrs.append(_instr_from_match(pm))
+                    continue
                 # Any other in-body line we cannot parse must be loud, not
                 # silently dropped: a dropped instruction would weaken the
                 # comparison without anyone noticing.
                 raise RuntimeError(
-                    f"unparsable disassembly line for {symbol!r} in {o_file}: "
-                    f"{line!r}")
-            addr_hex, bytes_str, mnemonic, operands = mi.groups()
-            instrs.append({
-                "address": addr_hex,
-                "bytes": bytes_str.split(),
-                "mnemonic": mnemonic,
-                "operands": (operands or "").strip(),
-            })
+                    f"unparsable disassembly line for {symbol!r} in "
+                    f"{source_label}: {line!r}")
+            instrs.append(_instr_from_match(mi))
 
     if not saw_symbol:
-        raise RuntimeError(
-            f"symbol {symbol!r} not found in disassembly of {o_file}. "
+        raise SymbolNotEmittedError(
+            f"symbol {symbol!r} not found in disassembly of {source_label}. "
             f"The impl must be emitted standalone (its address taken for the "
             f"dispatch table) for its symbol to appear in the object file.")
-    # Strip trailing NOP-family instructions: padding emitted after the
-    # function's final control-flow terminator to align the NEXT function. It
-    # belongs to no function and varies with inter-function layout, so it is
-    # not part of this function's codegen. Internal alignment nops (e.g. before
-    # a hot loop) are mid-body and are preserved.
-    while instrs and instrs[-1]["mnemonic"].startswith("nop"):
+    # Strip trailing padding (NOP family + data16): bytes emitted after the
+    # function's final control-flow terminator to align the NEXT function. They
+    # belong to no function and vary with inter-function layout, so they are not
+    # part of this function's codegen. Internal alignment nops (e.g. before a
+    # hot loop) are mid-body and are preserved.
+    while instrs and _is_trailing_padding(instrs[-1]["mnemonic"]):
         instrs.pop()
     if not instrs:
         raise RuntimeError(
-            f"symbol {symbol!r} found in {o_file} but its body is empty")
+            f"symbol {symbol!r} found in {source_label} but its body is empty")
     return instrs
 
 
@@ -387,6 +468,7 @@ def main():
 
     failures = []
     errors = []
+    skipped = []
     for t in tuples:
         try:
             a_o = resolve_object(args.build_lib_dir, t["impl_a"]["machine_o"])
@@ -395,6 +477,15 @@ def main():
                 a_o, t["impl_a"]["symbol"], objdump=args.objdump)
             b_instrs = extract_function_body(
                 b_o, t["impl_b"]["symbol"], objdump=args.objdump)
+        except SymbolNotEmittedError as e:
+            # Compiler inlined the impl rather than emitting it standalone
+            # (e.g. macOS clang): nothing to compare, so skip with a loud
+            # warning instead of failing the build. A present-but-divergent
+            # body is unaffected -- it still fails below.
+            print(f"codegen-equivalence: WARNING: skipping {tuple_id(t)}: {e}",
+                  file=sys.stderr)
+            skipped.append(tuple_id(t))
+            continue
         except RuntimeError as e:
             errors.append((tuple_id(t), str(e)))
             continue
@@ -443,7 +534,10 @@ def main():
             print("", file=sys.stderr)
         sys.exit(1)
 
-    print(f"codegen-equivalence: ok ({len(tuples)} tuples checked)")
+    checked = len(tuples) - len(skipped)
+    extra = (f", {len(skipped)} skipped -- not emitted standalone: {skipped}"
+             if skipped else "")
+    print(f"codegen-equivalence: ok ({checked} tuples checked{extra})")
 
 
 if __name__ == "__main__":

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -193,6 +193,36 @@ tuple ids without disassembling, useful for inspecting a generated manifest.
   another architecture requires extending the register table in
   `_operand_class`.
 
+## Cross-compiler robustness (mtibbits/volk#145)
+
+The harness runs across the full CI compiler matrix (gcc-11..14, clang-14..19,
+macOS clang, static builds, with either `llvm-objdump` or GNU `objdump`). It
+normalizes away codegen *noise* that differs by compiler but is not a real
+equivalence violation, while still hard-failing on a genuine divergence.
+
+**Stripped / tolerated (not a failure):**
+
+- **Trailing alignment NOPs** of any encoding, including the multi-byte forms
+  clang-15+ and gcc-11/14 emit after the function's final terminator
+  (`66 2e 0f 1f 84 00 00 00 00 00  nopw %cs:(%rax,%rax)`). These pad the *next*
+  function's alignment and belong to no function. Some objdump variants render
+  such a line with only a single tab between the byte column and the mnemonic,
+  which the primary line regex cannot parse; a padding-only fallback regex
+  (`_padding_line`) handles that form. **Mid-body** alignment NOPs (e.g. before
+  a hot loop) are *preserved* — only the trailing run is stripped.
+- **Trailing `data16` padding** — how GNU objdump renders a multi-byte NOP pad
+  (`data16 cs nopw …`); treated as padding like the NOP family.
+- **Symbol not emitted standalone** (e.g. macOS clang inlines the impl): there
+  is nothing to compare, so the tuple is **skipped with a warning** and the
+  build stays green. The summary line reports `N skipped`.
+
+**Still a hard failure:**
+
+- A genuine post-normalization divergence (differing mnemonic sequence or
+  operand class) → `CHECK FAILED`, exit 1.
+- A missing/ambiguous `.o`, malformed manifest, an unparsable *non-padding*
+  in-body line, or an empty function body → `CHECK ERROR`, exit 2.
+
 ## See also
 
 - the dispatch-table integrity check (mtibbits/volk#58, PR #59) — the

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -102,6 +102,27 @@ on.
   flag set introduces register-allocation churn without changing the
   instruction stream's shape.
 
+## Required-mnemonic assertion (scalar-fallback guard)
+
+Equivalence to a reference does not prove an impl emits the intended ISA — a
+scalar fallback could be byte-identical to a scalar reference and pass every
+criterion above. Declare an optional `REQUIRE_MNEMONIC <regex>` on a tuple to
+*additionally* assert the compared function contains at least one instruction
+whose mnemonic matches the regex, checked against **each** impl independently:
+
+```cmake
+ADD_CODEGEN_EQUIVALENCE_TUPLE(
+    ...
+    REQUIRE_MNEMONIC "^vaddps"   # the function MUST emit a packed vaddps
+)
+```
+
+The regex is matched against each instruction's mnemonic (pass if any matches).
+On failure the build halts, naming the tuple, the pattern, and the mnemonics
+actually present. The field is **opt-in**: tuples without it are unaffected and
+produce identical manifest JSON to before. Use it on framework-instantiation
+tuples to guarantee the instantiation didn't silently fall back to scalar code.
+
 ## How the check runs
 
 1. **CMake configure:** each `ADD_CODEGEN_EQUIVALENCE_TUPLE` appends a JSON

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -424,7 +424,46 @@ def test_padding_line_mnemonics_are_strippable():
     self-defending if someone extends one side without the other."""
     mod = _load_module()
     for m in ("nop", "nopw", "nopl", "nopq", "data16"):
-        assert mod._is_trailing_padding(m), m
+        assert mod._is_trailing_padding({"mnemonic": m, "operands": ""}), m
+
+
+def test_trailing_xchg_and_int3_padding_stripped():
+    """Trailing `xchg %ax,%ax` (0x66 0x90, the legacy 2-byte NOP) and `int3`
+    (0xcc gap fill) are inter-function alignment padding and must be stripped.
+    Real-world: clang-15 on ubuntu-22.04 emits a trailing `xchg %ax,%ax` after
+    the function's final jmp, which failed byte_identical before this
+    (mtibbits/volk#145)."""
+    mod = _load_module()
+    xchg_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: eb 00                        \tjmp\t0x2 <f+0x2>\n"
+        "       2: 66 90                        \txchg\t%ax, %ax\n"
+    )
+    int3_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+        "       1: cc                           \tint3\n"
+    )
+    plain = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+    )
+    a = mod.extract_function_body_from_text(xchg_pad, "f")
+    b = mod.extract_function_body_from_text(int3_pad, "f")
+    c = mod.extract_function_body_from_text(plain, "f")
+    assert [i["mnemonic"] for i in a] == ["jmp"], a
+    assert [i["mnemonic"] for i in b] == ["retq"], b
+    assert mod.compare_byte_identical(b, c)[0]
+
+
+def test_real_xchg_is_not_stripped():
+    """Safety: a genuine register exchange `xchg %rax,%rbx` (different operands)
+    must NOT be treated as padding -- only the self-exchange NOP idiom is."""
+    mod = _load_module()
+    assert not mod._is_trailing_padding(
+        {"mnemonic": "xchg", "operands": "%rax, %rbx"})
+    assert mod._is_trailing_padding(
+        {"mnemonic": "xchg", "operands": "%ax, %ax"})
 
 
 def main():

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -267,6 +267,139 @@ def test_require_mnemonic_absent_fails():
     assert "^vadd" in diff and "addss" in diff, diff
 
 
+# ---------------------------------------------------------------------------
+# Cross-compiler robustness (mtibbits/volk#145)
+# ---------------------------------------------------------------------------
+
+def test_extract_from_text_seam_basic():
+    """The text seam parses a literal disassembly block: collects the body of
+    the named symbol, stops at the next symbol, strips the trailing NOP."""
+    mod = _load_module()
+    text = (
+        "0000000000000000 <fixture>:\n"
+        "       0: c5 fc 58 04 06               \tvaddps\t(%rsi,%rax), %ymm0, %ymm0\n"
+        "       5: c3                           \tretq\n"
+        "       6: 90                           \tnop\n"
+        "0000000000000010 <other>:\n"
+        "      10: c3                           \tretq\n"
+    )
+    instrs = mod.extract_function_body_from_text(text, "fixture")
+    assert [i["mnemonic"] for i in instrs] == ["vaddps", "retq"], instrs
+
+
+def test_trailing_multibyte_nop_does_not_raise():
+    """The multi-byte alignment NOP clang-15+/gcc-11/14 emit as trailing pad
+    renders with a SINGLE tab between the last byte and the mnemonic, which
+    _disasm_line cannot match. The padding fallback must parse it so the
+    trailing-strip drops it -- not raise 'unparsable'. The line below is the
+    real rendering captured from `llvm-objdump` on a clang-18 build of
+    volk_machine_avx_*.o (mtibbits/volk#145)."""
+    mod = _load_module()
+    # Normal short instructions render space-padded (>=2 ws before the tab);
+    # only the full-width 10-byte NOP renders with a lone tab -- the real
+    # captured failing form from llvm-objdump on a clang-18 machine .o.
+    text = (
+        "0000000000000000 <f1>:\n"
+        "       0: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+        "       4: c3                           \tretq\n"
+        "       5: 66 2e 0f 1f 84 00 00 00 00 00\tnopw\t%cs:(%rax,%rax)\n"
+        "0000000000000020 <f2>:\n"
+        "      20: c3                           \tretq\n"
+    )
+    instrs = mod.extract_function_body_from_text(text, "f1")
+    assert [i["mnemonic"] for i in instrs] == ["vaddps", "retq"], instrs
+
+
+def test_trailing_data16_padding_stripped():
+    """A trailing `data16` padding instruction (how GNU objdump renders the
+    multi-byte NOP pad) is not part of the function body and must be stripped,
+    so a data16-vs-none pad does not fail byte_identical."""
+    mod = _load_module()
+    with_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+        "       1: 66 66 2e 0f 1f 84 00 \tdata16\tcs nopw 0x0(%rax,%rax,1)\n"
+    )
+    without_pad = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+    )
+    a = mod.extract_function_body_from_text(with_pad, "f")
+    b = mod.extract_function_body_from_text(without_pad, "f")
+    assert [i["mnemonic"] for i in a] == ["retq"], a
+    ok, diff = mod.compare_byte_identical(a, b)
+    assert ok, diff
+
+
+def test_symbol_not_standalone_raises_typed():
+    """When a symbol is absent (inlined, not emitted standalone) the parser
+    raises the typed SymbolNotEmittedError so main() can skip-with-warning,
+    not the bare RuntimeError that aggregates into a build-failing CHECK ERROR."""
+    mod = _load_module()
+    text = ("0000000000000000 <other>:\n"
+            "       0: c3\tretq\n")
+    try:
+        mod.extract_function_body_from_text(text, "inlined_away")
+        assert False, "expected SymbolNotEmittedError"
+    except mod.SymbolNotEmittedError as e:
+        assert "inlined_away" in str(e), str(e)
+    # It must be a RuntimeError subclass so existing `except RuntimeError`
+    # callers still see it if they do not special-case it.
+    assert issubclass(mod.SymbolNotEmittedError, RuntimeError)
+
+
+def test_padding_strip_does_not_swallow_real_instruction():
+    """Negative control: a trailing NON-padding instruction (an extra vaddps)
+    must remain and still cause a divergence -- the strip is padding-only."""
+    mod = _load_module()
+    longer = ("0000000000000000 <f>:\n"
+              "       0: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+              "       4: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+              "       8: c3                           \tretq\n")
+    shorter = ("0000000000000000 <f>:\n"
+               "       0: c5 fc 58 c1                  \tvaddps\t%ymm1, %ymm0, %ymm0\n"
+               "       4: c3                           \tretq\n")
+    a = mod.extract_function_body_from_text(longer, "f")
+    b = mod.extract_function_body_from_text(shorter, "f")
+    ok, diff = mod.compare_byte_identical(a, b)
+    assert not ok and "count differs" in diff, (ok, diff)
+
+
+def test_end_to_end_divergent_pair_fails_build():
+    """Negative control (end-to-end): a manifest comparing two genuinely
+    divergent impls (add vs mul) exits 1 with CHECK FAILED -- proving the
+    hardened parser still breaks the build on a real codegen divergence."""
+    import shutil
+    cc = shutil.which("cc")
+    objdump = _which_objdump()
+    if not cc:
+        print("  (skip test_end_to_end_divergent_pair_fails_build: no cc)")
+        return
+    add = ("#include <immintrin.h>\n"
+           "__m256 nc_fn(__m256 a,__m256 b){return _mm256_add_ps(a,b);}\n")
+    mul = ("#include <immintrin.h>\n"
+           "__m256 nc_fn(__m256 a,__m256 b){return _mm256_mul_ps(a,b);}\n")
+    a_c = Path("/tmp/cge_nc_a.c"); a_c.write_text(add)
+    b_c = Path("/tmp/cge_nc_b.c"); b_c.write_text(mul)
+    a_o = Path("/tmp/cge_nc_a.o"); b_o = Path("/tmp/cge_nc_b.o")
+    for s, o in ((a_c, a_o), (b_c, b_o)):
+        subprocess.run([cc, "-O3", "-mavx", "-c", str(s), "-o", str(o)],
+                       check=True)
+    manifest = {"tuples": [{
+        "kernel": "nc", "isa": "avx", "alignment": "a",
+        "impl_a": {"symbol": "nc_fn", "machine_o": str(a_o)},
+        "impl_b": {"symbol": "nc_fn", "machine_o": str(b_o)},
+        "criterion": "byte_identical",
+    }]}
+    mpath = Path("/tmp/cge_nc_manifest.json"); mpath.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(mpath),
+         "--build-lib-dir", "/tmp", "--objdump", objdump],
+        capture_output=True, text=True)
+    assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+    assert "CHECK FAILED" in result.stderr, result.stderr
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -400,6 +400,33 @@ def test_end_to_end_divergent_pair_fails_build():
     assert "CHECK FAILED" in result.stderr, result.stderr
 
 
+def test_padding_fallback_data16_single_tab():
+    """Exercises the _padding_line fallback's `data16` arm specifically: a
+    single-tab `data16` pad line (which _disasm_line cannot parse) must be
+    caught by the fallback and then stripped. A space-padded `data16` line would
+    not reach the fallback -- it matches the primary _disasm_line -- so without
+    this case the fallback's data16 branch is untested (red-team Nit G2)."""
+    mod = _load_module()
+    text = (
+        "0000000000000000 <f>:\n"
+        "       0: c3                           \tretq\n"
+        "       1: 66 66 2e 0f 1f 84 00 00 00\tdata16\tcs nopw 0x0(%rax,%rax,1)\n"
+    )
+    instrs = mod.extract_function_body_from_text(text, "f")
+    assert [i["mnemonic"] for i in instrs] == ["retq"], instrs
+
+
+def test_padding_line_mnemonics_are_strippable():
+    """Invariant (red-team Nit J): every mnemonic the _padding_line fallback
+    accepts must also be removed by _is_trailing_padding -- otherwise a
+    fallback-absorbed pad would survive into the comparison and silently change
+    it. Pin representative members of the accepted set so the invariant is
+    self-defending if someone extends one side without the other."""
+    mod = _load_module()
+    for m in ("nop", "nopw", "nopl", "nopq", "data16"):
+        assert mod._is_trailing_padding(m), m
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -248,6 +248,25 @@ def test_gnu_objdump_continuation_lines():
         assert ok, f"GNU vs llvm byte streams differ after stitching:\n{diff}"
 
 
+def test_require_mnemonic_present_passes():
+    """A required-mnemonic assertion passes when the pattern is in the body."""
+    mod = _load_module()
+    body = [{"address": "10", "bytes": ["aa"], "mnemonic": "vaddps",
+             "operands": "%ymm0, %ymm1, %ymm2"}]
+    ok, diff = mod.check_require_mnemonic(body, "^vadd")
+    assert ok, diff
+
+
+def test_require_mnemonic_absent_fails():
+    """It fails (with the observed mnemonics) when the pattern is absent."""
+    mod = _load_module()
+    body = [{"address": "10", "bytes": ["aa"], "mnemonic": "addss",
+             "operands": "%xmm0, %xmm1"}]
+    ok, diff = mod.check_require_mnemonic(body, "^vadd")
+    assert not ok
+    assert "^vadd" in diff and "addss" in diff, diff
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -658,6 +658,7 @@ if(_cge_avx_machine)
         IMPL_A_MACHINE_O volk_machine_${_cge_avx_machine}.c.o
         IMPL_B_SYMBOL    volk_32f_x2_add_32f_a_avx_ref
         IMPL_B_MACHINE_O codegen_bootstrap_ref.c.o
+        REQUIRE_MNEMONIC "^vaddps"
     )
 else()
     message(STATUS "codegen-equivalence: no base-avx machine built; "

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -636,7 +636,19 @@ foreach(_cge_m ${available_machines})
         break()
     endif()
 endforeach()
-if(_cge_avx_machine)
+# Gate the bootstrap tuple to native 64-bit builds. The reference TU hardcodes
+# -m64 (below) to mirror the 64-bit host machine TU, but a 32-bit / cross target
+# that still builds an avx machine -- notably Android NDK "x86" (i686, 32-bit) --
+# compiles the machine TU 32-bit while the reference TU is forced 64-bit, so the
+# two genuinely diverge (addl/movl vs addq) and byte_identical fails on benign
+# bitness, not a real codegen regression. The reference TU cannot faithfully
+# mirror a 32-bit/cross machine TU, so skip the tuple there (zero tuples is a
+# valid, false-positive-free configuration). mtibbits/volk#145.
+set(_cge_bootstrap_enabled FALSE)
+if(_cge_avx_machine AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
+    set(_cge_bootstrap_enabled TRUE)
+endif()
+if(_cge_bootstrap_enabled)
     # Optimisation flags are INHERITED from the build config (CMAKE_C_FLAGS_<cfg>),
     # not hardcoded, so this TU matches the avx machine TU under any build type
     # (Release -O3, Debug -O0, ...) rather than only Release. Only the avx
@@ -660,6 +672,11 @@ if(_cge_avx_machine)
         IMPL_B_MACHINE_O codegen_bootstrap_ref.c.o
         REQUIRE_MNEMONIC "^vaddps"
     )
+elseif(_cge_avx_machine)
+    message(STATUS "codegen-equivalence: base-avx machine present but build is "
+                   "not 64-bit (sizeof(void*)=${CMAKE_SIZEOF_VOID_P}); bootstrap "
+                   "tuple skipped -- the 64-bit reference TU cannot match a "
+                   "32-bit/cross machine TU (e.g. Android NDK x86)")
 else()
     message(STATUS "codegen-equivalence: no base-avx machine built; "
                    "bootstrap tuple skipped (harness runs with zero tuples)")
@@ -672,7 +689,7 @@ endif()
 # manifest is empty and the check is a no-op (zero false positives on
 # origin/main). Mirrors the volk_check_dispatch_tables wiring (PR #59 / B15).
 FINALIZE_CODEGEN_EQUIVALENCE_HARNESS()
-if(_cge_avx_machine)
+if(_cge_bootstrap_enabled)
     add_dependencies(volk_check_framework_codegen volk_codegen_bootstrap_ref)
 endif()
 add_dependencies(volk volk_check_framework_codegen)


### PR DESCRIPTION
## Summary

The codegen-equivalence build check (`cmake/check_framework_codegen.py`, the
harness from #82/#84) is wired as a build dependency of `volk_obj`, so when its
disassembly parser chokes it fails the **whole build**. Its parser was overfit
to gcc-12/13 + clang-14 objdump output and reddened nearly the entire CI matrix
(gcc-11/14, clang-15–19, static, macOS) on **benign** codegen noise, not real
divergence — turning a build-gating check into a build-*breaking* one on most
compilers. This hardens the parser so it tolerates that benign noise — the check
stays build-gating and still hard-fails on a genuine divergence. (Verified by
real build on three compilers; full-matrix green is pending a CI run — see
Testing for exactly what was and was not executed.)

- **Trailing multi-byte alignment NOPs** (clang-15+/gcc-11/14) render with a
  single tab between the byte column and the mnemonic, which the primary line
  regex can't match. A padding-only fallback regex (`_padding_line`) parses
  that form so the existing trailing-strip drops it.
- **Trailing `data16` padding** (how GNU objdump renders the multi-byte NOP
  pad) is now stripped alongside the NOP family.
- **Symbol inlined, not emitted standalone** (macOS clang) raises a typed
  `SymbolNotEmittedError` that `main()` **skips with a warning** (build stays
  green) instead of aborting — a present-but-divergent body still fails.

A parse seam (`extract_function_body_from_text`) makes all three unit-testable
from captured disassembly text. Scope is deliberately narrow: the harness stays
build-gating (no CMake/manifest-schema change), x86_64 matrix only; AArch64/RISC-V
`within_noise` normalization remains the #78 future-promotion.

**Deviation from plan:** the planned `_padding_line` fallback kept a separate
mandatory `[ \t]+` separator and would not have matched the real failing line.
Reproducing the failure on a clang-18 build pinpointed the root cause — the
primary regex needs ≥2 whitespace chars between the last byte and the mnemonic,
but a full-width 10-byte NOP renders with a lone tab. The fallback was corrected
to anchor the padding mnemonic directly after the byte column. The fallback
(vs. rewriting the load-bearing primary regex) was confirmed the correct,
passing-path-safe altitude by an independent review.

## Related issues

Refs #145

> Not `Closes #145`: AC #1 ("`dev/all-prs` builds green across the **full** CI
> compiler matrix") is provable only by a green matrix CI run, which this PR's
> local evidence (three compilers) does not contain. Close #145 by hand once the
> post-merge CI run on `dev/all-prs` is green across the matrix.

## Testing

- **Unit suite** (`python3 cmake/test_check_framework_codegen.py`): **20/20 pass**,
  including 8 new tests — text-seam, trailing multi-byte NOP (real captured line),
  trailing `data16` strip, single-tab `data16` *fallback* path, typed
  skip-on-inline, padding-strip negative control, the `_padding_line` ⊆
  `_is_trailing_padding` invariant, and an end-to-end divergent-pair (add vs mul)
  that **exits 1 / `CHECK FAILED`** (proves the gate still catches real divergence).
- **Real builds (3 compilers, all on this x86-64 dev box)** — the check target
  was red on the first two before this change:
  - `clang-18`: was `CHECK ERROR — unparsable disassembly line` → now
    `codegen-equivalence: ok (1 tuples checked)`.
  - `gcc-14`: full build → `codegen-equivalence: ok (1 tuples checked)`.
  - `gcc-13.3` (the one compiler it passed on before): unchanged →
    `ok (1 tuples checked)` (confirms no behavior change on the passing path).
- **NOT executed end-to-end here** (honest scope): macOS clang (the symbol-inline
  skip path), "Build static" (the `data16` path), gcc-11, and clang-15/16/19.
  These are covered by **captured-disassembly unit fixtures**, not real builds —
  AC #1's full-matrix green still needs the post-merge CI run.
- **Static analysis:** N/A — Python-only change (`cmake/*.py` + README), zero
  changed C/C++ files, so clang-tidy/cppcheck/sanitizers have nothing to scan.
- Branch based on `dev/all-prs` (edits fork-only files).

## Checklist
- [x] Builds cleanly — verified by real build under clang-18, gcc-14, gcc-13 (rest fixture-covered, CI pending)
- [x] Tests pass (standalone `python3 cmake/test_check_framework_codegen.py`: 20/20; not wired into ctest by design)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
