### PR TITLE
index_max_16u sse3 tie-break

### DIFF
--- a/kernels/volk/volk_32fc_index_max_16u.h
+++ b/kernels/volk/volk_32fc_index_max_16u.h
@@ -15,6 +15,9 @@
  * Returns Argmax_i mag(x[i]). Finds and returns the index which contains the
  * maximum magnitude for complex points in the given vector.
  *
+ * Tie-break: when several points share the maximum magnitude, the kernel returns
+ * the FIRST (lowest) such index.
+ *
  * Note that num_points is a uint32_t, but the return value is
  * uint16_t. Providing a vector larger than the max of a uint16_t
  * (65536) would miss anything outside of this boundary. The kernel
@@ -232,13 +235,15 @@ static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
 
         xmm1 = _mm_hadd_ps(xmm1, xmm2);
 
+        // First-index tie-break: a lane adopts the NEW index only where the new
+        // magnitude STRICTLY exceeds the running max (compared before the update);
+        // on an equal magnitude the earlier index is kept.
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+
         xmm3 = _mm_max_ps(xmm1, xmm3);
 
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_andnot_si128(xmm4.int_vec, xmm9);
 
         xmm9 = _mm_add_epi32(xmm11, xmm12);
 
@@ -257,15 +262,16 @@ static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
 
         xmm1 = _mm_hadd_ps(xmm2, xmm2);
 
+        // First-index tie-break (see the main loop): strict-greater takes the new
+        // index; an equal magnitude keeps the earlier index.
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+
         xmm3 = _mm_max_ps(xmm1, xmm3);
 
         xmm10 = _mm_setr_epi32(2, 2, 2, 2);
 
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_andnot_si128(xmm4.int_vec, xmm9);
 
         xmm9 = _mm_add_epi32(xmm11, xmm12);
 
@@ -296,14 +302,19 @@ static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
     _mm_store_ps((float*)&(holderf.f), xmm3);
     _mm_store_si128(&(holderi.int_vec), xmm9);
 
+    // Horizontal reduce with a first-index tie-break: a lane replaces the running
+    // winner only on a strictly greater magnitude, or on an equal magnitude with a
+    // smaller index (the per-lane accumulators can hold non-monotonic indices).
     target[0] = holderi.i[0];
     sq_dist = holderf.f[0];
-    target[0] = (holderf.f[1] > sq_dist) ? holderi.i[1] : target[0];
-    sq_dist = (holderf.f[1] > sq_dist) ? holderf.f[1] : sq_dist;
-    target[0] = (holderf.f[2] > sq_dist) ? holderi.i[2] : target[0];
-    sq_dist = (holderf.f[2] > sq_dist) ? holderf.f[2] : sq_dist;
-    target[0] = (holderf.f[3] > sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] > sq_dist) ? holderf.f[3] : sq_dist;
+    for (int lane = 1; lane < 4; ++lane) {
+        if (holderf.f[lane] > sq_dist) {
+            sq_dist = holderf.f[lane];
+            target[0] = holderi.i[lane];
+        } else if (holderf.f[lane] == sq_dist && holderi.i[lane] < target[0]) {
+            target[0] = holderi.i[lane];
+        }
+    }
 }
 
 #endif /*LV_HAVE_SSE3*/


### PR DESCRIPTION
## Fix volk_32fc_index_max_16u a_sse3 tie-break (first-index-wins)

**Finding.** At vlen 3 the correctness sweep's deterministic edge data (0,0),(5,5),(-5,-5)
ties two points at |z|²=50; `a_sse3` returns index **2** while `generic` and every other
implementation (avx2 variants, avx512f, and the unaligned variants) return **1**. `a_sse3`
is the lone nonconforming implementation.

**Decision — fix the implementation, not the harness.** The doc-comment did not previously
specify a tie-break, but first-index-wins is the
contract: upstream commit `0478a465` states it explicitly in lib/kernel_tests.h
("first index wins") and ("add tie-breaker for all kernels") added a test
enforcing it. I considered relaxing the harness to accept any argmax index, but (a) doing so
*correctly* needs input-aware magnitude comparison inside a generic output comparator —
semantically invasive and out of scope; a crude relaxation would blind the harness to real
index bugs; and (b) `a_sse3` disagreeing with 8 sibling implementations is a genuine
consumer-visible inconsistency (an FFT peak-finder switching arch would move on a tie). So
the convention is now documented in the kernel doc-comment and `a_sse3` is corrected to it.

**Scope note.** The gate review found the avx2 variants share a *separate* latent
tie bug (a scan-order reduce returns the later index on a cross-lane tie at vlen >= 8;
avx512f/neon were fixed by upstream 0478a465, avx2 was missed). It is out of scope here
(different root cause; one finding per PR) and filed as a follow-up; the harness's
fixed-position tie edges cannot detect it, so this kernel's sweep is `ok` regardless.

**Root cause.** `a_sse3`'s main-loop and 2-wide blocks awarded a magnitude tie to the NEWER
index (`cmpeq(new, newmax)` → new); the odd-tail is already correct; the final horizontal
reduce used a strict `>` that keeps the later LANE's index on a cross-lane magnitude tie.

**Fix** (`a_sse3` body + doc-comment only; `origin/main`-clean, no ABI/signature change):
- Main-loop + 2-wide blocks: take the new index only where `_mm_cmpgt_ps(new, oldmax)`
  (compared before the max update); ties keep the earlier index (`_mm_andnot_si128`).
- Odd-tail: unchanged (already keeps the earlier index on a lane-0 tie).
- Final reduce: replace only on a strictly greater magnitude, or an equal magnitude with a
  smaller index.
- Doc-comment: state the first-index (lowest) tie-break convention.

**Validation.** 280,000 brute-force checks (a_sse3 vs generic and vs an independent
first-argmax oracle, integer re/im in [-2,2] to force frequent ties, vlens 1..200) — zero
mismatches. The correctness sweep goes from FAIL (vlens 3) to `ok`; testqa passes; the
a_sse3 speedup is preserved (1.78×, marginally better — one fewer compare); index_min
untouched. clang-format clean.

Refs #127. (Fork posture: issue stays open, evidence in comments; not "Closes".)
