### PR TITLE
reduction-tolerance spectral_noise_floor

### DIFF
--- a/kernels/volk/volk_32f_s32f_calc_spectral_noise_floor_32f.h
+++ b/kernels/volk/volk_32f_s32f_calc_spectral_noise_floor_32f.h
@@ -35,6 +35,26 @@
  * \b Outputs
  * \li noiseFloorAmplitude: The noise floor of the input spectrum, in dB.
  *
+ * \b Numerical accuracy
+ *
+ * A two-pass selection reduction: a mean sets a threshold (mean +
+ * spectralExclusionValue), then the surviving bins are averaged. Because the
+ * output is a mean, its absolute error is roughly INDEPENDENT of num_points (the
+ * accumulated sum error divides by N) — unlike the raw dot products, whose error
+ * grows linearly. Two error sources: float accumulation in each pass, and
+ * near-threshold bins flipping in or out when a float-rounded mean lands on the
+ * other side of a bin (folded into the measured bounds). The SIMD tiers use
+ * W-way partial sums and are measurably more accurate than the generic serial
+ * loop; at num_points = 1000003 over the QA data (60-seed tail maxima), generic
+ * reaches 1.01e-5 absolute, sse <= 2.3e-6, avx <= 9.0e-7. Because generic is the
+ * least accurate side, the fork harness checks every impl against a
+ * double-precision oracle. Bounds carry a 2.5x extreme-value margin over
+ * 200-seed/60-seed tail maxima (lib/kernel_tests.h; derivation #126):
+ * impl-vs-generic 1e-5 absolute at num_points 131071 (replacing a relative 1e-4);
+ * the oracle check is 3e-5 absolute up to num_points 1000003. Absolute because
+ * the sweep's small edge-only vlens can produce a result of exactly zero, where a
+ * relative bound is ill-posed.
+ *
  * \b Example
  * \code
  * int N = 10000;

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -55,7 +55,6 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
 
     volk_test_params_t test_params_snf(test_params);
     test_params_snf.set_scalar(0.5);
-    test_params_snf.set_tol(1e-4);
 
     std::vector<volk_test_case_t> test_cases;
     QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt, test_params))
@@ -152,7 +151,16 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32f_asin_32f, test_params_asin))
     QA(VOLK_INIT_TEST(volk_32f_acos_32f, test_params_asin))
     QA(VOLK_INIT_TEST(volk_32fc_s32f_power_32fc, test_params_power))
