### PR TITLE
reduction-tolerance accumulator_s32f

### DIFF
--- a/kernels/volk/volk_32f_accumulator_s32f.h
+++ b/kernels/volk/volk_32f_accumulator_s32f.h
@@ -26,6 +26,23 @@
  * \b Outputs
  * \li result The accumulated result.
  *
+ * \b Numerical accuracy
+ *
+ * A single-precision real reduction: absolute error vs the exact sum grows
+ * ~linearly with num_points (random-sign accumulation of rounding errors), while
+ * the sum magnitude grows only ~sqrt(num_points) for zero-mean data — no single
+ * relative bound is meaningful across sizes. The SIMD tiers use W-way partial sums
+ * and are measurably more accurate than the generic serial loop; measured at
+ * num_points = 1000003 over uniform(-1,1), generic <= 1.17e-2 absolute, the AVX
+ * tiers <= 4.2e-3. Because generic is the least accurate side, the fork harness
+ * checks every impl against a double-precision oracle. The QA metric is a single
+ * random scalar per run with a heavy tail (200-seed sampling put the 131071 delta at
+ * 6.1e-3 and the 1000003 both-sides error at 3.3e-2), so bounds carry a 2.5x
+ * extreme-value margin (lib/kernel_tests.h; derivation #123): impl-vs-generic 2e-2
+ * absolute at num_points 131071; the oracle check is 9e-2 absolute up to
+ * num_points 1000003. Sums of zero-mean inputs cross zero, so tolerances are
+ * absolute by doctrine.
+ *
  * \b Example
  * Calculate the sum of numbers  0 through 99
  * \code

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -84,6 +84,11 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_16i_s32f_convert_32f, test_params))
     QA(VOLK_INIT_TEST(volk_16i_convert_8i, test_params))
     QA(VOLK_INIT_TEST(volk_16i_32fc_dot_prod_32fc, test_params.make_absolute(1e-1)))
+    // 2e-2 = ceil_1sf(2.5 x max measured impl-vs-generic delta at testqa's vlen
+    // 131071: 6.1e-3, x86 avx512f over 200 seeds). Re-derivation CONFIRMS the existing
+    // hand-tuned 2e-2 (a 10-seed sample undersampled the single-scalar tail ~3x). The
+    // 1000003 sweep is now oracle-governed (volk_reference); a CI arch that flickers
+    // triggers remeasure-and-rederive. See "Numerical accuracy". (#123)
     QA(VOLK_INIT_TEST(volk_32f_accumulator_s32f, test_params.make_absolute(2e-2)))
     QA(VOLK_INIT_TEST(volk_32f_x2_add_32f, test_params))
 

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,26 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_32f_accumulator_s32f: result = sum_i input[i], a single-input REAL reduction
+// (scalar float output). A REDUCTION oracle: accumulates the input in double and
+// writes only element 0 of the output (the harness zero-fills both sides, so the
+// untouched tail compares equal). Same rationale as the dot products (#118/#119):
+// the generic serial float sum has accumulation-order-dependent error, so only a
+// double-precision truth oracle judges each impl on its own merit.
+static void ref_accumulator_s32f(const std::vector<const void*>& in,
+                                 const std::vector<void*>& out,
+                                 lv_32fc_t /*scalar*/,
+                                 unsigned int vlen)
+{
+    const float* input = static_cast<const float*>(in[0]);
+    float* result = static_cast<float*>(out[0]);
+    double acc = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        acc += static_cast<double>(input[i]);
+    }
+    result[0] = static_cast<float>(acc);
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +137,13 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // accumulator_s32f abs tol = 9e-2 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003: 3.28e-2 over 60 seeds (generic is the
+    // driver; a 10-seed sample undersampled this tail ~2.8x). Scalar (real) reduction
+    // metric. 2.5x extreme-value margin per docs/kernel_correctness_harness/README.md
+    // §Reduction-tolerance methodology. ABSOLUTE. x86 + armv7 NEON; aarch64/rvv fall
+    // under the remeasure clause. (#123)
+    { "volk_32f_accumulator_s32f", ref_accumulator_s32f, 9e-2f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_32f_accumulator_s32f

**Plain-language summary.** This accumulator sums a float buffer to a single scalar. The
correctness harness judged each SIMD implementation against the plain C generic loop — the
wrong yardstick for a reduction, whose float error is accumulation-order-dependent. This PR
applies the #118 pattern: a double-precision oracle judges every implementation against real
ground truth, with two measurement-derived absolute tolerances.

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — `ref_accumulator_s32f` oracle (double accumulation of the input)
  + registry row `ref.tol = 9e-2` absolute.
- **lib/kernel_tests.h** — testqa tolerance unchanged at `2e-2` (re-derivation confirms it; comment added).
- **kernels/volk/…accumulator_s32f.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin; probe, 10 seeds, uniform(-1,1))
- **kp.tol = 2e-2** = ceil_1sf(2.5 × 6.1e-3 over 200 seeds @131071, avx512f) — confirms the existing hand-tuned 2e-2 (a 10-seed sample undersampled the single-scalar tail ~3x).
- **ref.tol = 9e-2** = ceil_1sf(2.5 × 3.28e-2 over 60 seeds), max both-sides error vs oracle @1000003
  (generic — the least-accurate side; the SIMD tiers are more accurate).
- Both **absolute** (zero-mean sums cross zero); scalar metric (fcompare).

### Validation (local, gcc-13 + clang-18)
- Banner `tol=2e-02`; 25/25 seeded testqa; ref sweep `ok [ref]` exit 0 (oracle evaluates).
- Two negative controls with teeth: kp→2e-4 fails testqa; ref→9e-4 fails the ref sweep;
  both restored + re-verified green. clang-format clean. Fleet CI runs post-push.

### Notes
- `volk_32f_accumulator_s32f` is already in `lib/volk_buffer_roles.cc` (#161), so the `#89`
  canary is clean for this kernel (no `part`).
- kp.tol basis is local (x86 + armv7 NEON); a CI arch that flickers triggers
  remeasure-and-rederive per the contract. aarch64 neonv8 + rvv unmeasured (remeasure clause).

Refs #123. (Fork posture: issue stays open — evidence in comments, upstream-filing queue;
this PR intentionally does not auto-close it.)
