### PR TITLE
reduction-tolerance stddev_and_mean

### DIFF
--- a/kernels/volk/volk_32f_stddev_and_mean_32f_x2.h
+++ b/kernels/volk/volk_32f_stddev_and_mean_32f_x2.h
@@ -28,6 +28,27 @@
  * \li stddev: The calculated standard deviation.
  * \li mean: The mean of the input buffer.
  *
+ * \b Numerical accuracy
+ *
+ * A two-output reduction computing the POPULATION standard deviation
+ * (sqrt(M2/num_points)) and the mean. The implementations use the numerically
+ * stable Youngs-Cramer updating form (interleaved accumulator lanes merged at
+ * the end), not the cancellation-prone E[x^2]-mean^2 formulation; the fork
+ * harness checks every impl against an exact double-precision two-pass oracle,
+ * which doubles as a continuously enforced stability guard. The stddev output
+ * dominates the error budget: its absolute error grows ~linearly with
+ * num_points (the M2 accumulation error outpaces the /N normalization), while
+ * the mean output's error is ~1e-8-scale (sum error divided by N). Measured at
+ * num_points = 1000003 over uniform(-1,1) (60-seed tail maxima), generic stddev
+ * reaches 4.5e-5 absolute, the SIMD tiers <= 6.5e-6 — generic is the least
+ * accurate side. QA bounds carry a 2.5x extreme-value margin over
+ * 200-seed/60-seed tail maxima and are shared across both outputs
+ * (lib/kernel_tests.h; derivation #125): impl-vs-generic 1e-5 absolute at
+ * num_points 131071 (the tail re-derivation lands on the pre-existing value);
+ * the oracle check is 2e-4 absolute up to num_points 1000003. Absolute because
+ * the mean output crosses zero on zero-mean data and one mode covers both
+ * outputs.
+ *
  * \b Example
  * Generate random numbers with c++11's normal distribution and estimate the mean and
  * standard deviation

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -240,6 +240,13 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
         { -1.f, 1.f, 0.f, inf, 1e-2f, 1e2f, 1e-10, 1e10 });
     QA(VOLK_INIT_TEST(volk_32f_invsqrt_32f, test_params_invsqrt))
     QA(VOLK_INIT_TEST(volk_32f_s32f_stddev_32f, test_params_inacc))
+    // 1e-5 = ceil_1sf(2.5 x max measured impl-vs-generic delta at testqa's vlen
+    // 131071 over BOTH outputs: 3.9e-6, the stddev output, x86 sse over 200 seeds
+    // (the README tail-sampling rule; the mean output's deltas are ~4.6e-8, three
+    // orders below). Re-derivation lands ON the pre-existing hand-tuned 1e-5 —
+    // kept. The 1000003 sweep is oracle-governed (volk_reference). Contract is the
+    // FORMULA: remeasure-and-rederive, not hand-bumping. See the kernel's
+    // "Numerical accuracy" comment. (#125)
     QA(VOLK_INIT_TEST(volk_32f_stddev_and_mean_32f_x2, test_params.make_absolute(1e-5)))
     QA(VOLK_INIT_TEST(volk_32f_x2_subtract_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32f_x3_sum_of_poly_32f, test_params.make_absolute(1e+3)))

--- a/lib/volk_reference.cc
+++ b/lib/volk_reference.cc
@@ -106,6 +106,46 @@ static void ref_log2_32f(const std::vector<const void*>& in,
     }
 }
 
