### PR TITLE
reduction-tolerance 16i_32fc dot_prod

### DIFF
--- a/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
+++ b/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
@@ -31,6 +31,24 @@
  * \b Outputs
  * \li result: pointer to a complex value to hold the dot product result.
  *
+ * \b Numerical accuracy
+ *
+ * A complex reduction with an integer input: the 16-bit samples are exact integers,
+ * so there is NO input quantization error and the output is full-precision complex
+ * float. The absolute error vs the exact dot product is therefore pure float
+ * accumulation error, growing ~linearly with num_points (random-sign accumulation of
+ * rounding), while the result magnitude grows ~sqrt(num_points) — no single relative
+ * bound is meaningful across sizes. The error metric is the complex-magnitude of the
+ * deviation. Absolute errors run ~6x larger than the pure-float dot products because
+ * the QA input ranges over [-6,6]. The SIMD tiers are more accurate than the generic
+ * serial loop; measured at num_points = 1000003 over that data, generic <= 4.53e-2
+ * absolute, the SIMD tiers <= 4.0e-2. Because generic is the least accurate side, the
+ * fork harness checks every impl against a double-precision oracle. The QA metric is
+ * a single random scalar per run with a heavy tail, so bounds carry a 2.5x
+ * extreme-value margin (lib/kernel_tests.h; derivation #122): impl-vs-generic 2e-2
+ * absolute at num_points 131071; the oracle check is 2e-1 absolute up to
+ * num_points 1000003. Tolerances are absolute (the metric spans zero).
+ *
  * \b Example
  * \code
  * int N = 10000;

--- a/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
+++ b/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
@@ -41,13 +41,15 @@
  * bound is meaningful across sizes. The error metric is the complex-magnitude of the
  * deviation. Absolute errors run ~6x larger than the pure-float dot products because
  * the QA input ranges over [-6,6]. The SIMD tiers are more accurate than the generic
- * serial loop; measured at num_points = 1000003 over that data, generic <= 4.53e-2
- * absolute, the SIMD tiers <= 4.0e-2. Because generic is the least accurate side, the
+ * loop; at num_points = 1000003 over that data (60-seed tail maxima), generic
+ * reaches 6.54e-2 absolute, the SIMD tiers <= 4.0e-2. Because generic is the least
+ * accurate side, the
  * fork harness checks every impl against a double-precision oracle. The QA metric is
- * a single random scalar per run with a heavy tail, so bounds carry a 2.5x
- * extreme-value margin (lib/kernel_tests.h; derivation #122): impl-vs-generic 2e-2
- * absolute at num_points 131071; the oracle check is 2e-1 absolute up to
- * num_points 1000003. Tolerances are absolute (the metric spans zero).
+ * a single random scalar per run with a heavy tail (bounds derive from 200-seed/
+ * 60-seed tail maxima), so they carry a 2.5x extreme-value margin
+ * (lib/kernel_tests.h; derivation #122): impl-vs-generic 3e-2 absolute at
+ * num_points 131071; the oracle check is 2e-1 absolute up to num_points 1000003.
+ * Tolerances are absolute (the metric spans zero).
  *
  * \b Example
  * \code

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -83,13 +83,14 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_16ic_x2_dot_prod_16ic, test_params))
     QA(VOLK_INIT_TEST(volk_16i_s32f_convert_32f, test_params))
     QA(VOLK_INIT_TEST(volk_16i_convert_8i, test_params))
-    // 2e-2 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
-    // testqa's vlen 131071: 7.4e-3, x86 avx2). Single-scalar reduction metric → 2.5x
-    // extreme-value margin. Tighter than the hand-tuned 1e-1; the 1000003 sweep is
-    // oracle-governed (volk_reference). int16 input is exact (no quantization); the
-    // error is float accumulation. Local basis (x86 + armv7 NEON); a CI arch that
-    // flickers triggers remeasure-and-rederive. See "Numerical accuracy". (#122)
-    QA(VOLK_INIT_TEST(volk_16i_32fc_dot_prod_32fc, test_params.make_absolute(2e-2)))
+    // 3e-2 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 1.14e-2, x86 avx2 over 200 seeds (a 10-seed sample
+    // undersampled the single-random-scalar tail ~1.5x here). Still ~3x tighter than
+    // the hand-tuned 1e-1 it replaces; the 1000003 sweep is oracle-governed
+    // (volk_reference). int16 input is exact (no quantization); the error is float
+    // accumulation. Contract is the FORMULA: remeasure-and-rederive, not
+    // hand-bumping. See "Numerical accuracy". (#122)
+    QA(VOLK_INIT_TEST(volk_16i_32fc_dot_prod_32fc, test_params.make_absolute(3e-2)))
     QA(VOLK_INIT_TEST(volk_32f_accumulator_s32f, test_params.make_absolute(2e-2)))
     QA(VOLK_INIT_TEST(volk_32f_x2_add_32f, test_params))
 

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -83,7 +83,13 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_16ic_x2_dot_prod_16ic, test_params))
     QA(VOLK_INIT_TEST(volk_16i_s32f_convert_32f, test_params))
     QA(VOLK_INIT_TEST(volk_16i_convert_8i, test_params))
