### PR TITLE
guard empty short-form match

### DIFF
--- a/apps/volk_option_helpers.cc
+++ b/apps/volk_option_helpers.cc
@@ -116,7 +116,8 @@ void option_list::parse(int argc, char** argv)
              this_option++) {
             int int_val = INT_MIN;
             if (this_option->longform == std::string(argv[arg_number]) ||
-                this_option->shortform == std::string(argv[arg_number])) {
+                (!this_option->shortform.empty() &&
+                 this_option->shortform == std::string(argv[arg_number]))) {
                 matched = true;
 
                 if (d_present_options.count(this_option->longform) == 0) {


### PR DESCRIPTION
## Summary
A long-form-only option carries `shortform == ""` (since PR #35 changed the
empty-short-form constructor from a bare `"-"` to `""`). The parser match in
`option_list::parse` compared `shortform` to `argv[arg_number]` with no
empty-guard, so an **empty argv element** (`prog ""`) equalled the empty
`shortform` and matched every long-form-only option, firing their callbacks
(the match loop doesn't break). This guards the comparison: require a non-empty
short-form before comparing it. Long options and options with a real short-form
are unaffected.

**Base / stacking:** based on **`feat/34` (PR #35)**, which introduced the
empty-short-form behavior this completes. `feat/34` is itself rebased onto
`fix/130` (#130) → `fix/12` (#19), so the branch carries the full parser stack.
PR base must be `feat/34` (or held until #35 merges).

## Related issues
Closes #131
Related: #35 (baseline; this closes the empty-argv hole #35 opened)

## Testing
- Isolated parser unit-proof (the runtime trigger — `volk_profile`'s
  `--with-minmax`/`--trial-csv` long-form-only options — exists only on
  `dev/all-prs`, not on `feat/34`, so the parser logic was tested directly):
  - Unguarded (`feat/34` baseline): empty arg **fires** the long-form-only
    callback (BUG).
  - Guarded (this fix): empty arg fires nothing (correct).
- Non-regression: `volk_profile -t 1e-3`, `--help` exit 0.
- Static analysis on changed lines (119-120): cppcheck/cpplint/clang-tidy/iwyu/
  clang-format all 0 novel; ASan/UBSan/TSan pass.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (ctest under ASan/UBSan/TSan)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
