### PR TITLE
bounded volk_prefs config line read

### DIFF
--- a/lib/volk_prefs.c
+++ b/lib/volk_prefs.c
@@ -99,10 +99,42 @@ void volk_get_config_path(char* path, bool read)
     return;
 }
 
+// Reads one full line into *buf (caller-owned, must be free()d), returning its
+// length or -1 at EOF/alloc-failure. Hand-rolled rather than POSIX getline()
+// because this TU is compiled as C++ under MSVC, where getline() is absent. The
+// 128 below is a growth seed, not a line-length cap: the buffer grows without
+// limit, so a long line is parsed as one record instead of split (cf. line[512]).
+static long read_config_line(char** buf, size_t* cap, FILE* f)
+{
+    size_t len = 0;
+    int c;
+    while ((c = getc(f)) != EOF) {
+        if (len + 1 >= *cap) { // reserve one byte for the NUL terminator
+            size_t ncap = *cap ? *cap * 2 : 128;
+            char* new_buf = (char*)realloc(*buf, ncap);
+            if (!new_buf) {
+                printf("volk_load_preferences: bad malloc\n");
+                return -1; // *buf still points at the valid old block
+            }
+            *buf = new_buf;
+            *cap = ncap;
+        }
+        (*buf)[len++] = (char)c;
+        if (c == '\n')
+            break;
+    }
+    if (len == 0) // EOF with no bytes read
+        return -1;
+    (*buf)[len] = '\0';
+    return (long)len;
+}
+
 size_t volk_load_preferences(volk_arch_pref_t** prefs_res)
 {
     FILE* config_file;
-    char path[CONFIG_PATH_MAX], line[512];
+    char path[CONFIG_PATH_MAX];
+    char* line = NULL;
+    size_t line_cap = 0;
     size_t n_arch_prefs = 0;
     volk_arch_pref_t* prefs = NULL;
 
@@ -115,7 +147,7 @@ size_t volk_load_preferences(volk_arch_pref_t** prefs_res)
         return n_arch_prefs; // no prefs found
 
     // reset the file pointer and write the prefs into volk_arch_prefs
-    while (fgets(line, sizeof(line), config_file) != NULL) {
+    while (read_config_line(&line, &line_cap, config_file) != -1) {
         void* new_prefs = realloc(prefs, (n_arch_prefs + 1) * sizeof(*prefs));
         if (!new_prefs) {
             printf("volk_load_preferences: bad malloc\n");
@@ -128,6 +160,7 @@ size_t volk_load_preferences(volk_arch_pref_t** prefs_res)
             n_arch_prefs++;
         }
     }
+    free(line);
     fclose(config_file);
     *prefs_res = prefs;
     return n_arch_prefs;


### PR DESCRIPTION
## Summary

`volk_load_preferences` read the user `volk_config` line-by-line into a fixed
`char line[512]` stack buffer. Any config line longer than 511 bytes is silently
split by `fgets` across loop iterations: the leading chunk parses normally and the
trailing fragment re-enters the loop as if it were a new record — usually dropped
by the `strncmp(p->name, "volk_", 5)` guard, but a continuation that happens to
begin with `volk_` produces a **spurious preference entry**. This replaces the
fixed-buffer read with a small file-local `read_config_line` helper — a portable
`getline(3)` equivalent that grows a heap buffer geometrically — so an arbitrarily
long line is parsed (or rejected) as a single logical record. The existing
`%127s` token-width guards, the `volk_` prefix filter, and the on-disk config
format are all unchanged; every well-formed config parses identically.

The helper is hand-rolled rather than POSIX `getline(3)` because this translation
unit is compiled as **C++ under MSVC** (`lib/CMakeLists.txt` forces
`LANGUAGE CXX`), where `getline(3)` is unavailable — the helper is one code path
valid in both C and C++, with no build-wiring change. The `128`-byte growth seed
is an allocation hint, not a line-length cap (the buffer grows without limit);
this is called out in the code comment so it isn't misread as a new `line[512]`.

This was a deliberate carve-out from #137, which modernized the sibling
`read_results` parser in `apps/volk_profile.cc`; `volk_prefs.c` was the remaining
fixed-buffer reader of the same config format. Robustness/maintainability only —
the earlier `%127s`/path overflow hardening (#14, `9af9ae15`) is untouched.

## Related issues

Closes #160
Related: #137 (sibling parser modernization), #14 (prior overflow hardening — not reopened)

## Testing

- **Old-vs-new differential harness** (throwaway; no committed lib config-parser
  test exists yet — deferred, same gap as #130/#131/#137), compiled and run as
  **both C and C++**:
  - Well-formed multi-line config (volk lines + comment + blank + non-volk line):
    OLD and NEW emit the **identical** record set and order (AC: equivalence).
  - A >511-byte line with a junk tail plus a following real line: OLD == NEW.
  - A 539-byte line crafted so the 512-byte `fgets` split lands exactly at a
    `volk_`-prefixed tail token: **OLD fabricates a spurious record**
    (`volk_SPURIOUS|a_evil|u_evil`), **NEW emits one record** and no tail entry —
    the motivating bug, fixed.
- **Build**: changed TU compiles with the project's exact flags
  (`-Wall -Werror=incompatible-pointer-types -Werror=pointer-sign …`), exit 0, no
  warnings. (The full-tree build stops earlier at the unrelated
  `volk_check_dispatch_tables` integrity check, #58 — `volk_prefs.c` is not
  implicated.)
- **Static analysis / sanitizers**: clang-format, clang-tidy, cppcheck,
  scan-build, tsan all clean on the changed lines. (cpplint's 5 nits conflict with
  the repo's own `.clang-format`, so they are non-actionable.)
- **No format change** → existing `volk_profile` write/reload round-trip behavior
  is preserved (`write_results` untouched; load-path equivalence shown above).

## Checklist
- [x] Builds cleanly (changed TU compiles clean; full build blocked by unrelated #58 pre-check)
- [ ] Tests pass (`ctest`) — no lib config-parser test target; equivalence shown via differential harness
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — `lib/volk_prefs.c` only, +35/−2
