### PR TITLE
acos accuracy tolerance adjudication

### DIFF
--- a/kernels/volk/volk_32f_acos_32f.h
+++ b/kernels/volk/volk_32f_acos_32f.h
@@ -27,6 +27,18 @@
  * \b Outputs
  * \li bVector: The vector where results will be stored.
  *
+ * \b Numerical accuracy
+ *
+ * All implementations (including generic) compute acos(x) = pi/2 - asin(x)
+ * over a shared two-range asin polynomial. Measured over uniform (-1, 1)
+ * plus a dense sweep approaching +/-1: absolute error vs IEEE acos reaches
+ * 1.9e-6 (worst near |x| = 0.5, the polynomial range handoff); the
+ * reflection itself adds only ~1.3e-7. Because acos -> 0 as x -> 1, a
+ * relative error metric is ill-posed near +/-1; the QA tolerance
+ * (registered in lib/kernel_tests.h) is therefore an ABSOLUTE bound of
+ * 4e-6 on the impl-vs-generic difference, covering the sum of both
+ * approximations' errors.
+ *
  * \b Example
  * \code
  * Calculate common angles around the top half of the unit circle.

--- a/kernels/volk/volk_32f_acos_32f.h
+++ b/kernels/volk/volk_32f_acos_32f.h
@@ -37,7 +37,7 @@
  * relative error metric is ill-posed near +/-1; the QA tolerance
  * (registered in lib/kernel_tests.h) is therefore an ABSOLUTE bound of
  * 4e-6 on the impl-vs-generic difference, covering the sum of both
- * approximations' errors.
+ * approximations' errors (~3.7e-6).
  *
  * \b Example
  * \code

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -150,7 +150,13 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
                                             0.707107f,
                                             -0.707107f });
     QA(VOLK_INIT_TEST(volk_32f_asin_32f, test_params_asin))
-    QA(VOLK_INIT_TEST(volk_32f_acos_32f, test_params_asin))
+    // acos = pi/2 - asin reflects the output through pi/2, so acos -> 0 as
+    // x -> 1 and a RELATIVE tol amplifies tiny impl-vs-generic deltas near
+    // +/-1 (measured 12x vs asin on the same inputs). Register acos with an
+    // absolute bound instead; split from test_params_asin so asin's contract
+    // is untouched. See the kernel's "Numerical accuracy" doc-comment. (#174)
+    volk_test_params_t test_params_acos(test_params_asin.make_absolute(4e-6));
+    QA(VOLK_INIT_TEST(volk_32f_acos_32f, test_params_acos))
     QA(VOLK_INIT_TEST(volk_32fc_s32f_power_32fc, test_params_power))
     QA(VOLK_INIT_TEST(volk_32f_s32f_calc_spectral_noise_floor_32f, test_params_snf))
 

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -150,11 +150,9 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
                                             0.707107f,
                                             -0.707107f });
     QA(VOLK_INIT_TEST(volk_32f_asin_32f, test_params_asin))
-    // acos = pi/2 - asin reflects the output through pi/2, so acos -> 0 as
-    // x -> 1 and a RELATIVE tol amplifies tiny impl-vs-generic deltas near
-    // +/-1 (measured 12x vs asin on the same inputs). Register acos with an
-    // absolute bound instead; split from test_params_asin so asin's contract
-    // is untouched. See the kernel's "Numerical accuracy" doc-comment. (#174)
+    // acos flakes ~12x worse than asin under the shared relative tol (near
+    // +/-1); split so asin's contract is untouched and register an absolute
+    // bound. See the kernel's "Numerical accuracy" doc-comment. (#174)
     volk_test_params_t test_params_acos(test_params_asin.make_absolute(4e-6));
     QA(VOLK_INIT_TEST(volk_32f_acos_32f, test_params_acos))
     QA(VOLK_INIT_TEST(volk_32fc_s32f_power_32fc, test_params_power))


### PR DESCRIPTION
## Summary

