### PR TITLE
read_results std-getline tokenizer

### DIFF
--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -15,6 +15,7 @@
 #include <iomanip>  // for setprecision, fixed
 #include <iostream> // for operator<<, basic_ostream
 #include <map>      // for map, map<>::iterator
+#include <sstream>  // for istringstream
 #include <utility>  // for pair
 #include <vector>   // for vector, vector<>::const_...
 
@@ -225,32 +226,16 @@ void read_results(std::vector<volk_test_results_t>* results, std::string path)
     if (config_status) {
         // a config exists and we are reading results from it
         std::ifstream config(path.c_str());
-        char config_line[256];
-        while (config.getline(config_line, 255)) {
+        std::string config_line;
+        while (std::getline(config, config_line)) {
             // tokenize the input line by kernel_name unaligned aligned
             // then push back in the results vector with fields filled in
 
+            std::istringstream iss(config_line);
             std::vector<std::string> single_kernel_result;
-            std::string config_str(config_line);
-            std::size_t str_size = config_str.size();
-            std::size_t found = config_str.find(' ');
-
-            // Split line by spaces
-            while (found && found < str_size) {
-                found = config_str.find(' ');
-                // kernel names MUST be less than 128 chars, which is
-                // a length restricted by volk/volk_prefs.c
-                // on the last token in the parsed string we won't find a space
-                // so make sure we copy at most 128 chars.
-                if (found > 127) {
-                    found = 127;
-                }
-                str_size = config_str.size();
-                char line_buffer[128] = { '\0' };
-                config_str.copy(line_buffer, found + 1, 0);
-                line_buffer[found] = '\0';
-                single_kernel_result.push_back(std::string(line_buffer));
-                config_str.erase(0, found + 1);
+            std::string token;
+            while (iss >> token) {
+                single_kernel_result.push_back(token);
             }
 
             if (single_kernel_result.size() == 3) {


### PR DESCRIPTION
## Summary
`read_results` parsed the volk config through fixed stack buffers (`char[256]`
line buffer via `istream::getline(.., 255)`, `char[128]` token buffer with manual
`copy`/`erase`/offset walking). Beyond truncation, an over-long line set the
stream failbit and ended the read loop — silently dropping the *entire rest* of
the config. This rewrites the read/tokenize path to `std::getline(std::string)`
+ `std::istringstream` extraction (the file is already C++). Same 3-field
(`name unaligned aligned`) semantics; net −15 LOC.

Incidentally improves robustness to foreign/hand-edited configs (collapses
repeated whitespace, tolerates a trailing CR on CRLF lines). Latent hardening,
not an active defect (today's kernel+impl strings fit the old
caps), per the issue.

**Base / stacking:** based on **`fix/30` (PR #31, cerr routing)**, which also edits
`apps/volk_profile.cc`. PR base must be `fix/30` (or held until #31 merges).

## Related issues
Closes #137
Related: #31 (baseline, same file)

## Testing
- Tokenizer equivalence (isolated old-vs-new harness, no apps test harness exists):
  - Well-formed config (comments + single-space 3-field lines + blank line):
    **identical** `(name,u,a)` tuples (old == new).
  - Config with a >255-char line: old drops the long line **and everything after**
    (failbit); new parses the long line and continues — the bug, fixed.
- Real round-trip: `volk_profile -R __nomatch__ -u` reads `~/.volk/volk_config`,
  exit 0, no error.
- Static on changed lines (18, 229-238): cppcheck/cpplint/clang-tidy/iwyu/
  clang-format 0 novel; ASan/UBSan/TSan pass.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (ctest under ASan/UBSan/TSan)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
