### PR TITLE
reduction-tolerance conjugate dot_prod 32fc

### DIFF
--- a/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
@@ -39,14 +39,15 @@
  * errors), while the result magnitude grows only ~sqrt(num_points) for zero-mean
  * data — no single relative bound is meaningful across sizes. The error metric is
  * the complex-magnitude of the deviation. The SIMD tiers (sse3, avx, avx512dq) are
- * measurably more accurate than the generic serial loop; measured at
- * num_points = 1000003 over uniform(-1,1), generic <= 2.16e-2 absolute (the
- * generic-class `block` impl is similar, <= 2.0e-2), the SIMD tiers 6.4e-3 (avx512dq)
- * to ~1e-2, and armhf NEON <= 1.5e-2. Because generic is the least accurate side,
+ * measurably more accurate than the generic serial loop; at num_points = 1000003
+ * over uniform(-1,1) (60-seed tail maxima), generic reaches 3.38e-2 absolute (the
+ * generic-class `block` impl <= 2.1e-2), the SIMD tiers 7.7e-3 (avx512dq) to
+ * ~1.6e-2, and armhf NEON <= 1.5e-2. Because generic is the least accurate side,
  * the fork harness checks every impl against a double-precision oracle. The QA
  * metric is a single random scalar per run with a heavy tail, so bounds carry a
- * 2.5x extreme-value margin (lib/kernel_tests.h; derivation #120): impl-vs-generic
- * 8e-3 absolute at num_points 131071; the oracle check is 6e-2 absolute up to
+ * 2.5x extreme-value margin over 200-seed/60-seed tail maxima (lib/kernel_tests.h;
+ * derivation #120): impl-vs-generic 3e-2 absolute at num_points 131071 (driven by
+ * the block impl's spread vs generic); the oracle check is 9e-2 absolute up to
  * num_points 1000003. Results for zero-mean inputs cross zero, so tolerances are
  * absolute by doctrine.
  *

--- a/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
@@ -32,6 +32,24 @@
  * \b Outputs
  * \li result: pointer to a complex float value to hold the dot product result.
  *
+ * \b Numerical accuracy
+ *
+ * A single-precision complex reduction: absolute error vs the exact conjugate dot
+ * product grows ~linearly with num_points (random-sign accumulation of rounding
+ * errors), while the result magnitude grows only ~sqrt(num_points) for zero-mean
+ * data — no single relative bound is meaningful across sizes. The error metric is
+ * the complex-magnitude of the deviation. The SIMD tiers (sse3, avx, avx512dq) are
+ * measurably more accurate than the generic serial loop; measured at
+ * num_points = 1000003 over uniform(-1,1), generic <= 2.16e-2 absolute (the
+ * generic-class `block` impl is similar, <= 2.0e-2), the SIMD tiers 6.4e-3 (avx512dq)
+ * to ~1e-2, and armhf NEON <= 1.5e-2. Because generic is the least accurate side,
+ * the fork harness checks every impl against a double-precision oracle. The QA
+ * metric is a single random scalar per run with a heavy tail, so bounds carry a
+ * 2.5x extreme-value margin (lib/kernel_tests.h; derivation #120): impl-vs-generic
+ * 8e-3 absolute at num_points 131071; the oracle check is 6e-2 absolute up to
+ * num_points 1000003. Results for zero-mean inputs cross zero, so tolerances are
+ * absolute by doctrine.
+ *
  * \b Example
  * \code
  * unsigned int N = 1000;

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -177,8 +177,14 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
           lv_cmake(nan, 1.0f),    // atan2(1, nan) = nan (propagate)
           lv_cmake(1.0f, nan) }); // atan2(nan, 1) = nan (propagate)
     QA(VOLK_INIT_TEST(volk_32fc_s32f_atan2_32f, test_params_atan2))
+    // 8e-3 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 3.0e-3, x86 sse3). Reduction QA is a SINGLE random scalar
+    // per run, so the 2.5x extreme-value margin (not the per-element 1.5x). Tighter
+    // than the hand-tuned 2e-2; the 1000003 sweep is oracle-governed (volk_reference).
+    // Local basis (x86 + armv7 NEON); a CI arch that flickers triggers remeasure-and-
+    // rederive, not a hand-bump. See the kernel's "Numerical accuracy" comment. (#120)
     QA(VOLK_INIT_TEST(volk_32fc_x2_conjugate_dot_prod_32fc,
-                      test_params.make_absolute(2e-2)))
+                      test_params.make_absolute(8e-3)))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_32f_x2, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_accumulator_s32fc, test_params.make_absolute(3e-2)))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_64f_x2, test_params))

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -177,14 +177,15 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
           lv_cmake(nan, 1.0f),    // atan2(1, nan) = nan (propagate)
           lv_cmake(1.0f, nan) }); // atan2(nan, 1) = nan (propagate)
     QA(VOLK_INIT_TEST(volk_32fc_s32f_atan2_32f, test_params_atan2))
