### PR TITLE
uninitialized retval in chainback_viterbi

### DIFF
--- a/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
+++ b/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
@@ -56,7 +56,7 @@ static inline int chainback_viterbi(unsigned char* data,
      */
 
     d += tailsize * d_decision_t_size; /* Look past tail */
-    int retval;
+    int retval = endstate;
     int dif = tailsize - (d_k - 1);
     // printf("break, %d, %d\n", dif, (nbits+dif)%d_framebits);
     p_decision_t dec;


### PR DESCRIPTION
## Summary
`chainback_viterbi` in `kernels/volk/volk_8u_conv_k7_r2puppet_8u.h` declared its
local `int retval;` with no initializer, assigned it only inside the body of the
first `while` loop, and then read it unconditionally at the return. When that
loop runs zero iterations, `retval` is read uninitialized — undefined behavior,
returning a garbage value. The loop is skipped whenever `nbits_initial < 6`;
since every impl variant calls `chainback_viterbi(dec, framebits/2 - 6, ...)`
guarded only by `if (framebits < 12) return;`, any call with `framebits ∈ [12,
23]` hits the uninitialized path. The default qa/profile suite uses a single
large vlen (≫ 24), so it never exercised the range — which is why this stayed
latent. This change initializes `retval = endstate` at declaration. `endstate`
is already normalized one statement earlier, and the loop body's own assignment
is `retval = endstate`, so on a zero-iteration run the function now returns the
entry state (a defined, sensible value) instead of garbage. The shared function
is `static inline`, so the one-line fix covers all five impl variants
(spiral/neonspiral/avx2/generic/rvv) identically.

## Related issues
Closes #159

## Testing
- **Build:** clean — Release + `-DENABLE_TESTING=ON`, `cmake --build`.
- **QA:** `qa_volk_8u_conv_k7_r2puppet_8u` passes (1/1). Output-identical for the
  default large-vlen path (`framebits >= 24`, where the loop runs and the
  assignment overwrites the initializer with the same value).
- **cppcheck (before/after):** on the pre-fix `origin/main` version cppcheck 2.13
  reports `volk_8u_conv_k7_r2puppet_8u.h:91:12: warning: Uninitialized variable:
  retval [uninitvar]`; after the fix the finding is gone.
- **Static analysis / sanitizers (changed-line scope):** cppcheck, clang-tidy,
  scan-build-18, iwyu, clang-format, cpplint, codespell + ASan/UBSan/TSan — 0
  novel findings; ASan/UBSan/TSan pass. (cpplint's 22 totals are pre-existing
  line-length in this file, 0 novel.)
- **Scope:** diff is exactly one line; no signature/ABI change.

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
