### PR TITLE
volk_32f_8u_polarbutterflypuppet_32f: no-op when frame exceeds elements (#116)

### DIFF
--- a/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
@@ -75,6 +75,27 @@ static inline int maximum_frame_size(const int elements)
     return next_lower_power_of_two(frame_size / frame_exp);
 }
 
+// A frame of size `frame_size` (depth frame_exp = log2(frame_size)) drives these
+// accesses into the harness's `elements`-sized buffers:
+//   llrs : (frame_exp+1)*frame_size floats -- the LLR decode tree
+//   u    : 3*frame_size bytes of encode scratch (memset[0,fs) + frame[fs,2fs) +
+//          temp[2fs,3fs)); the decode butterfly's recursion writes a little past 3*fs at
+//          frame_exp>=4 but stays under (frame_exp+1)*frame_size, so the llrs clause
+//          bounds `u` too. BOTH clauses below are load-bearing: 3*fs binds at fs=2 (where
+//          llrs needs only 4), (frame_exp+1)*fs binds everywhere else -- do not drop
+//          either.
+// At tiny `elements` no power-of-two frame fits (the smallest, fs=2, already needs u>=6),
+// so the caller no-ops rather than overrunning the buffers. (#116: the overflow landed in
+// volk_malloc allocator slack -- invisible to ASan -- but fed the compared llrs, a
+// nondeterministic FAIL at vlens 2-4; vlen 5 passed only by allocator-slack luck.)
+static inline int frame_fits_elements(const unsigned int frame_size,
+                                      const unsigned int frame_exp,
+                                      const int elements)
+{
+    return 3u * frame_size <= (unsigned int)elements &&
+           (frame_exp + 1u) * frame_size <= (unsigned int)elements;
+}
+
 #ifdef LV_HAVE_GENERIC
 static inline void volk_32f_8u_polarbutterflypuppet_32f_generic(float* llrs,
                                                                 const float* input,
@@ -89,6 +110,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_generic(float* llrs,
 
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
+
+    if (!frame_fits_elements(frame_size, frame_exp, elements)) {
+        return;
+    }
 
     sanitize_bytes(u, elements);
     clean_up_intermediate_values(llrs, u, frame_size, elements);
@@ -119,6 +144,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_u_avx(float* llrs,
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
 
+    if (!frame_fits_elements(frame_size, frame_exp, elements)) {
+        return;
+    }
+
     sanitize_bytes(u, elements);
     clean_up_intermediate_values(llrs, u, frame_size, elements);
     generate_error_free_input_vector(llrs + frame_exp * frame_size, u, frame_size);
@@ -147,6 +176,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_u_avx2(float* llrs,
 
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
+
+    if (!frame_fits_elements(frame_size, frame_exp, elements)) {
+        return;
+    }
 
     sanitize_bytes(u, elements);
     clean_up_intermediate_values(llrs, u, frame_size, elements);
@@ -177,6 +210,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_rvv(float* llrs,
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
 
+    if (!frame_fits_elements(frame_size, frame_exp, elements)) {
+        return;
+    }
+
     sanitize_bytes(u, elements);
     clean_up_intermediate_values(llrs, u, frame_size, elements);
     generate_error_free_input_vector(llrs + frame_exp * frame_size, u, frame_size);
@@ -205,6 +242,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_rvvseg(float* llrs,
 
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
+
+    if (!frame_fits_elements(frame_size, frame_exp, elements)) {
+        return;
+    }
 
     sanitize_bytes(u, elements);
     clean_up_intermediate_values(llrs, u, frame_size, elements);


### PR DESCRIPTION
## #116 — polarbutterflypuppet small-vlen OOB

`volk_32f_8u_polarbutterflypuppet_32f` FAILs the fork correctness harness at vlens 2, 3, 4 (`u_avx`/`u_avx2`). Root cause is an out-of-bounds in the **test puppet's** sizing contract, not a kernel defect.

### Root cause
The puppet runs a polar frame whose working set exceeds the harness's `elements`-sized buffers at tiny `elements`:
- `llrs`: `(frame_exp+1)*frame_size` floats (the LLR decode tree)
- `u`: `3*frame_size` bytes of encode scratch (`memset[0,fs)` + frame `[fs,2fs)` + temp `[2fs,3fs)`); the decode butterfly writes a little past `3*fs` at `frame_exp≥4` but stays under `(frame_exp+1)*frame_size`.

The smallest polar frame (`frame_size=2`) already needs `u≥6`, so every `elements<6` overran. Because `volk_malloc` pads allocations to alignment, the overflow landed in **allocator slack** — invisible to AddressSanitizer — but the slack fed back into the compared `llrs`, giving a nondeterministic generic-vs-AVX divergence at vlens 2, 3, 4.

### Fix (puppet `.h` only, +41/−0)
Add `frame_fits_elements()` and no-op in every impl (generic/u_avx/u_avx2/rvv/rvvseg) when the chosen frame's footprint would exceed `elements`. Behavior changes only for `elements` 2–5 (now a clean no-op — all impls agree trivially); `elements≥6` already fit, so `maximum_frame_size` is untouched and no currently-passing vlen changes its result.

### Evidence
- Before → after: FAIL vlens 2 3 4 → `ok` (0/15 runs fail).
- ASan+UBSan clean (0 reports), exact-size buffers, `elements` 1..2²⁰ + boundaries.
- Full impl sweep otherwise unchanged: only `u_avx`/`u_avx2` puppet rows flip FAIL→ok.
- Independently re-verified by an adversarial review gate (guard proven sufficient exhaustively).

Refs #116 (kept open per fork upstream-filing policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