-    QA(VOLK_INIT_TEST(volk_16i_32fc_dot_prod_32fc, test_params.make_absolute(1e-1)))
+    // 2e-2 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 7.4e-3, x86 avx2). Single-scalar reduction metric → 2.5x
+    // extreme-value margin. Tighter than the hand-tuned 1e-1; the 1000003 sweep is
+    // oracle-governed (volk_reference). int16 input is exact (no quantization); the
+    // error is float accumulation. Local basis (x86 + armv7 NEON); a CI arch that
+    // flickers triggers remeasure-and-rederive. See "Numerical accuracy". (#122)
+    QA(VOLK_INIT_TEST(volk_16i_32fc_dot_prod_32fc, test_params.make_absolute(2e-2)))
     QA(VOLK_INIT_TEST(volk_32f_accumulator_s32f, test_params.make_absolute(2e-2)))
     QA(VOLK_INIT_TEST(volk_32f_x2_add_32f, test_params))
 

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -144,12 +144,13 @@ static const std::vector<volk_reference_entry> g_registry = {
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
     // 16i_32fc_dot_prod abs tol = 2e-1 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
-    // oracle at the sweep's max vlen 1000003: generic reaches 4.53e-2 (the driver;
-    // SIMD tiers are more accurate, <= 4.0e-2). Errors are ~6x the pure-float dot
-    // products because the int16 input ranges over [-6,6] (harness data). Metric is
-    // the complex-magnitude error (ccompare abs mode). 2.5x extreme-value margin per
-    // docs/kernel_correctness_harness/README.md §Reduction-tolerance methodology.
-    // ABSOLUTE. x86 + armv7 NEON; aarch64/rvv fall under the remeasure clause. (#122)
+    // oracle at the sweep's max vlen 1000003, sampled over 60 seeds: generic reaches
+    // 6.54e-2 (the driver; SIMD tiers are more accurate, <= 4.0e-2). Errors are ~6x
+    // the pure-float dot products because the int16 input ranges over [-6,6]
+    // (harness data). Metric is the complex-magnitude error (ccompare abs mode).
+    // 2.5x extreme-value margin, mode/anchor/sampling per the reduction-tolerance
+    // methodology in docs/kernel_correctness_harness/README.md. ABSOLUTE. x86 +
+    // armv7 NEON; aarch64/rvv fall under the remeasure clause. (#122)
     { "volk_16i_32fc_dot_prod_32fc", ref_16i_32fc_dot_prod_32fc, 2e-1f, true },
 };
 

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,32 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_16i_32fc_dot_prod_32fc: result = sum_i input[i]*taps[i], a 16-bit INTEGER
+// real input scaled by complex float taps. A complex REDUCTION oracle: the int16
+// samples are exact integers (no input quantization), promoted to double and scaled
+// by the complex tap, accumulated in double, writing only element 0 of the complex
+// output (the harness zero-fills both sides, so the untouched tail compares equal).
+// in[0] is short* (real int input), in[1] is lv_32fc_t* (complex taps). The error is
+// float ACCUMULATION error (not quantization) — same #118 reduction rationale; only
+// a double-precision truth oracle judges each impl.
+static void ref_16i_32fc_dot_prod_32fc(const std::vector<const void*>& in,
+                                       const std::vector<void*>& out,
+                                       lv_32fc_t /*scalar*/,
+                                       unsigned int vlen)
+{
+    const short* input = static_cast<const short*>(in[0]);
+    const lv_32fc_t* taps = static_cast<const lv_32fc_t*>(in[1]);
+    lv_32fc_t* result = static_cast<lv_32fc_t*>(out[0]);
+    double acc_re = 0.0;
+    double acc_im = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double s = static_cast<double>(input[i]);
+        acc_re += s * static_cast<double>(lv_creal(taps[i]));
+        acc_im += s * static_cast<double>(lv_cimag(taps[i]));
+    }
+    result[0] = lv_cmake(static_cast<float>(acc_re), static_cast<float>(acc_im));
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +143,14 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // 16i_32fc_dot_prod abs tol = 2e-1 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003: generic reaches 4.53e-2 (the driver;
+    // SIMD tiers are more accurate, <= 4.0e-2). Errors are ~6x the pure-float dot
+    // products because the int16 input ranges over [-6,6] (harness data). Metric is
+    // the complex-magnitude error (ccompare abs mode). 2.5x extreme-value margin per
+    // docs/kernel_correctness_harness/README.md §Reduction-tolerance methodology.
+    // ABSOLUTE. x86 + armv7 NEON; aarch64/rvv fall under the remeasure clause. (#122)
+    { "volk_16i_32fc_dot_prod_32fc", ref_16i_32fc_dot_prod_32fc, 2e-1f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_16i_32fc_dot_prod_32fc

**Plain-language summary.** This kernel is a mixed-type reduction — a 16-bit *integer*
signal dotted with complex-float taps. The runbook flagged it for a "measure first" check:
does integer quantization dominate the error (which would make the reduction-oracle pattern
inapplicable)? **It does not.** The int16 samples are exact integers and the output is
full-precision complex float, so the error is ordinary float *accumulation* error — the same
#118 reduction behavior (SIMD tiers measurably more accurate than the generic serial loop).
So this PR applies the pattern: a double-precision oracle with two measurement-derived tols.

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — `ref_16i_32fc_dot_prod_32fc` oracle (int16→double, scaled by
  complex taps, double accumulation) + registry row `ref.tol = 2e-1` absolute.
- **lib/kernel_tests.h** — testqa tolerance `1e-1 → 2e-2` absolute (5× tighter; derived).
- **kernels/volk/…16i_32fc_dot_prod_32fc.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin; probe matched to harness data: int16 [-6,6], taps (-1,1))
- **kp.tol = 2e-2** = ceil_1sf(2.5 × 7.4e-3), max impl-vs-generic delta @131071 (x86 avx2).
- **ref.tol = 2e-1** = ceil_1sf(2.5 × 4.53e-2), max both-sides error vs oracle @1000003
  (generic). Errors run ~6× the pure-float dot products because the input ranges over [-6,6].