-    // 8e-3 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
-    // testqa's vlen 131071: 3.0e-3, x86 sse3). Reduction QA is a SINGLE random scalar
-    // per run, so the 2.5x extreme-value margin (not the per-element 1.5x). Tighter
-    // than the hand-tuned 2e-2; the 1000003 sweep is oracle-governed (volk_reference).
-    // Local basis (x86 + armv7 NEON); a CI arch that flickers triggers remeasure-and-
-    // rederive, not a hand-bump. See the kernel's "Numerical accuracy" comment. (#120)
+    // 3e-2 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 8.7e-3, the generic-class `block` impl over 200 seeds
+    // (the widest accumulation-order spread is generic-vs-block, not generic-vs-SIMD).
+    // Reduction QA is a SINGLE random scalar per run with a heavy tail — a 10-seed
+    // sample undersampled it ~3x and a first cut at 8e-3 sat BELOW block's tail. The
+    // 1000003 sweep is oracle-governed (volk_reference). Contract is the FORMULA:
+    // remeasure-and-rederive, not hand-bumping. See "Numerical accuracy". (#120)
     QA(VOLK_INIT_TEST(volk_32fc_x2_conjugate_dot_prod_32fc,
-                      test_params.make_absolute(8e-3)))
+                      test_params.make_absolute(3e-2)))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_32f_x2, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_accumulator_s32fc, test_params.make_absolute(3e-2)))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_64f_x2, test_params))

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -145,14 +145,15 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
-    // conjugate_dot_prod_32fc abs tol = 6e-2 = ceil_1sf(2.5 x max BOTH-SIDES error
-    // vs the oracle at the sweep's max vlen 1000003: generic reaches 2.16e-2 (the
-    // driver; SIMD tiers are more accurate, <= 2.0e-2 block ... 6.4e-3 avx512dq).
-    // Metric is the complex-magnitude error (ccompare abs mode). 2.5x extreme-value
-    // margin per docs/kernel_correctness_harness/README.md §Reduction-tolerance
-    // methodology. ABSOLUTE (zero-mean complex crosses zero). Derived on x86 +
-    // armv7 NEON; aarch64/rvv fall under the remeasure clause. (#120)
-    { "volk_32fc_x2_conjugate_dot_prod_32fc", ref_conjugate_dot_prod_32fc, 6e-2f, true },
+    // conjugate_dot_prod_32fc abs tol = 9e-2 = ceil_1sf(2.5 x max BOTH-SIDES error
+    // vs the oracle at the sweep's max vlen 1000003, sampled over 60 seeds: generic
+    // reaches 3.38e-2 (the driver; block <= 2.1e-2, sse3 <= 1.6e-2, avx512dq
+    // <= 7.7e-3). Metric is the complex-magnitude error (ccompare abs mode). 2.5x
+    // extreme-value margin, mode/anchor/sampling per the reduction-tolerance
+    // methodology in docs/kernel_correctness_harness/README.md. ABSOLUTE (zero-mean
+    // complex crosses zero). Derived on x86 + armv7 NEON; aarch64/rvv fall under
+    // the remeasure clause. (#120)
+    { "volk_32fc_x2_conjugate_dot_prod_32fc", ref_conjugate_dot_prod_32fc, 9e-2f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,34 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_32fc_x2_conjugate_dot_prod_32fc: result = sum_i input[i]*conj(taps[i]) (the
+// FIR inner product). A complex REDUCTION oracle: double-precision accumulation of
+// input * conj(taps), writing only element 0 of the complex output (the harness
+// zero-fills both sides, so the untouched tail compares equal). conj(taps) negates
+// the taps' imaginary part: (ar+ai*i)(br-bi*i) = (ar*br+ai*bi) + (ai*br-ar*bi)*i.
+// Same rationale as the plain dot_prod (#118/#119): only a double-precision truth
+// oracle judges each impl, not the accumulation-order-dependent generic.
+static void ref_conjugate_dot_prod_32fc(const std::vector<const void*>& in,
+                                        const std::vector<void*>& out,
+                                        lv_32fc_t /*scalar*/,
+                                        unsigned int vlen)
+{
+    const lv_32fc_t* input = static_cast<const lv_32fc_t*>(in[0]);
+    const lv_32fc_t* taps = static_cast<const lv_32fc_t*>(in[1]);
+    lv_32fc_t* result = static_cast<lv_32fc_t*>(out[0]);
+    double acc_re = 0.0;
+    double acc_im = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double ar = static_cast<double>(lv_creal(input[i]));
+        const double ai = static_cast<double>(lv_cimag(input[i]));
+        const double br = static_cast<double>(lv_creal(taps[i]));
+        const double bi = static_cast<double>(lv_cimag(taps[i]));
+        acc_re += ar * br + ai * bi;
+        acc_im += ai * br - ar * bi;
+    }
+    result[0] = lv_cmake(static_cast<float>(acc_re), static_cast<float>(acc_im));
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +145,14 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // conjugate_dot_prod_32fc abs tol = 6e-2 = ceil_1sf(2.5 x max BOTH-SIDES error
+    // vs the oracle at the sweep's max vlen 1000003: generic reaches 2.16e-2 (the
+    // driver; SIMD tiers are more accurate, <= 2.0e-2 block ... 6.4e-3 avx512dq).
+    // Metric is the complex-magnitude error (ccompare abs mode). 2.5x extreme-value
+    // margin per docs/kernel_correctness_harness/README.md §Reduction-tolerance
+    // methodology. ABSOLUTE (zero-mean complex crosses zero). Derived on x86 +
+    // armv7 NEON; aarch64/rvv fall under the remeasure clause. (#120)
+    { "volk_32fc_x2_conjugate_dot_prod_32fc", ref_conjugate_dot_prod_32fc, 6e-2f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_32fc_x2_conjugate_dot_prod_32fc

**Plain-language summary.** The correctness harness judged this conjugate dot-product
(the core FIR inner product) by comparing each SIMD implementation against the plain C
generic loop. For a reduction that is the wrong yardstick — floating-point summation error
is accumulation-order-dependent, so generic is just one more approximation. This PR applies
the #118/#119 pattern: a double-precision oracle judges every implementation against real
ground truth, with two measurement-derived absolute tolerances.

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — `ref_conjugate_dot_prod_32fc` oracle (double accumulation of
  input·conj(taps)) + registry row `ref.tol = 6e-2` absolute.
- **lib/kernel_tests.h** — testqa tolerance `2e-2 → 8e-3` absolute (tighter; derived).
- **kernels/volk/…conjugate_dot_prod_32fc.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin; probe, 10 seeds, complex-magnitude metric)
- **kp.tol = 8e-3** = ceil_1sf(2.5 × 3.02e-3), max impl-vs-generic delta @131071 (x86 sse3).
- **ref.tol = 6e-2** = ceil_1sf(2.5 × 2.16e-2), max both-sides error vs oracle @1000003
  (generic — the least-accurate side; the SIMD tiers are more accurate here).
- Both **absolute** (zero-mean complex crosses zero). Metric matches `ccompare` abs mode.

### Validation (local, gcc-13 + clang-18)
- Banner `tol=8e-03`; 10/10 seeded testqa green on both.
- ref-mode sweep `ok [ref]`, exit 0, oracle evaluates (0 skipped).
- Two negative controls with teeth: kp→8e-5 fails testqa; ref→6e-4 fails the ref sweep;
  both restored + re-verified green. clang-format clean.
- Fleet CI (armv7 NEON, aarch64, Apple-clang legs) runs post-push.

### Notes
- Not yet in `lib/volk_buffer_roles.cc`, so the `#89` canary reports its single-element
  output as `part` — expected for a reduction, a separate buffer-roles follow-up (out of scope).
- kp.tol basis is local (x86 + armv7 NEON); a CI arch that flickers triggers
  remeasure-and-rederive per the contract (~1.2× local headroom, honest caveat). aarch64
  neonv8 + rvv/rvvseg unmeasured (remeasure clause).

Refs #120. (Fork posture: issue stays open — evidence in comments, upstream-filing queue;
this PR intentionally does not auto-close it.)

---

### Revision (2026-07-04): tail-sampled re-derivation — supersedes the derivation numbers above

A 10-seed probe max undersamples the single-random-scalar reduction error tail ~3× (caught
when #123's first cut flickered locally; see the README §Reduction-tolerance methodology
sampling rule added on the #118 branch). Re-measured with **200 seeds @131071 (kp)** and
**60 seeds @1000003 (ref)**, max over **both sides and all impls**:

- **kp.tol = 3e-2 (was 8e-3; tail 8.7e-3 — the generic-class `block` impl, whose tail sat ABOVE the first-cut 8e-3, 200 seeds)**
- **ref.tol = 9e-2 (was 6e-2; 60-seed generic tail 3.38e-2)**

Commit `cda2b399` on this branch; the same constants are folded to dev/all-prs (`964bba66`).
Re-validated at the corrected values: 10/10 seeded testqa on gcc-13 + clang-18, ref sweep
`ok [ref]` exit 0, and both negative controls (100× tighter kp / ref) trip and restore green.
