### PR TITLE
harness modes under-seed fixed-param array

### DIFF
--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -2129,12 +2129,22 @@ volk_canary_summary run_volk_canary_test(volk_func_desc_t desc,
     fmt::print("\nRUN_VOLK_CANARY_TEST: {}(vlen={})\n", name, vlen);
 
     volk_qa_aligned_mem_pool mem_pool;
-    // Inputs are sized exactly `vlen` (no twiddle) and drawn from the pool; the
-    // canary only guards the OUTPUT write side (input immutability / over-read is
-    // #90, best-effort via ASan). benchmark_mode=true bypasses the ">=2 arch"
-    // guard so single-impl kernels are still checked.
-    qa_test_data d = setup_test_data(
-        desc, name, vlen, true, float_edge_cases, complex_edge_cases, mem_pool);
+    // Inputs are over-allocated and seeded with vlen_twiddle extra elements (as
+    // run_volk_tests does), so a kernel that reads a fixed-size pointer argument
+    // past `vlen` (e.g. sum_of_poly's 5-element coefficient array) hits seeded data
+    // rather than unseeded slack at vlen < that fixed size (#98). The kernel is still
+    // RUN at `vlen`; the extra elements only pad the input allocations. The canary
+    // guards the OUTPUT write side (input immutability / over-read is #90, best-effort
+    // via ASan). benchmark_mode=true bypasses the ">=2 arch" guard so single-impl
+    // kernels are still checked.
+    const unsigned int vlen_twiddle = 5;
+    qa_test_data d = setup_test_data(desc,
+                                     name,
+                                     vlen + vlen_twiddle,
+                                     true,
+                                     float_edge_cases,
+                                     complex_edge_cases,
+                                     mem_pool);
     if (!d.ok) {
         return summary;
     }
@@ -2372,8 +2382,18 @@ run_volk_immutability_test(volk_func_desc_t desc,
     fmt::print("\nRUN_VOLK_IMMUTABILITY_TEST: {}(vlen={})\n", name, vlen);
 
     volk_qa_aligned_mem_pool mem_pool;
-    qa_test_data d = setup_test_data(
-        desc, name, vlen, true, float_edge_cases, complex_edge_cases, mem_pool);
+    // Over-allocate inputs by vlen_twiddle (as run_volk_tests does) so a fixed-size
+    // pointer argument read past `vlen` (e.g. sum_of_poly's 5-element coefficient
+    // array) hits seeded data, not unseeded slack, at vlen < that fixed size (#98).
+    // The kernel is still RUN at `vlen`.
+    const unsigned int vlen_twiddle = 5;
+    qa_test_data d = setup_test_data(desc,
+                                     name,
+                                     vlen + vlen_twiddle,
+                                     true,
+                                     float_edge_cases,
+                                     complex_edge_cases,
+                                     mem_pool);
     if (!d.ok) {
         return summary;
     }
@@ -2658,8 +2678,21 @@ run_volk_misaligned_test(volk_func_desc_t desc,
     fmt::print("\nRUN_VOLK_MISALIGNED_TEST: {}(vlen={})\n", name, vlen);
 
     volk_qa_aligned_mem_pool mem_pool;
-    qa_test_data d = setup_test_data(
-        desc, name, vlen, true, float_edge_cases, complex_edge_cases, mem_pool);
+    // Over-allocate/seed inputs by vlen_twiddle (as run_volk_tests does) so a
+    // fixed-size pointer argument read past `vlen` (e.g. sum_of_poly's 5-element
+    // coefficient array) hits seeded data at vlen < that fixed size (#98). Both the
+    // aligned pool buffers AND the misaligned own-malloc copies below are sized to
+    // vlen_twiddle and filled from the SAME seeded pre-image, so the two allocations
+    // read identical bytes there (a mere zero-fill would make the vlen < 5 comparison
+    // vacuous). The kernel is still RUN at `vlen`.
+    const unsigned int vlen_twiddle = 5;
+    qa_test_data d = setup_test_data(desc,
+                                     name,
+                                     vlen + vlen_twiddle,
+                                     true,
+                                     float_edge_cases,
+                                     complex_edge_cases,
+                                     mem_pool);
     if (!d.ok) {
         return summary;
     }
@@ -2944,7 +2977,10 @@ run_volk_misaligned_test(volk_func_desc_t desc,
         std::vector<void*> buffs;
         for (size_t j = 0; j < d.both_sigs.size(); j++) {
             const size_t elem = d.both_sigs[j].size * (d.both_sigs[j].is_complex ? 2 : 1);
-            const size_t bytes = static_cast<size_t>(vlen) * elem;
+            // vlen_twiddle padding here too: the misaligned copy must span the same
+            // seeded region as the aligned pool buffer so a fixed-element over-read
+            // reads identical bytes on both sides (#98).
+            const size_t bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
             mbufs.push_back(std::make_unique<misaligned_buffer>(bytes, alignment, elem));
             buffs.push_back(mbufs.back()->data());
         }
@@ -2954,8 +2990,10 @@ run_volk_misaligned_test(volk_func_desc_t desc,
             memset(buffs[j], 0, out_bytes);
         }
         for (size_t k = 0; k < d.inputsig.size(); k++) {
-            const size_t in_bytes = static_cast<size_t>(vlen) * d.inputsig[k].size *
-                                    (d.inputsig[k].is_complex ? 2 : 1);
+            // Copy the full seeded region (vlen + vlen_twiddle), matching the aligned
+            // pool pre-image, so fixed-element over-reads see identical bytes (#98).
+            const size_t elem = d.inputsig[k].size * (d.inputsig[k].is_complex ? 2 : 1);
+            const size_t in_bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
             memcpy(buffs[d.outputsig.size() + k], d.inbuffs[k], in_bytes);
         }
 


### PR DESCRIPTION
# MR — #98 qa_utils: seed vlen_twiddle margin in canary/immutability/misaligned modes

Fork PR to mtibbits/volk, base dev/all-prs (fork-only harness file). Refs #98 (stays OPEN).

## What
The three fork-only harness modes (run_volk_canary_test #89, run_volk_immutability_test #90,
run_volk_misaligned_test #91) passed the raw num_points to setup_test_data, unlike
run_volk_tests / run_volk_reference_test which over-allocate + seed vlen_twiddle (=5) extra
elements. A kernel reading a fixed-size pointer argument independent of num_points
(volk_32f_x3_sum_of_poly_32f always reads center_point_array[0..4]) therefore read
allocated-but-unseeded slack at vlen<5. Under HARNESS_MISALIGNED the two separate allocations
read different slack -> nondeterministic aligned-vs-misaligned divergence (12/12 FAIL at vlens 1..4).

## Fix (lib/qa_utils.cc only; +51/-13)
Pass vlen + vlen_twiddle to setup_test_data in all three modes (kernel still RUN at num_points).
The misaligned mode also sizes its own-malloc copy to vlen + vlen_twiddle and memcpys the full
seeded pre-image, so both allocations read identical bytes there (not a vacuous zero-fill).

## Evidence (see validation.md)
12/12 FAIL -> no-FAIL in 20/20 runs of all three modes (misaligned/immutability report ok;
canary reports its expected reduction `part` hedge, exit 0). Full misaligned/canary sweeps
0 diverged / 0 over-run and are per-impl IDENTICAL fixed-vs-unfixed (no regression, Fable gate);
run_volk_tests untouched -> default qa byte-identical; ASan/UBSan clean bar one pre-existing,
orthogonal misaligned-load alignment warning.