- Both **absolute**; metric matches `ccompare` abs mode (complex magnitude).

### Validation (local, gcc-13 + clang-18)
- Banner `tol=2e-02`; 10/10 seeded testqa; ref sweep `ok [ref]` exit 0 (oracle evaluates).
- Two negative controls with teeth: kp→2e-4 fails testqa; ref→2e-3 fails the ref sweep;
  both restored + re-verified green. clang-format clean. Fleet CI runs post-push.

### Notes
- Not yet in `lib/volk_buffer_roles.cc` → the `#89` canary reports its single-element output
  as `part` (expected for a reduction; separate buffer-roles follow-up, out of scope).
- kp.tol basis is local (x86 + armv7 NEON); a CI arch that flickers triggers
  remeasure-and-rederive per the contract. aarch64 neonv8 + rvv/rvvseg unmeasured.

Refs #122. (Fork posture: issue stays open — evidence in comments, upstream-filing queue;
this PR intentionally does not auto-close it.)

---

### Revision (2026-07-04): tail-sampled re-derivation — supersedes the derivation numbers above

A 10-seed probe max undersamples the single-random-scalar reduction error tail ~3× (caught
when #123's first cut flickered locally; see the README §Reduction-tolerance methodology
sampling rule added on the #118 branch). Re-measured with **200 seeds @131071 (kp)** and
**60 seeds @1000003 (ref)**, max over **both sides and all impls**:

- **kp.tol = 3e-2 (was 2e-2; tail 1.14e-2, avx2, 200 seeds — still ~3x tighter than the hand-tuned 1e-1)**
- **ref.tol = 2e-1 (unchanged; 60-seed generic tail 6.54e-2 re-derives to the same constant)**

Commit `ac34f729` on this branch; the same constants are folded to dev/all-prs (`964bba66`).
Re-validated at the corrected values: 10/10 seeded testqa on gcc-13 + clang-18, ref sweep
`ok [ref]` exit 0, and both negative controls (100× tighter kp / ref) trip and restore green.
