### PR TITLE
log2 accuracy tolerance adjudication

### DIFF
--- a/kernels/volk/volk_32f_log2_32f.h
+++ b/kernels/volk/volk_32f_log2_32f.h
@@ -55,6 +55,14 @@
  * \b Outputs
  * \li bVector: The output vector.
  *
+ * \b Accuracy
+ * All implementations approximate log2: the SIMD tiers share a polynomial whose
+ * measured absolute error reaches 5.25e-6 vs IEEE log2 (worst near power-of-two
+ * inputs), and generic uses volk_log2f_non_ieee (measured 9.5e-7). The QA
+ * tolerance bounds the impl-vs-generic difference, which can approach the sum
+ * of both errors; it is registered as 8e-6 absolute. Inputs <= 0 produce
+ * unspecified non-IEEE values.
+ *
  * \b Example
  * \code
  *   int N = 10;

--- a/kernels/volk/volk_32f_log2_32f.h
+++ b/kernels/volk/volk_32f_log2_32f.h
@@ -55,13 +55,15 @@
  * \b Outputs
  * \li bVector: The output vector.
  *
- * \b Accuracy
- * All implementations approximate log2: the SIMD tiers share a polynomial whose
- * measured absolute error reaches 5.25e-6 vs IEEE log2 (worst near power-of-two
- * inputs), and generic uses volk_log2f_non_ieee (measured 9.5e-7). The QA
- * tolerance bounds the impl-vs-generic difference, which can approach the sum
- * of both errors; it is registered as 8e-6 absolute. Inputs <= 0 produce
- * unspecified non-IEEE values.
+ * \b Numerical accuracy
+ *
+ * All implementations approximate log2. The SIMD tiers share a polynomial
+ * whose measured absolute error reaches 5.25e-6 vs IEEE log2 (worst near
+ * power-of-two inputs); generic uses volk_log2f_non_ieee (measured 9.5e-7).
+ * The QA tolerance (registered in lib/kernel_tests.h) bounds the
+ * impl-vs-generic difference, which can approach the sum of both errors,
+ * and is set to 8e-6 absolute. Inputs <= 0 produce unspecified non-IEEE
+ * values.
  *
  * \b Example
  * \code

--- a/kernels/volk/volk_32f_log2_32f.h
+++ b/kernels/volk/volk_32f_log2_32f.h
@@ -57,15 +57,20 @@
  *
  * \b Numerical accuracy
  *
- * All implementations approximate log2. The SIMD tiers share a polynomial
- * whose measured absolute error reaches 5.25e-6 vs IEEE log2 (worst near
- * power-of-two inputs; larger than the polynomial's ~1.55e-6 design residual
- * because float Horner evaluation and range reduction add rounding);
- * generic uses volk_log2f_non_ieee (measured 9.5e-7). The QA tolerance
- * (registered in lib/kernel_tests.h) bounds the impl-vs-generic difference,
- * which can approach the sum of both errors, and is set to 8e-6 absolute.
- * Inputs <= 0 follow the non-IEEE mapping above (0 -> -127.0f, negative ->
- * NaN) uniformly across implementations.
+ * All implementations approximate log2. Measured over the QA input
+ * distribution (uniform in (-1, 1)): the SIMD tiers share a polynomial
+ * whose absolute error reaches 5.25e-6 vs IEEE log2 (worst near
+ * power-of-two inputs; larger than the polynomial's ~1.55e-6 design
+ * residual because float Horner evaluation and range reduction add
+ * rounding); generic uses volk_log2f_non_ieee (measured 9.5e-7). The QA
+ * tolerance (registered in lib/kernel_tests.h) bounds the impl-vs-generic
+ * difference, which can approach the sum of both errors, and is set to
+ * 8e-6 absolute. Outside that range the bound does not apply: subnormal
+ * inputs bypass the SIMD range reduction (raw exponent field 0) and return
+ * ~= -127 where generic returns IEEE log2f down to -149, and for
+ * |log2(x)| >~ 32 float representation granularity exceeds the stated
+ * bound. Inputs <= 0 follow the non-IEEE mapping above (0 -> -127.0f,
+ * negative -> NaN) uniformly across implementations.
  *
  * \b Example
  * \code

--- a/kernels/volk/volk_32f_log2_32f.h
+++ b/kernels/volk/volk_32f_log2_32f.h
@@ -59,11 +59,13 @@
  *
  * All implementations approximate log2. The SIMD tiers share a polynomial
  * whose measured absolute error reaches 5.25e-6 vs IEEE log2 (worst near
- * power-of-two inputs); generic uses volk_log2f_non_ieee (measured 9.5e-7).
- * The QA tolerance (registered in lib/kernel_tests.h) bounds the
- * impl-vs-generic difference, which can approach the sum of both errors,
- * and is set to 8e-6 absolute. Inputs <= 0 produce unspecified non-IEEE
- * values.
+ * power-of-two inputs; larger than the polynomial's ~1.55e-6 design residual
+ * because float Horner evaluation and range reduction add rounding);
+ * generic uses volk_log2f_non_ieee (measured 9.5e-7). The QA tolerance
+ * (registered in lib/kernel_tests.h) bounds the impl-vs-generic difference,
+ * which can approach the sum of both errors, and is set to 8e-6 absolute.
+ * Inputs <= 0 follow the non-IEEE mapping above (0 -> -127.0f, negative ->
+ * NaN) uniformly across implementations.
  *
  * \b Example
  * \code

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -114,7 +114,10 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_32f_multiply_32fc, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_32f_add_32fc, test_params))
 
