### PR TITLE
validate FLOAT_CALLBACK parsing

### DIFF
--- a/apps/volk_option_helpers.cc
+++ b/apps/volk_option_helpers.cc
@@ -168,15 +168,15 @@ void option_list::parse(int argc, char** argv)
                             char* endptr = nullptr;
                             errno = 0;
                             double double_val = strtod(argv[++arg_number], &endptr);
+                            float float_val = (float)double_val;
                             if (endptr == argv[arg_number] || *endptr != '\0' ||
-                                errno == ERANGE ||
-                                !std::isfinite(static_cast<float>(double_val))) {
+                                errno == ERANGE || !std::isfinite(float_val)) {
                                 std::cerr << "Error: option '" << argv[arg_number - 1]
                                           << "' requires a numeric value, got '"
                                           << argv[arg_number] << "'" << std::endl;
                                 exit(1);
                             }
-                            ((void (*)(float))this_option->callback)(double_val);
+                            ((void (*)(float))this_option->callback)(float_val);
                         }
                     } catch (std::exception& exc) {
                         std::cerr << "A float option can only receive a number"

--- a/apps/volk_option_helpers.cc
+++ b/apps/volk_option_helpers.cc
@@ -12,6 +12,7 @@
 
 #include <limits.h>  // IWYU pragma: keep
 #include <cerrno>    // IWYU pragma: keep
+#include <cmath>     // for std::isfinite
 #include <cstdlib>   // IWYU pragma: keep
 #include <cstring>   // IWYU pragma: keep
 #include <exception> // for exception
@@ -165,8 +166,11 @@ void option_list::parse(int argc, char** argv)
                         }
                         {
                             char* endptr = nullptr;
+                            errno = 0;
                             double double_val = strtod(argv[++arg_number], &endptr);
-                            if (endptr == argv[arg_number] || *endptr != '\0') {
+                            if (endptr == argv[arg_number] || *endptr != '\0' ||
+                                errno == ERANGE ||
+                                !std::isfinite(static_cast<float>(double_val))) {
                                 std::cerr << "Error: option '" << argv[arg_number - 1]
                                           << "' requires a numeric value, got '"
                                           << argv[arg_number] << "'" << std::endl;


### PR DESCRIPTION
## Summary
The `volk_profile` float-option parser (`FLOAT_CALLBACK` in
`apps/volk_option_helpers.cc`) validated only `endptr` after `strtod`, so
overflow, `inf`, and `NaN` were accepted silently — e.g. `volk_profile -t 1e999`
became an `inf` tolerance and `-t nan` produced a tolerance that fails every
comparison. This mirrors the INT path's existing `errno`/`ERANGE` hardening
(PR #19) onto the FLOAT path: set `errno = 0` before `strtod`, reject `ERANGE`,
and reject non-finite results — rejecting at **parse time**, before the value
ever reaches the `set_tolerance` callback. Finiteness is tested on the narrowed
`float` (the value actually passed to the callback), so it also catches values
that are finite as a `double` but overflow to `inf` when narrowed to `float`
(e.g. `-t 1e300`). The narrowing is done once into a `float` local and both
validated and passed, mirroring the INT path's `int_val` handling. No behavior
change for valid inputs.

**Base / stacking:** this branch is based on **`fix/12-volk-profile-parser-crashes`
(PR #19)**, which introduced the `strtod` conversion and the `<cerrno>` include
this fix builds on. It does **not** apply to `origin/main` (still `atof`). The PR
base must be set to `fix/12` (or held until #19 merges) — the dependency is
mechanical, not just narrative.

## Scope (and what is deliberately out)
In scope: reject non-finite / out-of-`float`-range tolerances at parse time
(`ERANGE`, `NaN`, `inf`, and finite-double-overflows-float).

Out of scope, by design:
- **Negative tolerances** (`-t -1`): a separate validation concern, handled in
  `set_tolerance` itself on the integration branch (`dev/all-prs` has an
  `if (val < 0)` guard; the `fix/12` baseline does not). Not duplicated here.
- **Underflow to zero** (`-t 1e-300` → `0.0f`): a finite value; flushing a
  far-subnormal tolerance to 0 is standard float behavior, not the
  overflow/NaN class this issue targets. Left as-is (noted in
  `imPlan-potentialFutureEnhancements.md`).
- The error message ("requires a numeric value, got 'X'") is reused verbatim
  from the INT path for consistency, though out-of-range input is technically
  numeric. Tightening the wording is deferred to keep both paths identical.

## Related issues
Closes #130
Related: #19 (baseline; this completes the FLOAT half of #19's parser hardening)

## Testing
- Build: `volk_profile` builds warning-clean; `clang-format-18` clean on changed lines.
- Manual (no `apps/` unit-test harness exists today — a known coverage gap;
  encoding this matrix as a CLI regression test is future work tracked with the
  apps test-infra):
  - Rejected with exit 1: `-t 1e999`, `-t nan`, `-t inf`, `-t 1e300`.
  - Accepted (exit 0): `-t 1e-6`, `-t 1e-3`, `-t 0`.
- Sanitizers (full `ctest`, 254 tests) on the first commit: ASan/UBSan/TSan all
  100% pass, 0 failures.
- Static analysis: the `static_analysis_diff` pass ran against an empty range
  (it diffs the pre-commit committed range — the known analyze-before-commit
  ordering gap), so it did **not** analyze this change; coverage here rests on
  the warning-clean build, sanitizer ctest, and the manual matrix.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`) — ASan/UBSan/TSan 254/254
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