**The acos QA tolerance was measuring the wrong thing: a relative bound on an
output that crosses zero. This PR gives acos its own params object with an
absolute 4e-6 bound — asin's contract is untouched — ending the last rotating
CI flake.**

Detail: root cause is **metric ill-posedness, not kernel error** (companion to
#173/log2): acos and asin shared one RELATIVE 1e-5 tolerance (`test_params_asin`), but
acos = π/2 − asin drives the output to 0 as x → 1, where `fcompare`'s
`|impl−generic| / |generic|` amplifies tiny deltas (the exact zero is guarded at
1e-30; the danger zone is small-but-nonzero outputs from draws near ±1 — at
vlen=131071 the input distribution lands there a few percent of runs, matching the
observed occasional rotation). Measured: armhf neon relative delta reaches
**8.0e-06 = 80% of tol** while asin shows 6.5e-07 on identical inputs — a **12×
metric artifact** on the same polynomial. Against IEEE truth (libm probe, 1M points
incl. a dense sweep approaching ±1) the implementations are sound: absolute error
≤ 1.9e-6, worst at the |x| = 0.5 range handoff — nowhere near the flake region —
and the π/2−asin reflection adds only **+1.3e-7**, refuting the issue's
reflection-defect hypothesis. gcc-13 x86 SIMD is bit-identical to generic
(delta exactly 0); deltas exist only under clang/ARM codegen (abs max 4.8e-07).

The fix: **split acos into its own params object** (asin's registration byte-
identical, edge cases carried through the `make_absolute` copy ctor) and register
an **ABSOLUTE 4e-6 bound** = ceil_1sf of the err_impl + err_generic sum (3.72e-6),
covering the worst possible impl-vs-generic delta under independent codegen. This
also *tightens* the effective contract at ordinary outputs (the old 1e-5 relative
allowed ~1.6e-5 absolute at π/2) while eliminating the near-±1 amplification. The
accuracy contract is documented in the kernel's `\b Numerical accuracy` doc-comment
(#173 convention). Full evidence: `devDoc/volk/Issue-Fork-174/adjudication.md`
(private operator repo; load-bearing numbers restated here).

## Related issues

Refs #174 — intentionally NOT a closing reference: fork issues stay open as the
upstream-filing queue; completion is recorded by comment.
Related: #173 (companion log2 adjudication — the absolute-for-zero-crossing precedent)

## Testing

- 10 seeds × {gcc-13, clang-17, clang-18, armhf-qemu} × BOTH kernels = **80/80**
  runs pass; banner-verified per build: acos `tol=4e-06`, asin `tol=1e-05` unchanged.
- **Two-sided negative control:** acos tol at 1e-8 → FAILS on clang-18 (measured
  delta 2.4e-07) while **asin passes the same binary** — proves both the test's
  teeth and the split's isolation. (gcc-13 cannot trip any tolerance: impl-vs-generic
  is bit-identical there — noted, verified, and why the control ran on clang-18.)
- asin invariance (AC-3): zero asin-line changes in the diff; `test_params_acos`
  single-consumer.
- libm truth probe (per-impl, both x86 builds): acos 1.858e-06 / asin 1.726e-06 abs
  err, reflection +1.32e-07; absolute impl-vs-generic delta ≤ 4.768e-07 (armhf neon,
  dense near-±1 sampling included).
- Analyzers (changed-line scope): cppcheck 0, cpplint 0 novel (78 pre-existing),
  clang-tidy 0, scan-build pass, compiler 0; ASan+UBSan pass, TSan pass.
- Post-ship: two consecutive green `Run VOLK tests` matrix passes to be recorded
  on this PR (AC-4), zero acos (and still zero log2) failures.

## Checklist
- [x] Builds cleanly (`cmake --build`) — 4 configs (gcc-13, clang-17, clang-18, armhf cross)
- [x] Tests pass (`ctest`) — seeded volk_test_all runs (both kernels) + analyze-step sanitizer ctest
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — acos params split + adjudicated tolerance + its documentation
