### PR TITLE
reduction-tolerance dot_prod 32fc

### DIFF
--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -39,18 +39,20 @@
  * no single relative bound is meaningful across sizes. The error metric is the
  * complex-magnitude of the deviation. Unlike the real dot product, the SIMD tiers
  * are NOT uniformly more accurate than the generic loop, and the comparison is
- * per-arch: measured at num_points = 1000003 over uniform(-1,1), on x86 generic is
- * <= 1.44e-2 absolute while the AVX tiers are more accurate (<= 1.18e-2) and SSE3
- * marginally less (1.47e-2); on armhf the generic loop is tighter (<= 4.3e-3) and
- * the NEON tiers are less accurate than it (<= 1.15e-2). Accuracy tracks each
+ * per-arch: at num_points = 1000003 over uniform(-1,1) (60-seed tail maxima), on
+ * x86 generic reaches 1.83e-2 absolute with SSE3 essentially equal (1.82e-2) and
+ * the AVX tiers more accurate (<= 1.4e-2); on armhf the generic loop is tighter
+ * (<= 7.9e-3) and the NEON tiers are less accurate than it (<= 1.27e-2). Accuracy
+ * tracks each
  * impl's accumulation order, not its width. Because the ordering is mixed,
  * impl-vs-generic comparison
  * is unreliable in both directions, so the fork harness checks every impl against
  * a double-precision oracle. The QA metric is a single random scalar per run with