-    volk_test_params_t test_params_log2(test_params.make_absolute(5e-6));
+    // 8e-6 covers the shared SIMD polynomial's measured worst case vs generic:
+    // impl-vs-generic delta reaches 5.2e-6 across compilers (intrinsic error
+    // 5.25e-6 + generic 9.5e-7); see the kernel's Accuracy doc-comment. (#173)
+    volk_test_params_t test_params_log2(test_params.make_absolute(8e-6));
     test_params_log2.add_float_edge_cases({ -1.f, 0.f, inf, 65536.f });
     QA(VOLK_INIT_TEST(volk_32f_log2_32f, test_params_log2))
 

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -114,9 +114,8 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_32f_multiply_32fc, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_32f_add_32fc, test_params))
 
-    // 8e-6 covers the shared SIMD polynomial's measured worst case vs generic:
-    // impl-vs-generic delta reaches 5.2e-6 across compilers (intrinsic error
-    // 5.25e-6 + generic 9.5e-7); see the kernel's Accuracy doc-comment. (#173)
+    // impl-vs-generic delta measured up to 5.2e-6 across compilers; see the
+    // kernel's "Numerical accuracy" doc-comment (#173)
     volk_test_params_t test_params_log2(test_params.make_absolute(8e-6));
     test_params_log2.add_float_edge_cases({ -1.f, 0.f, inf, 65536.f });
     QA(VOLK_INIT_TEST(volk_32f_log2_32f, test_params_log2))


### PR DESCRIPTION
## Summary

Adjudicates the `volk_32f_log2_32f` accuracy contract, resolving the rotating CI
flake where `qa_volk_32f_log2_32f` failed its 5e-06 absolute tolerance on a
different compiler/arch leg each run (clang-14/15/16/19 and g++-15 x86 legs,
armv7, while siblings passed). Measurement across gcc-13/clang-17/clang-18 (x86)
and cross-gcc-13+qemu (armv7 NEON), 10 seeds each against the fork's
double-precision oracle, shows the shared SIMD polynomial's intrinsic error
reaches 5.25e-06 (4.49e-06 under gcc — pure codegen spread on one algorithm).
The QA comparator's actual metric (impl-vs-generic delta, bounded by the sum of
both approximations' errors) peaked at 5.0e-06 in the local campaign, and the
failing CI leg's log (armv7 g++, run 28520349258) records 5.2e-06 — over the old
tolerance by 4%; that CI-observed value drives the rule. The contract was
tighter than the algorithm family it tests. The tolerance is re-registered at
8e-06 absolute = ceil_1sf(1.5 × 5.2e-06), covering the oracle-sum bound
(6.2e-06) with ~29% headroom, and the accuracy contract is documented in the
kernel's doc-comment (`\b Numerical accuracy`, following the
volk_32fc_x2_divide_32fc.h precedent), scoped to the QA input distribution with
explicit subnormal/large-output caveats. Full evidence + decision rule:
`devDoc/volk/Issue-Fork-173/adjudication.md` (private operator repo; the
load-bearing numbers are all restated above and in Testing). Note:
`volk_32fc_s32f_power_spectrum_32f` shares this polynomial family under a
relative tolerance — deliberately not touched here (one patch per kernel);
separate adjudication if it ever flakes.

Two findings corrected along the way: the armv7 failing arch is **neon**
(upstream PR #801's tier), not the scalar generic path as the issue stated; and
the fork harness's ref-mode double-oracle sweep ignores the registered QA
tolerance, so the true-accuracy CI signal is NOT loosened by this change — only
the impl-vs-generic QA contract moves.

## Related issues

Refs #173 — intentionally NOT a closing reference: fork issues stay open as the upstream-filing queue; completion recorded by comment.
Related: #174 (companion acos flake, same class, separate adjudication)

## Testing

- 10 seeds × {gcc-13, clang-17, clang-18, armhf-qemu} = **40/40**
  `volk_test_all volk_32f_log2_32f` runs pass, runtime-verified at `tol=8e-06`
  (each run's banner echoes the registered tol).
- Negative control: tolerance temporarily set to 1e-7 → QA FAILS (the test keeps
  teeth); restored → passes.
- Double-oracle margins (fork harness `HARNESS_REPORT`, per-impl max_err) and ULP
  profiles captured per compiler; tables in adjudication.md.
- Analyzers (changed-line scope): cppcheck 0, cpplint 0 novel (109 pre-existing),
  clang-tidy 0, scan-build pass, iwyu 0, clang-format clean, codespell 0;
  ASan+UBSan pass, TSan pass.
- Edge cases `{-1, 0, inf, 65536}` unaffected: -1 is structurally compared
  (NaN==NaN); 0/inf/65536 produce exactly-equal finite constants across impls
  (delta = 0), so none depend on the tolerance value.
- `test_params_log2` verified single-consumer — no other kernel's tolerance is
  relaxed by this change.
- Post-ship: two consecutive full `Run VOLK tests` matrix passes to be recorded
  on this PR (AC-4).

## Checklist
- [x] Builds cleanly (`cmake --build`) — 4 configs (gcc-13, clang-17, clang-18, armhf cross)
- [x] Tests pass (`ctest`) — full QA suite via volk_test_all filtered runs + analyze-step sanitizer ctest
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — tolerance re-registration + its documentation; no unrelated changes

