### PR TITLE
buffer-role registry skip/partial to FAIL

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -687,6 +687,7 @@ if(ENABLE_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/test_correctness.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_reference.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
+            ${CMAKE_CURRENT_SOURCE_DIR}/volk_buffer_roles.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk_static)
     else()
         volk_gen_test(volk_test_all SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc
@@ -696,6 +697,7 @@ if(ENABLE_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/test_correctness.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_reference.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
+            ${CMAKE_CURRENT_SOURCE_DIR}/volk_buffer_roles.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk)
     endif()
     target_link_libraries(volk_test_all fmt::fmt)

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -1896,7 +1896,8 @@ volk_canary_summary run_volk_canary_test(volk_func_desc_t desc,
                                          unsigned int vlen,
                                          std::vector<volk_test_results_t>* results,
                                          const std::vector<float>& float_edge_cases,
-                                         const std::vector<lv_32fc_t>& complex_edge_cases)
+                                         const std::vector<lv_32fc_t>& complex_edge_cases,
+                                         unsigned int contracted_elems)
 {
     volk_canary_summary summary;
 
@@ -2086,8 +2087,23 @@ volk_canary_summary run_volk_canary_test(volk_func_desc_t desc,
             // (deterministic) value in both runs, so it cannot equal S1 after run 1
             // AND S2 after run 2. A byte that still equals both sentinels was never
             // written -- an in-bounds element left untouched (which ASan cannot see).
+            // #161: for a registered kernel (contracted_elems > 0) only the first
+            // `contracted_elems` elements are contracted to be written; scan just that
+            // region so a reduction's expected unwritten tail is not flagged, while an
+            // under-write of the contracted region still is. 0 = unregistered: scan the
+            // whole buffer exactly as before.
             const uint8_t* d2 = static_cast<const uint8_t*>(gbufs[j]->data());
-            for (size_t b = 0; b < gbufs[j]->data_bytes(); b++) {
+            size_t scan_bytes = gbufs[j]->data_bytes();
+            if (contracted_elems > 0) {
+                const size_t elem_bytes =
+                    d.outputsig[j].size * (d.outputsig[j].is_complex ? 2 : 1);
+                const size_t contracted_bytes =
+                    static_cast<size_t>(contracted_elems) * elem_bytes;
+                if (contracted_bytes < scan_bytes) {
+                    scan_bytes = contracted_bytes;
+                }
+            }
+            for (size_t b = 0; b < scan_bytes; b++) {
                 if (snap_s1[j][b] == S1 && d2[b] == S2) {
                     arch_unwritten = true;
                     std::cout << name << ": canary found unwritten output byte on arch "

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -261,6 +261,13 @@ struct volk_canary_summary {
 // both sentinels across the two runs flags a never-written element. This canary is
 // allocator-independent and authoritative; ASan is best-effort double coverage.
 // Toggle is in the driver; run_volk_tests/default qa are untouched.
+// #161: `contracted_elems` declares how many elements per output buffer the kernel
+// is contracted to write (from the buffer-role registry). 0 = unregistered: scan
+// the whole output buffer for unwritten bytes exactly as before. N>0 = scan only
+// the first N elements (the contracted region); a survived sentinel there is a real
+// under-write, while survivals past the boundary are the expected reduction tail and
+// are ignored. This lets the driver promote a registered reduction's `part` to a
+// clean pass and a registered map's under-write to a hard FAIL.
 volk_canary_summary run_volk_canary_test(
     volk_func_desc_t,
     void (*)(),
@@ -269,7 +276,8 @@ volk_canary_summary run_volk_canary_test(
     unsigned int,
     std::vector<volk_test_results_t>* results = NULL,
     const std::vector<float>& float_edge_cases = std::vector<float>(),
-    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
+    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>(),
+    unsigned int contracted_elems = 0);
 
 // #90: outcome of run_volk_immutability_test. A kernel that writes any byte of an
 // input buffer (which an out-of-place kernel's contract forbids) sets `mutated`.

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -32,6 +32,7 @@
 #include "qa_canary_kernel.h" // for the planted output-canary negative controls (#89)
 #include "qa_utils.h"         // for volk_test_case_t, run_volk_tests
 #include "volk/volk_complex.h"
+#include "volk_buffer_roles.h" // for the per-kernel buffer-role registry (#161)
 #include "volk_reference.h" // for the independent double-precision oracle registry (#88)
 #include <volk/volk.h>
 
@@ -210,12 +211,46 @@ quiet_run(volk_test_case_t& tc,
     return fail;
 }
 
+// #161: single source of canary verdict truth, shared by the roster sweep and the
+// negative-control block, so the registry promotion path is itself exercised against
+// the planted controls. Maps the aggregated per-kernel canary signals + the kernel's
+// buffer-role entry (nullptr = unregistered) to the verdict the sweep emits:
+//   - any guard/over-run violation        -> "FAIL" (a buffer overflow is always a defect)
+//   - an unwritten contracted region:
+//       registered (entry != nullptr)     -> "FAIL" (declared map/reduction under-wrote
+//                                            its contract; for a registered kernel the
+//                                            runner scanned only the contracted region,
+//                                            so `any_unwritten` already means under-write)
+//       unregistered                      -> "part" (today's hedge: cannot tell a
+//                                            reduction's fixed-size output from a real
+//                                            map under-write without a declared role)
+//   - nothing guardable observed at all   -> "skip" (fail closed; never masquerade as ok)
+//   - else                                -> "ok"
+static const char* classify_canary(bool any_applied,
+                                   bool any_guard,
+                                   bool any_unwritten,
+                                   const volk_buffer_roles_entry* entry)
+{
+    if (any_guard)
+        return "FAIL";
+    if (any_unwritten)
+        return entry ? "FAIL" : "part";
+    if (!any_applied)
+        return "skip";
+    return "ok";
+}
+
 // #89: run the output-buffer canary for one (kernel, vlen) with stdout muted
 // (mirrors quiet_run). Returns the split summary so the driver can treat a buffer
 // over/under-write (always a defect) differently from an in-bounds unwritten
 // element (expected for reduction/index kernels). On an exception, the guarded
 // path could not complete -- reported as a guard violation to surface it.
-static volk_canary_summary quiet_canary_run(volk_test_case_t& tc, unsigned int v)
+// #161: `contracted_elems` is the per-output contracted write count from the
+// buffer-role registry (0 = unregistered, scan whole buffer as before; for a map
+// pass `v`, for a reduction pass its fixed element count). Threaded to the runner
+// so a registered reduction's expected unwritten tail is not flagged.
+static volk_canary_summary
+quiet_canary_run(volk_test_case_t& tc, unsigned int v, unsigned int contracted_elems = 0)
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
@@ -237,7 +272,8 @@ static volk_canary_summary quiet_canary_run(volk_test_case_t& tc, unsigned int v
                                        v /*vlen*/,
                                        &results,
                                        kFloatEdges,
-                                       kComplexEdges);
+                                       kComplexEdges,
+                                       contracted_elems);
     } catch (...) {
         summary.guard_violation = true;
     }
@@ -563,6 +599,29 @@ int main(int argc, char* argv[])
             nc_err = "the planted kernel volk_32f_canaryunwritten_32f did not trip the "
                      "unwritten check — the canary is blind to in-bounds gaps";
         }
+        // #161: prove the registry PROMOTION path on the same planted control. The
+        // under-writing puppet, treated as a registered map (output_elems = 0), must be
+        // promoted by classify_canary to a hard FAIL; the SAME summary unregistered
+        // (nullptr) must stay the `part` hedge. This exercises the exact verdict mapping
+        // the roster sweep uses, against a control whose under-write is known.
+        if (!nc_err) {
+            const volk_buffer_roles_entry map_entry{ "volk_32f_canaryunwritten_32f", 0 };
+            const std::string promoted = classify_canary(unwritten_sum.applied,
+                                                         unwritten_sum.guard_violation,
+                                                         unwritten_sum.unwritten,
+                                                         &map_entry);
+            const std::string hedged = classify_canary(unwritten_sum.applied,
+                                                       unwritten_sum.guard_violation,
+                                                       unwritten_sum.unwritten,
+                                                       nullptr);
+            if (promoted != "FAIL") {
+                nc_err = "the under-writing planted kernel, registered as a map, was not "
+                         "promoted to FAIL — the #161 registry FAIL path is broken";
+            } else if (hedged != "part") {
+                nc_err = "the under-writing planted kernel, unregistered, did not stay "
+                         "`part` — the #161 backward-compat path is broken";
+            }
+        }
         if (nc_err) {
             std::cerr << "NEGATIVE CONTROL LOST: " << nc_err << ". Aborting.\n";
             if (report)
@@ -594,6 +653,8 @@ int main(int argc, char* argv[])
                 std::cout.flush();
                 continue;
             }
+            // #161: a registered kernel declares its contracted output cardinality.
+            const volk_buffer_roles_entry* roles = volk_buffer_roles_lookup(tc.name());
             std::vector<unsigned int> over_run;
             std::vector<unsigned int> partial;
             bool any_applied = false;
@@ -601,7 +662,13 @@ int main(int argc, char* argv[])
             std::map<std::string, std::vector<unsigned int>> guard_fails;
             std::map<std::string, std::vector<unsigned int>> unwritten_fails;
             for (unsigned int v : vlens) {
-                const volk_canary_summary s = quiet_canary_run(tc, v);
+                // #161: pass the contracted write count so the runner flags only an
+                // unwritten byte INSIDE the contracted region. Map => `v` elements;
+                // reduction => its fixed count; 0 => unregistered (whole-buffer scan,
+                // today's behavior).
+                const unsigned int contracted =
+                    roles ? (roles->output_elems == 0 ? v : roles->output_elems) : 0u;
+                const volk_canary_summary s = quiet_canary_run(tc, v, contracted);
                 if (s.applied)
                     any_applied = true;
                 if (s.guard_violation)
@@ -615,13 +682,16 @@ int main(int argc, char* argv[])
                 for (const std::string& impl : s.unwritten_impls)
                     unwritten_fails[impl].push_back(v);
             }
-            // A kernel the canary could not guard (no output buffer / unsupported
-            // signature) is SKIPPED, not reported ok — an unguarded kernel must not
-            // masquerade as covered. But a guard violation (incl. an exception, which
-            // quiet_canary_run reports as guard_violation) is a real defect and must
-            // FAIL even when no impl was successfully guarded: skip only when nothing
-            // was observed at all (fail closed).
-            if (!any_applied && over_run.empty() && partial.empty()) {
+            // #161: classify_canary is the single source of canary verdict truth
+            // (shared with the negative-control block). A kernel the canary could not
+            // guard at all is SKIPPED (fail closed); a guard/over-run is always a FAIL;
+            // an unwritten contracted region is a hard FAIL for a registered kernel (a
+            // declared map/reduction that under-wrote its contract) but stays the `part`
+            // hedge for an unregistered kernel (signature alone cannot tell a reduction's
+            // fixed-size output from a real map under-write).
+            const std::string verdict =
+                classify_canary(any_applied, !over_run.empty(), !partial.empty(), roles);
+            if (verdict == "skip") {
                 std::cout << "skip  [canary] " << tc.name()
                           << " (no guardable output buffer)\n";
                 if (report)
@@ -631,11 +701,18 @@ int main(int argc, char* argv[])
             }
             ++c_tested;
             const std::vector<unsigned int>* vl;
-            if (!over_run.empty()) {
+            if (verdict == "FAIL") {
                 ++c_failed;
-                vl = &over_run;
-                std::cout << "FAIL  [canary] " << tc.name() << "  over-run vlens:";
-            } else if (!partial.empty()) {
+                if (!over_run.empty()) {
+                    vl = &over_run;
+                    std::cout << "FAIL  [canary] " << tc.name() << "  over-run vlens:";
+                } else {
+                    // registered map/reduction that under-wrote its contracted region
+                    vl = &partial;
+                    std::cout << "FAIL  [canary] " << tc.name()
+                              << "  under-wrote contracted region, vlens:";
+                }
+            } else if (verdict == "part") {
                 ++c_partial;
                 vl = &partial;
                 std::cout << "part  [canary] " << tc.name()
@@ -650,13 +727,15 @@ int main(int argc, char* argv[])
             }
             std::cout << "\n";
             if (report) {
-                // Guard violation > unwritten (#92).
+                // Guard violation > unwritten (#92). For a registered kernel an
+                // unwritten contracted region is a FAIL, not a partial (#161).
+                const char* uw_label = roles ? "FAIL" : "partial";
                 emit_impl_rows(
                     report,
                     tc.name(),
                     "canary",
                     impls_seen,
-                    { { &guard_fails, "FAIL" }, { &unwritten_fails, "partial" } });
+                    { { &guard_fails, "FAIL" }, { &unwritten_fails, uw_label } });
                 // Guard-violation vlens with no impl attribution (an exception
                 // inside the guarded run) stay visible on a "-" row.
                 const std::vector<unsigned int> unattr =

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -215,12 +215,14 @@ quiet_run(volk_test_case_t& tc,
 // negative-control block, so the registry promotion path is itself exercised against
 // the planted controls. Maps the aggregated per-kernel canary signals + the kernel's
 // buffer-role entry (nullptr = unregistered) to the verdict the sweep emits:
-//   - any guard/over-run violation        -> "FAIL" (a buffer overflow is always a defect)
+//   - any guard/over-run violation        -> "FAIL" (a buffer overflow is always a
+//   defect)
 //   - an unwritten contracted region:
 //       registered (entry != nullptr)     -> "FAIL" (declared map/reduction under-wrote
 //                                            its contract; for a registered kernel the
 //                                            runner scanned only the contracted region,
-//                                            so `any_unwritten` already means under-write)
+//                                            so `any_unwritten` already means
+//                                            under-write)
 //       unregistered                      -> "part" (today's hedge: cannot tell a
 //                                            reduction's fixed-size output from a real
 //                                            map under-write without a declared role)

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -1217,6 +1217,42 @@ int main(int argc, char* argv[])
                           << uns_results.back().skip_reason << ")\n";
             }
         }
+
+        // #161: the buffer-role registry promotes a registered under-write from the
+        // canary's `part` hedge to a hard FAIL. Run the planted under-writer through
+        // the SAME run_volk_canary_test path and assert classify_canary (the verdict
+        // mapping the roster sweep uses) promotes it to FAIL when registered as a map,
+        // and keeps it `part` when unregistered. CI-enforced here so a regression to
+        // the promotion path or classify_canary breaks the build, not just the opt-in
+        // HARNESS_CANARY sweep.
+        {
+            std::vector<volk_test_results_t> uw_results;
+            const volk_canary_summary uw_sum =
+                run_volk_canary_test(volk_canary_desc(),
+                                     (void (*)())(&volk_32f_canaryunwritten_32f),
+                                     "volk_32f_canaryunwritten_32f",
+                                     power_scalar,
+                                     127u,
+                                     &uw_results,
+                                     kFloatEdges,
+                                     kComplexEdges);
+            const volk_buffer_roles_entry map_entry{ "volk_32f_canaryunwritten_32f", 0 };
+            const std::string promoted = classify_canary(
+                uw_sum.applied, uw_sum.guard_violation, uw_sum.unwritten, &map_entry);
+            const std::string hedged = classify_canary(
+                uw_sum.applied, uw_sum.guard_violation, uw_sum.unwritten, nullptr);
+            const bool good = uw_sum.unwritten && promoted == "FAIL" && hedged == "part";
+            std::cout << (good ? "ok    " : "LOST  ")
+                      << "[combined-nc] buffer-role promotion: under-writer registered "
+                         "as map → FAIL, unregistered → part (#161)\n";
+            if (!good) {
+                std::cerr << "NEGATIVE CONTROL LOST: the planted under-writer was not "
+                             "promoted to FAIL when registered as a map (or no longer "
+                             "stays `part` unregistered) — the #161 buffer-role "
+                             "promotion path is broken.\n";
+                lost = true;
+            }
+        }
         if (lost)
             return 2;
         std::cerr << "combined negative control OK: power flagged by the independent "

--- a/lib/volk_buffer_roles.cc
+++ b/lib/volk_buffer_roles.cc
@@ -1,0 +1,38 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "volk_buffer_roles.h"
+
+// Sparse, opt-in buffer-role registry (#161). See volk_buffer_roles.h for the
+// schema and "how to add a kernel". Proof-of-concept entries: reduction kernels
+// whose single-element output the canary otherwise reports as `part` (the rest of
+// the num_points-sized buffer is legitimately unwritten). Declaring output_elems=1
+// lets the canary confirm the one contracted element was written and emit a clean
+// pass. Grows over time -- comprehensive characterization is incremental follow-up.
+static const std::vector<volk_buffer_roles_entry> g_registry{
+    // result = sum_i input[i] * taps[i] -- writes a single float.
+    { "volk_32f_x2_dot_prod_32f", 1 },
+    // result = sum_i inputBuffer[i] -- writes a single float.
+    { "volk_32f_accumulator_s32f", 1 },
+};
+
+const std::vector<volk_buffer_roles_entry>& volk_buffer_roles_registry()
+{
+    return g_registry;
+}
+
+const volk_buffer_roles_entry* volk_buffer_roles_lookup(const std::string& name)
+{
+    for (const volk_buffer_roles_entry& e : g_registry) {
+        if (name == e.name) {
+            return &e;
+        }
+    }
+    return nullptr;
+}

--- a/lib/volk_buffer_roles.h
+++ b/lib/volk_buffer_roles.h
@@ -1,0 +1,56 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/*
+ * Per-kernel buffer-role registry for the kernel-correctness harness (#161).
+ * A sparse, opt-in table (modeled on lib/volk_reference.h's reference-oracle
+ * registry) that declares the buffer semantics a sweep cannot infer from a
+ * kernel's signature alone, so the sweep can replace a hedged verdict with a
+ * hard pass/FAIL.
+ *
+ * Currently declares OUTPUT CARDINALITY for the #89 output-canary sweep: how
+ * many elements the kernel is contracted to write per output buffer. The canary
+ * cannot otherwise distinguish a map kernel that under-wrote its output (a
+ * defect) from a reduction/index/accumulator kernel that writes a fixed-size
+ * scalar and legitimately leaves the rest of the buffer untouched -- it reports
+ * both as `part` (partial). With a declared cardinality the canary confirms the
+ * contracted region was written: a registered reduction becomes a clean pass and
+ * a registered map that under-writes becomes a hard FAIL.
+ *
+ * Input-mutability roles (which input buffers are read-only) for the #90
+ * input-immutability sweep are a planned extension; see this issue's
+ * potential-future-enhancements note.
+ *
+ * HOW TO ADD A KERNEL: append one volk_buffer_roles_entry to g_registry in
+ * volk_buffer_roles.cc, keyed by the exact kernel name. Set output_elems to 0
+ * for a map kernel (writes `vlen` elements per output) or to the fixed element
+ * count for a reduction (e.g. 1 for a dot product / accumulator / single-index).
+ * Unregistered kernels keep today's verdict exactly.
+ */
+
+#ifndef INCLUDED_VOLK_BUFFER_ROLES_H
+#define INCLUDED_VOLK_BUFFER_ROLES_H
+
+#include <string>
+#include <vector>
+
+struct volk_buffer_roles_entry {
+    const char* name;          // exact kernel name, e.g. "volk_32f_x2_dot_prod_32f"
+    unsigned int output_elems; // 0 => map (writes `vlen` per output); N>0 => fixed
+                               // (reduction/index/accumulator writes N elements)
+};
+
+// The opt-in registry. Sparse by design: only registered kernels get a promoted
+// canary verdict; everything else keeps today's `part`/`ok`. Grows over time.
+const std::vector<volk_buffer_roles_entry>& volk_buffer_roles_registry();
+
+// Returns the entry for `name`, or nullptr if the kernel is not registered.
+const volk_buffer_roles_entry* volk_buffer_roles_lookup(const std::string& name);
+
+#endif /* INCLUDED_VOLK_BUFFER_ROLES_H */

--- a/lib/volk_buffer_roles.h
+++ b/lib/volk_buffer_roles.h
@@ -32,6 +32,12 @@
  * for a map kernel (writes `vlen` elements per output) or to the fixed element
  * count for a reduction (e.g. 1 for a dot product / accumulator / single-index).
  * Unregistered kernels keep today's verdict exactly.
+ *
+ * NOTE: output_elems is a single value applied to EVERY output buffer of the
+ * kernel; it assumes all outputs share one cardinality (true for the single-output
+ * reductions registered today). A kernel with multiple outputs of differing
+ * cardinalities would need a per-output vector -- a planned extension, not yet
+ * needed.
  */
 
 #ifndef INCLUDED_VOLK_BUFFER_ROLES_H


### PR DESCRIPTION
## Summary

Adds a sparse, opt-in **per-kernel buffer-role registry** (`lib/volk_buffer_roles.{h,cc}`,
modeled on #88's `lib/volk_reference.{h,cc}`) so the #89 output-canary sweep can replace a
hedged `part` verdict with a hard pass/FAIL for registered kernels.

The canary plants guard bytes around the output buffer and flags in-bounds elements left
unwritten. A reduction/index/accumulator kernel writes a fixed-size scalar (one element),
not `num_points`, so the canary sees the rest of the buffer as "unwritten" and — unable to
tell that from a real map kernel that under-wrote — reports `part`. By declaring each
registered kernel's **output cardinality** (`output_elems`: 0 = map writes `vlen`, N>0 =
reduction writes N), the canary now confirms the *contracted* region was written:

- a registered reduction that writes its contracted element(s) → clean **pass** (was `part`);
- a registered map (or reduction) that under-writes its contracted region → hard **FAIL**.

The cardinality is threaded into the canary runner (`run_volk_canary_test`, defaulted
`contracted_elems=0`) so the unwritten scan is bounded to the contracted region — this
confirms the region was actually written rather than guessing at the verdict site, so a
no-op reduction would FAIL rather than silently pass. A single pure `classify_canary()`
is the shared source of verdict truth for both the roster sweep and the negative-control
block, so the FAIL-promotion path is exercised against the planted `canaryunwritten` puppet.

Test-harness-internal only — no kernel, codegen, dispatch, or public-API change.
Unregistered kernels keep today's verdict exactly (backward compatible by construction).

## Scope note

This implements the **#89 (output-canary) half** of the issue. The **#90 input-immutability
half is deferred**: building and running the harness showed every multi-buffer kernel
already gets a real `ok`/`FAIL` from the immutability sweep, and the only non-puppet
`skip [immutable]` is `volk_32f_s32f_normalize` (a legitimately in-place single buffer with
no separate read-only input — its skip is correct). No current VOLK kernel has the
in-place-output + read-only-array-input shape the #90 FAIL path targets, so there is no
honest real-kernel demonstration today. The input-mutability role design is preserved for
a follow-up; the registry entry is forward-compatible.

## Related issues

Implements the #89 half of #161 (the #90 half is deferred to a follow-up). Builds on #88
(reference registry, the pattern), #89 (output canary), #90 (input-immutability sweep).

## Testing

Built and ran `volk_test_correctness` on the `dev/all-prs` baseline:

- **Builds clean** (`cmake --build volk_test_correctness`, exit 0).
- **Negative-control gate passes** (`HARNESS_CANARY=1`, exit 0) — all planted controls
  still gate, including the new assertion that the `canaryunwritten` puppet, registered as
  a map, is promoted to `FAIL`, while unregistered it stays `part`.
- **CI-enforced:** the same promotion check is wired into the `harness_negative_control`
  ctest (`HARNESS_COMBINED_NC`) — the gate CI actually runs — so a regression to the
  promotion path breaks the build, matching the #87/#88/#133 controls (verified exit 0).
- **Reduction → pass:** `volk_32f_x2_dot_prod_32f` and `volk_32f_accumulator_s32f` both
  `part [canary]` → `ok [canary]`.
- **Unregistered unchanged:** `volk_32f_index_max_16u` still `part`.
- **Surgical:** verdict-line-only roster diff = exactly the 2 registered kernels
  (ok 90→92, part 22→20, skip unchanged); immutability roster byte-identical.
- **ASan:** built + ran the canary sweep under AddressSanitizer — zero reports (the new
  scan bound is provably within the original `[0, data_bytes)` range).
- Static analysis (clang-tidy / scan-build / iwyu / clang-format / cmake-lint / codespell /
  TSan) clean on the diff.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass — harness builds + the canary negative-control gate passes (exit 0)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — the #89 buffer-role/output-cardinality mechanism (test-only)