- * a heavy tail, so bounds carry a 2.5x extreme-value margin (lib/kernel_tests.h;
- * derivation #119): impl-vs-generic 8e-3 absolute at num_points 131071; the oracle
- * check is 4e-2 absolute up to num_points 1000003. Results for zero-mean inputs
- * cross zero, so tolerances are absolute by doctrine.
+ * a heavy tail (bounds derive from 200-seed/60-seed tail maxima), so they carry a
+ * 2.5x extreme-value margin (lib/kernel_tests.h; derivation #119): impl-vs-generic
+ * 2e-2 absolute at num_points 131071; the oracle check is 5e-2 absolute up to
+ * num_points 1000003. Results for zero-mean inputs cross zero, so tolerances are
+ * absolute by doctrine.
  *
  * \b Example
  * \code

--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -31,6 +31,27 @@
  * \b Outputs
  * \li result: pointer to a complex float value to hold the dot product result.
  *
+ * \b Numerical accuracy
+ *
+ * A single-precision complex reduction: absolute error vs the exact dot product
+ * grows ~linearly with num_points (random-sign accumulation of rounding errors),
+ * while the result's magnitude grows only ~sqrt(num_points) for zero-mean data —
+ * no single relative bound is meaningful across sizes. The error metric is the
+ * complex-magnitude of the deviation. Unlike the real dot product, the SIMD tiers
+ * are NOT uniformly more accurate than the generic loop, and the comparison is
+ * per-arch: measured at num_points = 1000003 over uniform(-1,1), on x86 generic is
+ * <= 1.44e-2 absolute while the AVX tiers are more accurate (<= 1.18e-2) and SSE3
+ * marginally less (1.47e-2); on armhf the generic loop is tighter (<= 4.3e-3) and
+ * the NEON tiers are less accurate than it (<= 1.15e-2). Accuracy tracks each
+ * impl's accumulation order, not its width. Because the ordering is mixed,
+ * impl-vs-generic comparison
+ * is unreliable in both directions, so the fork harness checks every impl against
+ * a double-precision oracle. The QA metric is a single random scalar per run with
+ * a heavy tail, so bounds carry a 2.5x extreme-value margin (lib/kernel_tests.h;
+ * derivation #119): impl-vs-generic 8e-3 absolute at num_points 131071; the oracle
+ * check is 4e-2 absolute up to num_points 1000003. Results for zero-mean inputs
+ * cross zero, so tolerances are absolute by doctrine.
+ *
  * \b Example
  * \code
  * int N = 10000;

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -186,7 +186,13 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_imag_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_64f, test_params))
-    QA(VOLK_INIT_TEST(volk_32fc_x2_dot_prod_32fc, test_params.make_absolute(2e-2)))
+    // 8e-3 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 3.1e-3, x86 avx). Reduction QA is a SINGLE random scalar
+    // per run, so the margin uses the 2.5x extreme-value factor (not the per-element
+    // 1.5x). Tighter than the hand-tuned 2e-2 it replaces; the 1000003 sweep is
+    // oracle-governed (volk_reference). Contract is the FORMULA: remeasure-and-rederive,
+    // don't hand-bump. See the kernel's "Numerical accuracy" doc-comment. (#119)
+    QA(VOLK_INIT_TEST(volk_32fc_x2_dot_prod_32fc, test_params.make_absolute(8e-3)))
     QA(VOLK_INIT_TEST(volk_32fc_32f_dot_prod_32fc, test_params.make_absolute(1e-2)))
 
     // Complex index kernels: same magnitude values to test tie-breaking

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -186,13 +186,14 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_imag_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_64f, test_params))
-    // 8e-3 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
-    // testqa's vlen 131071: 3.1e-3, x86 avx). Reduction QA is a SINGLE random scalar
-    // per run, so the margin uses the 2.5x extreme-value factor (not the per-element
-    // 1.5x). Tighter than the hand-tuned 2e-2 it replaces; the 1000003 sweep is
-    // oracle-governed (volk_reference). Contract is the FORMULA: remeasure-and-rederive,
-    // don't hand-bump. See the kernel's "Numerical accuracy" doc-comment. (#119)
-    QA(VOLK_INIT_TEST(volk_32fc_x2_dot_prod_32fc, test_params.make_absolute(8e-3)))
+    // 2e-2 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 4.4e-3, x86 avx over 200 seeds. Reduction QA is a SINGLE
+    // random scalar per run with a heavy tail — a 10-seed sample undersampled it ~3x
+    // and a first cut at 8e-3 left too little margin. The re-derivation lands ON the
+    // pre-existing hand-tuned 2e-2; the 1000003 sweep is oracle-governed
+    // (volk_reference). Contract is the FORMULA: remeasure-and-rederive, don't
+    // hand-bump. See the kernel's "Numerical accuracy" doc-comment. (#119)
+    QA(VOLK_INIT_TEST(volk_32fc_x2_dot_prod_32fc, test_params.make_absolute(2e-2)))
     QA(VOLK_INIT_TEST(volk_32fc_32f_dot_prod_32fc, test_params.make_absolute(1e-2)))
 
     // Complex index kernels: same magnitude values to test tie-breaking

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,35 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_32fc_x2_dot_prod_32fc: result = sum_i input[i]*taps[i] (complex MAC). A
+// complex REDUCTION oracle: reads two complex inputs, accumulates real and
+// imaginary parts in double, writes only element 0 of the complex output (the
+// harness zero-fills both sides, so the untouched tail compares equal). Same
+// rationale as the real dot_prod (#118): impl-vs-generic comparison judges the
+// wrong side for reductions — the comparator delta is dominated by whichever side
+// accumulates in the worse order, so only a double-precision truth oracle judges
+// each impl on its own merit. Complex buffers are interleaved re/im floats.
+static void ref_dot_prod_32fc(const std::vector<const void*>& in,
+                              const std::vector<void*>& out,
+                              lv_32fc_t /*scalar*/,
+                              unsigned int vlen)
+{
+    const lv_32fc_t* input = static_cast<const lv_32fc_t*>(in[0]);
+    const lv_32fc_t* taps = static_cast<const lv_32fc_t*>(in[1]);
+    lv_32fc_t* result = static_cast<lv_32fc_t*>(out[0]);
+    double acc_re = 0.0;
+    double acc_im = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double ar = static_cast<double>(lv_creal(input[i]));
+        const double ai = static_cast<double>(lv_cimag(input[i]));
+        const double br = static_cast<double>(lv_creal(taps[i]));
+        const double bi = static_cast<double>(lv_cimag(taps[i]));
+        acc_re += ar * br - ai * bi;
+        acc_im += ar * bi + ai * br;
+    }
+    result[0] = lv_cmake(static_cast<float>(acc_re), static_cast<float>(acc_im));
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +146,15 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // dot_prod_32fc abs tol = 4e-2 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003: generic reaches 1.44e-2, the a_sse3
+    // impl 1.47e-2 (the driver), armhf NEON 1.15e-2; every impl incl generic runs
+    // ref mode. Metric is the complex-magnitude error (ccompare abs mode). The
+    // 2.5x extreme-value margin for scalar reduction metrics, mode and anchor per
+    // the reduction-tolerance methodology in
+    // docs/kernel_correctness_harness/README.md. ABSOLUTE: complex dot products of
+    // zero-mean data cross zero. (#119)
+    { "volk_32fc_x2_dot_prod_32fc", ref_dot_prod_32fc, 4e-2f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -146,15 +146,15 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
-    // dot_prod_32fc abs tol = 4e-2 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
-    // oracle at the sweep's max vlen 1000003: generic reaches 1.44e-2, the a_sse3
-    // impl 1.47e-2 (the driver), armhf NEON 1.15e-2; every impl incl generic runs
-    // ref mode. Metric is the complex-magnitude error (ccompare abs mode). The
-    // 2.5x extreme-value margin for scalar reduction metrics, mode and anchor per
-    // the reduction-tolerance methodology in
-    // docs/kernel_correctness_harness/README.md. ABSOLUTE: complex dot products of
-    // zero-mean data cross zero. (#119)
-    { "volk_32fc_x2_dot_prod_32fc", ref_dot_prod_32fc, 4e-2f, true },
+    // dot_prod_32fc abs tol = 5e-2 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003, sampled over 60 seeds: generic
+    // reaches 1.83e-2 (the driver; sse3 1.82e-2, AVX <= 1.4e-2, armhf NEON
+    // <= 1.27e-2); every impl incl generic runs ref mode. Metric is the
+    // complex-magnitude error (ccompare abs mode). 2.5x extreme-value margin for
+    // scalar reduction metrics, mode/anchor/sampling per the reduction-tolerance
+    // methodology in docs/kernel_correctness_harness/README.md. ABSOLUTE: complex
+    // dot products of zero-mean data cross zero. (#119)
+    { "volk_32fc_x2_dot_prod_32fc", ref_dot_prod_32fc, 5e-2f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_32fc_x2_dot_prod_32fc

**Plain-language summary.** The correctness harness was judging the complex
dot-product kernel by comparing each SIMD implementation against the plain C
"generic" loop. For a reduction that is the wrong yardstick: floating-point
summation error depends on accumulation order, so "generic" is not ground truth —
it is just one more approximation, and for this kernel the implementations sit on
*both* sides of it (AVX is more accurate than generic, NEON less). This PR applies
the #118 pattern decision: register a double-precision **oracle** for the kernel and
judge every implementation (generic included) against real ground truth, with two
tolerances *derived from measurement* rather than hand-tuned.

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — new `ref_dot_prod_32fc` oracle (double-precision
  complex accumulation) + registry row, `ref.tol = 4e-2` absolute.
- **lib/kernel_tests.h** — testqa tolerance `2e-2 → 8e-3` absolute (tighter; derived).
- **kernels/volk/volk_32fc_x2_dot_prod_32fc.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin, ceil to 1 sig-fig; probe, 10 seeds)
- **kp.tol = 8e-3** = ceil_1sf(2.5 × 3.09e-3), the max impl-vs-generic complex-magnitude
  delta at testqa's vlen 131071 (x86 AVX).
- **ref.tol = 4e-2** = ceil_1sf(2.5 × 1.47e-2), the max both-sides error vs the oracle at
  the sweep's vlen 1000003 (x86 SSE3 impl, just above generic's 1.44e-2).
