### PR TITLE
armhf NEON detection fallback flags

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -228,10 +228,42 @@ endif(NOT CPU_IS_x86)
 
 include(CheckCSourceCompiles)
 
+# On native 32-bit armhf toolchains (e.g. gcc on a Raspberry Pi) NEON is not
+# enabled by default, so the default-flag probe fails and -- without the fallback
+# below -- every NEON arch is overruled and the build silently loses all NEON
+# acceleration.
+set(VOLK_NEON_TEST_SOURCE "#include <arm_neon.h>
+int main(){ uint8_t *dest; uint8x8_t res; vst1_u8(dest, res); }")
+
+# Flags that enable NEON on a native armhf toolchain, and a single ARM-target test.
+# Both the fallback retry and the warning below must agree on "is this ARM", and the
+# detection retry and the build must use the same flags -- keep them single-sourced.
+set(VOLK_NEON_FALLBACK_FLAGS "-mfpu=neon -march=armv7-a")
+set(VOLK_TARGET_IS_ARM FALSE)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|aarch64.*)$")
+    set(VOLK_TARGET_IS_ARM TRUE)
+endif()
+
 set(CMAKE_C_FLAGS_SAVED "${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-uninitialized")
-check_c_source_compiles("#include <arm_neon.h>
-int main(){ uint8_t *dest; uint8x8_t res; vst1_u8(dest, res); }" neon_compile_result)
+
+# First probe: default flags. Passes on aarch64 (mandatory ASIMD) and any
+# toolchain with NEON enabled by default.
+check_c_source_compiles("${VOLK_NEON_TEST_SOURCE}" neon_compile_result)
+
+set(VOLK_NEON_ARMV7_FALLBACK FALSE)
+if(NOT neon_compile_result AND VOLK_TARGET_IS_ARM)
+    # Native armhf does not enable NEON by default. Retry with explicit
+    # NEON-enabling flags before giving up. A DISTINCT result variable is required:
+    # check_c_source_compiles caches its result, so reusing neon_compile_result
+    # would return the stale failure.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${VOLK_NEON_FALLBACK_FLAGS}")
+    check_c_source_compiles("${VOLK_NEON_TEST_SOURCE}" neon_compile_result_armv7)
+    if(neon_compile_result_armv7)
+        set(neon_compile_result TRUE)
+        set(VOLK_NEON_ARMV7_FALLBACK TRUE)
+    endif()
+endif()
 
 if(neon_compile_result)
     set(CMAKE_REQUIRED_INCLUDES ${PROJECT_SOURCE_DIR}/include)
@@ -248,11 +280,31 @@ if(neon_compile_result)
         overrule_arch(neonv8 "Compiler doesn't support neonv8")
     endif()
 else(neon_compile_result)
+    if(VOLK_TARGET_IS_ARM)
+        message(WARNING
+            "VOLK: NEON could not be enabled on ARM target "
+            "'${CMAKE_SYSTEM_PROCESSOR}' even with ${VOLK_NEON_FALLBACK_FLAGS}. "
+            "All NEON kernels are DISABLED; only generic C kernels will run. "
+            "Check that the compiler supports NEON for this target.")
+    endif()
     overrule_arch(neon "Compiler doesn't support NEON")
     overrule_arch(neonv7 "Compiler doesn't support NEON")
     overrule_arch(neonv8 "Compiler doesn't support NEON")
 endif(neon_compile_result)
+
+# Restore the probe-only flags (-Wno-uninitialized). When the armv7 fallback was
+# needed to detect NEON, persist its flags into the build. A cross toolchain file
+# would normally carry these; a native armhf build has none, so without this:
+#   - the plain `neon` machine TU (compiled with the `neon` arch flags only, no
+#     -mfpu=neon) fails to compile arm_neon.h intrinsics, and
+#   - the hand-written NEON .s kernels (globbed in once neonv7 is available) fail to
+#     assemble with "selected FPU does not support instruction".
+# So propagate the flags to both the C compiler and the assembler.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_SAVED}")
+if(VOLK_NEON_ARMV7_FALLBACK)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${VOLK_NEON_FALLBACK_FLAGS}")
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${VOLK_NEON_FALLBACK_FLAGS}")
+endif()
 ########################################################################
 # implement overruling in the ORC case,
 # since ORC always passes flag detection


### PR DESCRIPTION
## Summary

On native 32-bit ARM (armhf) toolchains — e.g. gcc on a Raspberry Pi — NEON is not
enabled by default, so VOLK's `arm_neon.h` capability probe in `lib/CMakeLists.txt`
fails to compile and the build silently overrules `neon`, `neonv7`, and `neonv8`,
dropping every NEON kernel and running generic C on NEON-capable hardware.

This adds a fallback to the NEON detection probe: when the default-flag probe fails
**on an ARM target**, it retries with `-mfpu=neon -march=armv7-a` (using a distinct,
cache-safe result variable). When the fallback is what detected NEON, those flags are
persisted into both `CMAKE_C_FLAGS` and `CMAKE_ASM_FLAGS` for the build — required
because the plain `neon` machine TU and the hand-written NEON `.s` kernels are otherwise
compiled/assembled without `-mfpu=neon` and fail to build on native armhf. If NEON still
can't be enabled on an ARM target, a loud `CMake Warning` is emitted instead of silently
disabling NEON. Detection/build-config only — confined to `lib/CMakeLists.txt`; no
kernel, codegen (`archs.xml`), or dispatch changes.

## Design note

Why persist into global `CMAKE_C_FLAGS`/`CMAKE_ASM_FLAGS` rather than add `-mfpu=neon`
to the `neon` arch in `gen/archs.xml`? The archs.xml route would fix only the `neon`
machine C TU — it does not reach the hand-written `kernels/volk/asm/neon/*.s` kernels,
which are assembled with `CMAKE_ASM_FLAGS` (normally supplied by a cross toolchain file,
empty on a native armhf build; see the existing comment at `lib/CMakeLists.txt`). The
global persist is the more complete native-armhf fix and is gated to fire **only** when
the armv7 fallback was what detected NEON, so aarch64, x86, and proper cross-toolchain
builds are untouched. A narrower archs.xml refinement is noted for future work.

## Related issues

Closes #167.

## Testing

Reproduced and verified on a real cross-toolchain (`arm-linux-gnueabihf-gcc 13.3.0`,
which like the Pi 4's gcc-14 does not enable NEON by default):

- **Bug reproduced:** the probe program compiles only with `-mfpu=neon -march=armv7-a`
  (exit 1 default, exit 0 with the flags).
- **armhf configure:** first probe `Failed`; fallback `neon_compile_result_armv7 -
  Success`; `Available architectures: …;neon;neonv7`; `neonv8` correctly overruled
  (armv7, not v8); no warning; `asm flags: -mfpu=neon -march=armv7-a`.
- **armhf full build** (`cmake --build --target volk_obj`): **succeeds** — builds the
  `neon`/`neonv7` machine TUs and all `kernels/volk/asm/neon/*.s` kernels (these fail
  before the assembler-flags fix).
- **x86_64 no-regression:** first probe fails, ARM-target guard excludes x86 → fallback
  not run, NEON overruled exactly as before, no spurious warning, global flags unchanged.
- **aarch64:** passes the first probe (mandatory ASIMD), never enters the fallback →
  behavior identical to today.
- Static analysis + sanitizers (ASan/UBSan/TSan/scan-build/clang-format/cppcheck/
  clang-tidy) clean on the diff.

## Checklist
- [x] Builds cleanly (`cmake --build`) — verified on armhf cross + x86_64
- [x] Tests pass (`ctest`) — n/a to the configure probe; build verified instead
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — single-file CMake detection/build-config change