-    QA(VOLK_INIT_TEST(volk_32f_s32f_calc_spectral_noise_floor_32f, test_params_snf))
+    // 1e-5 ABSOLUTE = ceil_1sf(2.5 x max measured impl-vs-generic delta at testqa's
+    // vlen 131071: 3.9e-6, x86 sse over 200 seeds — the README tail-sampling rule).
+    // Replaces the relative 1e-4 (~2.5e-5 effective at the QA result's |res|~0.25,
+    // only ~2.4x above the 1M delta tail). Unlike the raw dot products, this output
+    // is a MEAN, so its absolute error is ~vlen-stable; the wrong-side pathology
+    // still holds (generic 5-10x less accurate than SIMD), so the 1000003 sweep is
+    // oracle-governed (volk_reference). Absolute: small edge-only sweep vlens can
+    // land exactly on 0, where relative is ill-posed. Scalar 0.5 preserved. (#126)
+    QA(VOLK_INIT_TEST(volk_32f_s32f_calc_spectral_noise_floor_32f,
+                      test_params_snf.make_absolute(1e-5)))
 
     volk_test_params_t test_params_atan2(test_params);
     test_params_atan2.add_complex_edge_cases(

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,42 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_32f_s32f_calc_spectral_noise_floor_32f: a two-pass SELECTION reduction.
+// Pass 1: mean of all points; threshold = mean + spectralExclusionValue (the s32f
+// scalar, real part of `scalar`). Pass 2: mean of the points <= threshold; if no
+// point survives (all amplitudes equal edge case), the threshold itself. Computed
+// exactly in double, including the threshold comparison — an impl whose
+// float-rounded mean flips a near-threshold bin is charged for it, per the
+// exact-math contract. Writes only element 0 (harness zero-fills both sides).
+// Unlike the raw dot products the output is normalized (a mean), so its absolute
+// error is ~vlen-stable; the #118 wrong-side pathology still holds at that scale
+// (generic 5-10x less accurate than SIMD), so the oracle judges each impl. (#126)
+static void ref_spectral_noise_floor_32f(const std::vector<const void*>& in,
+                                         const std::vector<void*>& out,
+                                         lv_32fc_t scalar,
+                                         unsigned int vlen)
+{
+    const float* data = static_cast<const float*>(in[0]);
+    float* result = static_cast<float*>(out[0]);
+    const double excl = static_cast<double>(lv_creal(scalar));
+    double sum = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        sum += static_cast<double>(data[i]);
+    }
+    const double threshold = sum / vlen + excl;
+    double kept_sum = 0.0;
+    unsigned int kept = vlen;
+    for (unsigned int i = 0; i < vlen; i++) {
+        if (static_cast<double>(data[i]) <= threshold) {
+            kept_sum += static_cast<double>(data[i]);
+        } else {
+            kept--;
+        }
+    }
+    const double nf = (kept == 0) ? threshold : kept_sum / kept;
+    result[0] = static_cast<float>(nf);
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +153,16 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // spectral_noise_floor abs tol = 3e-5 = ceil_1sf(2.5 x max BOTH-SIDES error vs
+    // the oracle at the sweep's max vlen 1000003, sampled over 60 seeds: generic
+    // reaches 1.01e-5 (the driver; SIMD tiers are more accurate, sse <= 2.3e-6,
+    // avx <= 9.0e-7; armhf serial-order, <= 1.4e-6). The output is a mean, so the
+    // error is ~vlen-stable rather than linear in N. 2.5x extreme-value margin,
+    // mode/anchor/sampling per the reduction-tolerance methodology in
+    // docs/kernel_correctness_harness/README.md. ABSOLUTE (small edge-only sweep
+    // vlens can land exactly on 0). x86 + armv7 NEON; aarch64/rvv fall under the
+    // remeasure clause. (#126)
+    { "volk_32f_s32f_calc_spectral_noise_floor_32f", ref_spectral_noise_floor_32f, 3e-5f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -162,7 +162,10 @@ static const std::vector<volk_reference_entry> g_registry = {
     // docs/kernel_correctness_harness/README.md. ABSOLUTE (small edge-only sweep
     // vlens can land exactly on 0). x86 + armv7 NEON; aarch64/rvv fall under the
     // remeasure clause. (#126)
-    { "volk_32f_s32f_calc_spectral_noise_floor_32f", ref_spectral_noise_floor_32f, 3e-5f, true },
+    { "volk_32f_s32f_calc_spectral_noise_floor_32f",
+      ref_spectral_noise_floor_32f,
+      3e-5f,
+      true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_32f_s32f_calc_spectral_noise_floor_32f

**Plain-language summary.** This kernel estimates a spectrum's noise floor in two passes:
average everything, keep only the bins at or below (mean + exclusion), average those. The
harness judged its SIMD implementations against the plain C generic loop under a *relative*
1e-4 tolerance. Two things were wrong with that: generic is the *least* accurate side
(5–10× worse than SIMD — the #118 wrong-side pathology), and the relative bound sat only
~2.4× above the observed impl-vs-generic tail. This PR applies the #118 pattern: a
double-precision oracle judges every implementation, with two tail-derived absolute bounds.

**A regime note the other siblings don't share:** the output is a *mean*, so its absolute
error is roughly independent of num_points (the accumulated sum error divides by N) — the
dot products' linear-in-N growth model doesn't transfer, and the derived constants are
correspondingly small (1e-5-scale, not 1e-2). The wrong-side pathology transfers intact.

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — `ref_spectral_noise_floor_32f` oracle: the exact two-pass
  computation in double (including the threshold comparison and the all-bins-excluded
  degenerate branch), exclusion value taken from the s32f scalar. Registry row
  `ref.tol = 3e-5` absolute.
- **lib/kernel_tests.h** — registration moves from relative 1e-4 to **absolute 1e-5**
  (`test_params_snf.make_absolute(1e-5)`; scalar 0.5 preserved, the dead `set_tol` dropped).
- **kernels/volk/…calc_spectral_noise_floor_32f.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin; README tail-sampling rule: 200/60 seeds, both sides, all impls)
- **kp.tol = 1e-5** = ceil_1sf(2.5 × 3.9e-6), the 200-seed delta tail @131071 (x86 sse;
  clang bit-identical; armhf NEON is serial-order, delta 0).
- **ref.tol = 3e-5** = ceil_1sf(2.5 × 1.01e-5), the 60-seed both-sides tail @1000003
  (generic — the least-accurate side).
- **Absolute**, because the sweep's small edge-only vlens can produce a result of exactly
  zero (where relative is ill-posed), and per family doctrine. On the QA anchors the result
  sits near −0.25, so the old relative 1e-4 was effectively ~2.5e-5 — the new bounds are
  tighter *and* mode-correct.
- Threshold selection-flips (a float-rounded mean landing across a near-threshold bin) are
  real error charged to the impl by the exact-math oracle; they are folded into the
  measured tails.

### Validation (local, gcc-13 + clang-18)
- Banner `tol=1e-05`; 10/10 seeded testqa; ref sweep `ok [ref]` exit 0 with
  **0 ref kernels skipped** — the s32f scalar-input path through ref mode (the registered
  atan2/power precedent) evaluates.
- Two negative controls with teeth: kp→1e-7 fails testqa; ref→3e-7 fails the ref sweep;
  both restored + re-verified green. clang-format clean. Fleet CI runs post-push.

### Notes
- Not yet in `lib/volk_buffer_roles.cc` → `#89` canary `part` row expected (batched in #191).
- aarch64 neonv8 + rvv unmeasured (remeasure clause).

Refs #126. (Fork posture: issue stays open — evidence in comments, upstream-filing queue;
this PR intentionally does not auto-close it.)