- Both **absolute** (complex zero-mean dot products cross zero). Metric is the
  complex-magnitude error, matching `ccompare` absolute mode. Methodology:
  docs/kernel_correctness_harness/README.md §Reduction-tolerance methodology.

### Validation (local, gcc-13 + clang-18)
- Banner echoes `tol=8e-03`; 10/10 seeded testqa green on both.
- ref-mode sweep `ok [ref]`, exit 0, oracle evaluates (0 ref kernels skipped).
- Two negative controls with teeth: kp.tol→8e-5 fails testqa; ref.tol→4e-4 fails the
  ref sweep; both restored and re-verified green.
- clang-format-18 clean; static analysis clean (only cpplint 80-vs-90 line-length noise).
- Fleet CI (incl. armv7 NEON, aarch64, Apple-clang legs) runs post-push.

### AC-2: triage re-run
Clean under the new contract. The sse3 margin-flicker the issue calls out is resolved
(see above). The one remaining non-`ok` row is the `#89` output canary reporting `part`
(next item), which is a canary-coverage scope-out, not a tolerance FAIL.

### Notes
- `volk_32fc_x2_dot_prod_32fc` is not yet registered in `lib/volk_buffer_roles.cc` (only
  the real dot_prod + accumulator_s32f are), so the `#89` output canary reports its
  single-element complex output as `part`. Buffer-role registration is a separate
  #161/#89 concern, intentionally out of scope for this tolerance PR; it is tracked as a
  follow-up (candidate to batch across the still-unregistered reduction siblings).
- kp.tol basis is local (x86 gcc/clang + armhf NEON). Honest caveat: local headroom is
  only ~1.2× over the CI extreme this family projects (#118 saw a CI compiler draw ~2.1×
  over its local max), so a CI flicker here would not be a surprise — per the contract it
  triggers remeasure-and-rederive (the formula is the contract), not a hand-bump.

Refs #119. (Fork posture: this issue stays open — evidence tracked in comments — and is
part of the upstream-filing queue; not "Closes".)

---

### Revision (2026-07-04): tail-sampled re-derivation — supersedes the derivation numbers above

A 10-seed probe max undersamples the single-random-scalar reduction error tail ~3× (caught
when #123's first cut flickered locally; see the README §Reduction-tolerance methodology
sampling rule added on the #118 branch). Re-measured with **200 seeds @131071 (kp)** and
**60 seeds @1000003 (ref)**, max over **both sides and all impls**:

- **kp.tol = 2e-2 (was 8e-3; tail 4.4e-3, x86 avx, 200 seeds — lands on the pre-existing hand-tuned 2e-2)**
- **ref.tol = 5e-2 (was 4e-2; 60-seed both-sides tail 1.83e-2, generic)**

Commit `8ef50416` on this branch; the same constants are folded to dev/all-prs (`964bba66`).
Re-validated at the corrected values: 10/10 seeded testqa on gcc-13 + clang-18, ref sweep
`ok [ref]` exit 0, and both negative controls (100× tighter kp / ref) trip and restore green.
