### PR TITLE
cmake: use bundled cpu_features when cross-compiling (fix wrong-arch find_package)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,10 +115,18 @@ else()
 endif()
 
 if(VOLK_CPU_FEATURES)
-    find_package(CpuFeatures QUIET)
+    # Skip find_package when cross-compiling: a host-installed CpuFeatures is likely
+    # to have headers for the wrong architecture (e.g. an x86 host install lacks
+    # cpuinfo_aarch64.h), which is silently picked over the correct bundled submodule
+    # and breaks the cross build. See mtibbits/volk#66.
+    if(NOT CMAKE_CROSSCOMPILING)
+        find_package(CpuFeatures QUIET)
+    endif()
     if(NOT CpuFeatures_FOUND)
         message(
-            STATUS "cpu_features package not found. Requiring cpu_features submodule ...")
+            STATUS
+                "cpu_features package not found (or skipped for cross-compile). Requiring cpu_features submodule ..."
+        )
         if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cpu_features/CMakeLists.txt")
             message(
                 FATAL_ERROR


### PR DESCRIPTION
Surgical fix for #66. `find_package(CpuFeatures)` ran unconditionally, so a host-installed **wrong-arch** CpuFeatures was silently picked over the bundled submodule when cross-compiling, breaking the build at `cpuinfo_<arch>.h`. Arch-agnostic (any cross target), not Pi-specific.

**Fix:** skip `find_package(CpuFeatures)` when `CMAKE_CROSSCOMPILING` is set (any toolchain file that specifies `CMAKE_SYSTEM_NAME`) and go straight to the submodule. Native builds unchanged.

**Stacked on #181** (the toolchain configs) — base is `chore/180-...`; retarget to `dev/fork-base` once #181 merges.

**Before/after — verified on this x86 box** (host x86 CpuFeatures at `/usr/local/lib/cmake/CpuFeatures`, headers x86-only):

| | configure | build |
|---|---|---|
| **before** | picks host x86 (`CpuFeatures_DIR=/usr/local/lib/cmake/CpuFeatures`) | `volk_cpu.c:27: fatal error: cpuinfo_aarch64.h: No such file` |
| **after** | `find_package` skipped → submodule used | `volk_obj` builds clean (`volk_cpu.c.o` produced) |

Native configure unchanged (`find_package` still runs; `CpuFeatures_DIR` still resolves to the host x86 package, correct for a native build).

Closes #66