### PR TITLE
reduction-tolerance accumulator_s32fc

### DIFF
--- a/kernels/volk/volk_32fc_accumulator_s32fc.h
+++ b/kernels/volk/volk_32fc_accumulator_s32fc.h
@@ -26,6 +26,24 @@
  * \b Outputs
  * \li result: The accumulated result.
  *
+ * \b Numerical accuracy
+ *
+ * A single-precision complex reduction: absolute error vs the exact sum grows
+ * ~linearly with num_points (random-sign accumulation of rounding errors in each
+ * component), while the sum magnitude grows only ~sqrt(num_points) for zero-mean
+ * data — no single relative bound is meaningful across sizes. The error metric is
+ * the complex-magnitude of the deviation. The SIMD tiers use W-way partial sums
+ * and are measurably more accurate than the generic serial loop; at
+ * num_points = 1000003 over uniform(-1,1) (60-seed tail maxima), generic reaches
+ * 5.4e-2 absolute, sse <= 2.5e-2, avx512f <= 9.6e-3, armhf NEON <= 9.0e-3.
+ * Because generic is the least accurate side, the fork harness checks every impl
+ * against a double-precision oracle. The QA metric is a single random scalar per
+ * run with a heavy tail (bounds derive from 200-seed/60-seed tail maxima), so they
+ * carry a 2.5x extreme-value margin (lib/kernel_tests.h; derivation #124):
+ * impl-vs-generic 2e-2 absolute at num_points 131071; the oracle check is 2e-1
+ * absolute up to num_points 1000003. Sums of zero-mean inputs cross zero, so
+ * tolerances are absolute by doctrine.
+ *
  * \b Example
  * Calculate the sum of numbers  0 through 99
  * \code

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -180,7 +180,13 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_x2_conjugate_dot_prod_32fc,
                       test_params.make_absolute(2e-2)))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_32f_x2, test_params))
-    QA(VOLK_INIT_TEST(volk_32fc_accumulator_s32fc, test_params.make_absolute(3e-2)))
+    // 2e-2 = ceil_1sf(2.5 x max measured impl-vs-generic complex-magnitude delta at
+    // testqa's vlen 131071: 7.75e-3, x86 sse over 200 seeds (the README tail-sampling
+    // rule). Single-scalar reduction metric → 2.5x extreme-value margin. Tighter than
+    // the hand-tuned 3e-2; the 1000003 sweep is oracle-governed (volk_reference).
+    // Contract is the FORMULA: remeasure-and-rederive, not hand-bumping. See the
+    // kernel's "Numerical accuracy" comment. (#124)
+    QA(VOLK_INIT_TEST(volk_32fc_accumulator_s32fc, test_params.make_absolute(2e-2)))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_64f_x2, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_s32f_deinterleave_real_16i, test_params.make_tol(1)))
     QA(VOLK_INIT_TEST(volk_32fc_deinterleave_imag_32f, test_params))

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,29 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_32fc_accumulator_s32fc: result = sum_i input[i], a single-input COMPLEX
+// reduction (scalar complex output; real and imaginary parts sum independently).
+// A REDUCTION oracle: accumulates both components in double and writes only
+// element 0 of the output (the harness zero-fills both sides, so the untouched
+// tail compares equal). Same rationale as the dot products (#118/#119): the
+// generic serial float sum has accumulation-order-dependent error, so only a
+// double-precision truth oracle judges each impl on its own merit.
+static void ref_accumulator_s32fc(const std::vector<const void*>& in,
+                                  const std::vector<void*>& out,
+                                  lv_32fc_t /*scalar*/,
+                                  unsigned int vlen)
+{
+    const lv_32fc_t* input = static_cast<const lv_32fc_t*>(in[0]);
+    lv_32fc_t* result = static_cast<lv_32fc_t*>(out[0]);
+    double acc_re = 0.0;
+    double acc_im = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        acc_re += static_cast<double>(lv_creal(input[i]));
+        acc_im += static_cast<double>(lv_cimag(input[i]));
+    }
+    result[0] = lv_cmake(static_cast<float>(acc_re), static_cast<float>(acc_im));
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +140,15 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // accumulator_s32fc abs tol = 2e-1 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003, sampled over 60 seeds: generic reaches
+    // 5.36e-2 (the driver; SIMD tiers are more accurate, sse <= 2.5e-2, avx512f
+    // <= 9.6e-3; armhf generic <= 1.8e-2). Metric is the complex-magnitude error
+    // (ccompare abs mode). 2.5x extreme-value margin, mode/anchor/sampling per the
+    // reduction-tolerance methodology in docs/kernel_correctness_harness/README.md.
+    // ABSOLUTE (zero-mean complex sums cross zero). x86 + armv7 NEON; aarch64/rvv
+    // fall under the remeasure clause. (#124)
+    { "volk_32fc_accumulator_s32fc", ref_accumulator_s32fc, 2e-1f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_32fc_accumulator_s32fc

**Plain-language summary.** This accumulator sums a complex float buffer to a single
complex scalar. The correctness harness judged each SIMD implementation against the plain C
generic loop — the wrong yardstick for a reduction, whose float error is
accumulation-order-dependent. This PR applies the #118 pattern: a double-precision oracle
judges every implementation against real ground truth, with two measurement-derived absolute
tolerances. First sibling derived under the README's tail-sampling rule from the start
(200 seeds @131071 / 60 seeds @1000003, max over both sides and all impls).

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — `ref_accumulator_s32fc` oracle (double accumulation of both
  components) + registry row `ref.tol = 2e-1` absolute.
- **lib/kernel_tests.h** — testqa tolerance `3e-2 → 2e-2` absolute (tighter; derived).
- **kernels/volk/…accumulator_s32fc.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin; complex-magnitude metric per ccompare)
- **kp.tol = 2e-2** = ceil_1sf(2.5 × 7.75e-3), the 200-seed impl-vs-generic delta tail
  @131071 (x86 sse; clang bit-identical; armhf NEON 3.9e-3 at 50 seeds does not drive).
- **ref.tol = 2e-1** = ceil_1sf(2.5 × 5.36e-2), the 60-seed both-sides tail vs the oracle
  @1000003 (generic — the least-accurate side; SIMD tiers ≤ 2.5e-2).
- Both **absolute** (zero-mean complex sums cross zero).

### Validation (local, gcc-13 + clang-18)
- Banner `tol=2e-02`; 10/10 seeded testqa; ref sweep `ok [ref]` exit 0 — which also
  confirms the scalar-complex-output (s32fc) path evaluates in ref mode (0 skipped).
- Two negative controls with teeth: kp→2e-4 fails testqa; ref→2e-3 fails the ref sweep;
  both restored + re-verified green. clang-format clean. Fleet CI runs post-push.

### Notes
- Not yet in `lib/volk_buffer_roles.cc` → the `#89` canary reports its single-element output
  as `part` (expected for a reduction; batch registration tracked in #191, out of scope here).
- aarch64 neonv8 + rvv unmeasured (remeasure clause); a CI arch that flickers triggers
  remeasure-and-rederive per the contract.

Refs #124. (Fork posture: issue stays open — evidence in comments, upstream-filing queue;
this PR intentionally does not auto-close it.)
