### PR TITLE
reduction-tolerance 32fc_32f dot_prod

### DIFF
--- a/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
@@ -38,16 +38,17 @@
  * accumulation of rounding errors), while the result magnitude grows only
  * ~sqrt(num_points) for zero-mean data — no single relative bound is meaningful
  * across sizes. The error metric is the complex-magnitude of the deviation. The
- * SIMD tiers are measurably more accurate than the generic serial loop; measured at
- * num_points = 1000003 over uniform(-1,1), generic <= 1.42e-2 absolute, the AVX
- * tiers <= 4.5e-3, armhf NEON <= 9.4e-3 (some NEON variants accumulate in the same
- * serial order as generic). Because generic is the least accurate side, the fork
+ * SIMD tiers are measurably more accurate than the generic serial loop; at
+ * num_points = 1000003 over uniform(-1,1) (60-seed tail maxima), generic reaches
+ * 4.25e-2 absolute, the AVX tiers <= 4.5e-3, armhf NEON <= 9.4e-3 (some NEON
+ * variants accumulate in the same serial order as generic). Because generic is the
+ * least accurate side, the fork
  * harness checks every impl against a double-precision oracle. The QA metric is a
- * single random scalar per run with a heavy tail, so bounds carry a 2.5x
- * extreme-value margin (lib/kernel_tests.h; derivation #121): impl-vs-generic 8e-3
- * absolute at num_points 131071; the oracle check is 4e-2 absolute up to
- * num_points 1000003. Results for zero-mean inputs cross zero, so tolerances are
- * absolute by doctrine.
+ * single random scalar per run with a heavy tail (bounds derive from 200-seed/
+ * 60-seed tail maxima), so they carry a 2.5x extreme-value margin
+ * (lib/kernel_tests.h; derivation #121): impl-vs-generic 1e-2 absolute at
+ * num_points 131071; the oracle check is 2e-1 absolute up to num_points 1000003.
+ * Results for zero-mean inputs cross zero, so tolerances are absolute by doctrine.
  *
  * \b Example
  * \code

--- a/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
@@ -31,6 +31,24 @@
  * \b Outputs
  * \li result: pointer to a complex value to hold the dot product result.
  *
+ * \b Numerical accuracy
+ *
+ * A single-precision complex reduction (complex input, real taps): absolute error
+ * vs the exact dot product grows ~linearly with num_points (random-sign
+ * accumulation of rounding errors), while the result magnitude grows only
+ * ~sqrt(num_points) for zero-mean data — no single relative bound is meaningful
+ * across sizes. The error metric is the complex-magnitude of the deviation. The
+ * SIMD tiers are measurably more accurate than the generic serial loop; measured at
+ * num_points = 1000003 over uniform(-1,1), generic <= 1.42e-2 absolute, the AVX
+ * tiers <= 4.5e-3, armhf NEON <= 9.4e-3 (some NEON variants accumulate in the same
+ * serial order as generic). Because generic is the least accurate side, the fork
+ * harness checks every impl against a double-precision oracle. The QA metric is a
+ * single random scalar per run with a heavy tail, so bounds carry a 2.5x
+ * extreme-value margin (lib/kernel_tests.h; derivation #121): impl-vs-generic 8e-3
+ * absolute at num_points 131071; the oracle check is 4e-2 absolute up to
+ * num_points 1000003. Results for zero-mean inputs cross zero, so tolerances are
+ * absolute by doctrine.
+ *
  * \b Example
  * \code
  * int N = 10000;

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -187,7 +187,13 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_64f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_x2_dot_prod_32fc, test_params.make_absolute(2e-2)))
-    QA(VOLK_INIT_TEST(volk_32fc_32f_dot_prod_32fc, test_params.make_absolute(1e-2)))
+    // 8e-3 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 2.9e-3, x86 avx). Single-scalar reduction metric → 2.5x
+    // extreme-value margin (not the per-element 1.5x). Tighter than the hand-tuned
+    // 1e-2; the 1000003 sweep is oracle-governed (volk_reference). Local basis
+    // (x86 + armv7 NEON); a CI arch that flickers triggers remeasure-and-rederive,
+    // not a hand-bump. See the kernel's "Numerical accuracy" comment. (#121)
+    QA(VOLK_INIT_TEST(volk_32fc_32f_dot_prod_32fc, test_params.make_absolute(8e-3)))
 
     // Complex index kernels: same magnitude values to test tie-breaking
     volk_test_params_t test_params_index_fc(test_params.make_tol(0));

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -187,13 +187,14 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_real_64f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_x2_dot_prod_32fc, test_params.make_absolute(2e-2)))
-    // 8e-3 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
-    // testqa's vlen 131071: 2.9e-3, x86 avx). Single-scalar reduction metric → 2.5x
-    // extreme-value margin (not the per-element 1.5x). Tighter than the hand-tuned
-    // 1e-2; the 1000003 sweep is oracle-governed (volk_reference). Local basis
-    // (x86 + armv7 NEON); a CI arch that flickers triggers remeasure-and-rederive,
-    // not a hand-bump. See the kernel's "Numerical accuracy" comment. (#121)
-    QA(VOLK_INIT_TEST(volk_32fc_32f_dot_prod_32fc, test_params.make_absolute(8e-3)))
+    // 1e-2 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 4.0e-3, x86 avx512f over 200 seeds. Reduction QA is a
+    // SINGLE random scalar per run with a heavy tail — a 10-seed sample undersampled
+    // it ~3x and a first cut at 8e-3 left too little margin. The re-derivation lands
+    // ON the pre-existing hand-tuned 1e-2; the 1000003 sweep is oracle-governed
+    // (volk_reference). Contract is the FORMULA: remeasure-and-rederive, not
+    // hand-bumping. See the kernel's "Numerical accuracy" comment. (#121)
+    QA(VOLK_INIT_TEST(volk_32fc_32f_dot_prod_32fc, test_params.make_absolute(1e-2)))
 
     // Complex index kernels: same magnitude values to test tie-breaking
     volk_test_params_t test_params_index_fc(test_params.make_tol(0));

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,30 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_32fc_32f_dot_prod_32fc: result = sum_i input[i]*taps[i], complex input with
+// a REAL tap vector. A complex REDUCTION oracle: double-precision accumulation of
+// the complex input scaled by the real tap (no cross terms), writing only element 0
+// of the complex output (the harness zero-fills both sides, so the untouched tail
+// compares equal). in[1] is a plain float* (real taps). Same rationale as the plain
+// dot_prod (#118/#119): only a double-precision truth oracle judges each impl.
+static void ref_32fc_32f_dot_prod_32fc(const std::vector<const void*>& in,
+                                       const std::vector<void*>& out,
+                                       lv_32fc_t /*scalar*/,
+                                       unsigned int vlen)
+{
+    const lv_32fc_t* input = static_cast<const lv_32fc_t*>(in[0]);
+    const float* taps = static_cast<const float*>(in[1]);
+    lv_32fc_t* result = static_cast<lv_32fc_t*>(out[0]);
+    double acc_re = 0.0;
+    double acc_im = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double t = static_cast<double>(taps[i]);
+        acc_re += static_cast<double>(lv_creal(input[i])) * t;
+        acc_im += static_cast<double>(lv_cimag(input[i])) * t;
+    }
+    result[0] = lv_cmake(static_cast<float>(acc_re), static_cast<float>(acc_im));
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +141,14 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // 32fc_32f_dot_prod abs tol = 4e-2 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003: generic reaches 1.42e-2 (the driver;
+    // SIMD tiers are more accurate, avx <= 4.5e-3, armhf NEON <= 9.4e-3). Metric is
+    // the complex-magnitude error (ccompare abs mode). 2.5x extreme-value margin per
+    // docs/kernel_correctness_harness/README.md §Reduction-tolerance methodology.
+    // ABSOLUTE (zero-mean complex crosses zero). x86 + armv7 NEON; aarch64/rvv fall
+    // under the remeasure clause. (#121)
+    { "volk_32fc_32f_dot_prod_32fc", ref_32fc_32f_dot_prod_32fc, 4e-2f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -141,14 +141,15 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
-    // 32fc_32f_dot_prod abs tol = 4e-2 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
-    // oracle at the sweep's max vlen 1000003: generic reaches 1.42e-2 (the driver;
-    // SIMD tiers are more accurate, avx <= 4.5e-3, armhf NEON <= 9.4e-3). Metric is
-    // the complex-magnitude error (ccompare abs mode). 2.5x extreme-value margin per
-    // docs/kernel_correctness_harness/README.md §Reduction-tolerance methodology.
-    // ABSOLUTE (zero-mean complex crosses zero). x86 + armv7 NEON; aarch64/rvv fall
-    // under the remeasure clause. (#121)
-    { "volk_32fc_32f_dot_prod_32fc", ref_32fc_32f_dot_prod_32fc, 4e-2f, true },
+    // 32fc_32f_dot_prod abs tol = 2e-1 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003, sampled over 60 seeds: generic reaches
+    // 4.25e-2 (the driver, with a notably heavy tail — the 10-seed max was 1.42e-2;
+    // SIMD tiers are far more accurate, avx <= 4.5e-3, armhf NEON <= 9.4e-3). Metric
+    // is the complex-magnitude error (ccompare abs mode). 2.5x extreme-value margin,
+    // mode/anchor/sampling per the reduction-tolerance methodology in
+    // docs/kernel_correctness_harness/README.md. ABSOLUTE (zero-mean complex crosses
+    // zero). x86 + armv7 NEON; aarch64/rvv fall under the remeasure clause. (#121)
+    { "volk_32fc_32f_dot_prod_32fc", ref_32fc_32f_dot_prod_32fc, 2e-1f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_32fc_32f_dot_prod_32fc

**Plain-language summary.** The correctness harness judged this complex-by-real dot
product by comparing each SIMD implementation against the plain C generic loop — the wrong
yardstick for a reduction, whose floating-point error is accumulation-order-dependent. This
PR applies the #118/#119 pattern: a double-precision oracle judges every implementation
against real ground truth, with two measurement-derived absolute tolerances.

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — `ref_32fc_32f_dot_prod_32fc` oracle (double accumulation of
  complex input × real taps) + registry row `ref.tol = 4e-2` absolute.
- **lib/kernel_tests.h** — testqa tolerance `1e-2 → 8e-3` absolute (tighter; derived).
- **kernels/volk/…32fc_32f_dot_prod_32fc.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin; probe, 10 seeds, complex-magnitude metric)
- **kp.tol = 8e-3** = ceil_1sf(2.5 × 2.86e-3), max impl-vs-generic delta @131071 (x86 avx).
- **ref.tol = 4e-2** = ceil_1sf(2.5 × 1.42e-2), max both-sides error vs oracle @1000003
  (generic — the least-accurate side; the SIMD tiers are more accurate).
- Both **absolute** (zero-mean complex crosses zero); metric matches `ccompare` abs mode.

### Validation (local, gcc-13 + clang-18)
- Banner `tol=8e-03`; 10/10 seeded testqa; ref sweep `ok [ref]` exit 0 (oracle evaluates).
- Two negative controls with teeth: kp→8e-5 fails testqa; ref→4e-4 fails the ref sweep;
  both restored + re-verified green. clang-format clean. Fleet CI runs post-push.

### Notes
- Not yet in `lib/volk_buffer_roles.cc` → the `#89` canary reports its single-element output
  as `part` (expected for a reduction; separate buffer-roles follow-up, out of scope).
- kp.tol basis is local (x86 + armv7 NEON, ~1.2× CI headroom); a CI arch that flickers
  triggers remeasure-and-rederive per the contract. aarch64 neonv8 + rvv/rvvseg unmeasured.

Refs #121. (Fork posture: issue stays open — evidence in comments, upstream-filing queue;
this PR intentionally does not auto-close it.)

---

### Revision (2026-07-04): tail-sampled re-derivation — supersedes the derivation numbers above

A 10-seed probe max undersamples the single-random-scalar reduction error tail ~3× (caught
when #123's first cut flickered locally; see the README §Reduction-tolerance methodology
sampling rule added on the #118 branch). Re-measured with **200 seeds @131071 (kp)** and
**60 seeds @1000003 (ref)**, max over **both sides and all impls**:

- **kp.tol = 1e-2 (was 8e-3; tail 4.0e-3, avx512f, 200 seeds — lands on the pre-existing hand-tuned 1e-2)**
- **ref.tol = 2e-1 (was 4e-2; 60-seed generic tail 4.25e-2 sat ABOVE the first-cut 4e-2)**

Commit `77358388` on this branch; the same constants are folded to dev/all-prs (`964bba66`).
Re-validated at the corrected values: 10/10 seeded testqa on gcc-13 + clang-18, ref sweep
`ok [ref]` exit 0, and both negative controls (100× tighter kp / ref) trip and restore green.