+// volk_32f_stddev_and_mean_32f_x2: a TWO-OUTPUT reduction — population standard
+// deviation (sqrt(M2/N)) and mean (sum/N) of one input buffer. The first
+// multi-output oracle: writes the contracted prefix of EACH output buffer
+// (outputs[0][0] = stddev, outputs[1][0] = mean, matching the kernel's argument
+// order; the harness zero-fills both sides so the untouched tails compare
+// equal). Computed as the exact double two-pass — which also makes the ref
+// sweep a continuously enforced STABILITY guard: the shipped kernel uses the
+// stable Youngs-Cramer updating form, and a regression to a naive
+// E[x^2]-mean^2 formulation would blow past the registered bound. Kernel edge
+// contract mirrored: N==1 -> (0, x[0]); N==0 -> no write. (#125)
+static void ref_stddev_and_mean_32f_x2(const std::vector<const void*>& in,
+                                       const std::vector<void*>& out,
+                                       lv_32fc_t /*scalar*/,
+                                       unsigned int vlen)
+{
+    const float* input = static_cast<const float*>(in[0]);
+    float* stddev = static_cast<float*>(out[0]);
+    float* mean = static_cast<float*>(out[1]);
+    if (vlen == 0) {
+        return;
+    }
+    if (vlen == 1) {
+        stddev[0] = 0.0f;
+        mean[0] = input[0];
+        return;
+    }
+    double sum = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        sum += static_cast<double>(input[i]);
+    }
+    const double m = sum / vlen;
+    double m2 = 0.0;
+    for (unsigned int i = 0; i < vlen; i++) {
+        const double d = static_cast<double>(input[i]) - m;
+        m2 += d * d;
+    }
+    stddev[0] = static_cast<float>(std::sqrt(m2 / vlen));
+    mean[0] = static_cast<float>(m);
+}
+
 static const std::vector<volk_reference_entry> g_registry = {
     // name                          oracle             tol      absolute
     { "volk_32fc_s32f_power_32fc", ref_power_32fc, 1e-4f, false },
@@ -117,6 +157,17 @@ static const std::vector<volk_reference_entry> g_registry = {
     // too tight when comparing SIMD-vs-true-double. 2e-5 covers the approximation
     // envelope with margin while still catching gross defects (off by >>1e-4).
     { "volk_32f_log2_32f", ref_log2_32f, 2e-5f, true },
+    // stddev_and_mean abs tol = 2e-4 = ceil_1sf(2.5 x max BOTH-SIDES error vs the
+    // oracle at the sweep's max vlen 1000003, sampled over 60 seeds and over BOTH
+    // outputs: generic's stddev reaches 4.46e-5 (the driver; SIMD stddev <= 6.5e-6;
+    // mean errors are ~1e-8, three orders below — the shared bound is effectively a
+    // stddev bound). The stddev error GROWS ~linearly with vlen (M2 accumulation
+    // outpaces the /N normalization). 2.5x extreme-value margin, mode/anchor/
+    // sampling per the reduction-tolerance methodology in
+    // docs/kernel_correctness_harness/README.md. ABSOLUTE: the mean output crosses
+    // zero on zero-mean data and one mode covers both outputs. x86 + armv7 NEON;
+    // aarch64/rvv fall under the remeasure clause. (#125)
+    { "volk_32f_stddev_and_mean_32f_x2", ref_stddev_and_mean_32f_x2, 2e-4f, true },
 };
 
 const std::vector<volk_reference_entry>& volk_reference_registry() { return g_registry; }


### PR DESCRIPTION
## Apply the reduction-tolerance contract to volk_32f_stddev_and_mean_32f_x2

**Plain-language summary.** This kernel computes a buffer's standard deviation and mean in
one pass — the reduction family's only two-output member, saved for last. The harness
judged its SIMD implementations against the plain C generic loop, which is the *least*
accurate side (its stddev error runs 7–43× the SIMD tiers' — the #118 wrong-side
pathology). This PR adds the family's first **multi-output oracle**: an exact
double-precision two-pass that writes the contracted first element of *each* output, with
tail-derived bounds shared across both outputs.

**The issue's "stability check", answered:** the shipped implementations already use the
numerically stable Youngs–Cramer updating form (interleaved accumulator lanes, merged at
the end) — not the cancellation-prone E[x²]−mean² formulation. The exact-two-pass oracle
now doubles as a *continuously enforced* stability guard: a future regression to a naïve
formulation would blow past the 2e-4 oracle bound on the first sweep.

### What changed (fork harness only — no kernel logic)
- **lib/volk_reference.cc** — `ref_stddev_and_mean_32f_x2` (exact double two-pass;
  population stddev; mirrors the kernel's N==1 → (0, x[0]) and N==0 → no-write contract;
  writes outputs[0][0]=stddev, outputs[1][0]=mean) + registry row `ref.tol = 2e-4` absolute.
- **lib/kernel_tests.h** — value **unchanged at 1e-5**; the tail re-derivation lands
  exactly on the pre-existing hand-tuned constant (ceil_1sf(2.5 × 3.9e-6) = 1e-5), so the
  change is the derivation comment that makes it a formula instead of folklore.
- **kernels/volk/…stddev_and_mean_32f_x2.h** — a `\b Numerical accuracy` doc-comment.

### Derivation (2.5× scalar-reduction margin; README tail rule: 200/60 seeds, both sides, all impls, both outputs)
- The **stddev output dominates**: mean-output errors are ~1e-8 (sum error / N), three
  orders below — the shared bound is effectively a stddev bound.
- **kp.tol = 1e-5** = ceil_1sf(2.5 × 3.9e-6), the 200-seed delta tail @131071 (x86 sse;
  clang bit-identical; armhf NEON 3.8e-6).
- **ref.tol = 2e-4** = ceil_1sf(2.5 × 4.46e-5), the 60-seed both-sides tail @1000003
  (generic stddev). Unlike #126's vlen-stable regime, the stddev error *grows* ~linearly
  with vlen (M2 accumulation outpaces the /N normalization) — stated in the doc-comment.
- **Absolute**: the mean output crosses zero on zero-mean data, and the registry's single
  mode covers both outputs.

### Validation (local, gcc-13 + clang-18)
- Banner `tol=1e-05`; 10/10 seeded testqa; ref sweep `ok [ref]` exit 0 with
  **0 ref kernels skipped** — the registry's first **two-output** oracle path evaluates.
- Two negative controls with teeth: kp→1e-7 fails testqa; ref→2e-6 fails the ref sweep;
  both restored + re-verified green. clang-format clean (post-commit `--diff HEAD~1` gate).
- An output-order mistake (stddev↔mean swap) is structurally self-catching: it fails the
  sweep by ~0.577 ≫ 2e-4.

### Notes
- Not yet in `lib/volk_buffer_roles.cc` → `#89` canary `part` rows expected on both outputs
  (batched in #191; the schema's single `output_elems=1` applies to every output buffer).
- aarch64 neonv8 + rvv unmeasured (remeasure clause).

Refs #125. (Fork posture: issue stays open — evidence in comments, upstream-filing queue;
this PR intentionally does not auto-close it.)
