### PR TITLE
volk_32f_tan_32f: fix sine-sign XOR degenerating to OR for negative x (#110)

### DIFF
--- a/kernels/volk/volk_32f_tan_32f.h
+++ b/kernels/volk/volk_32f_tan_32f.h
@@ -16,6 +16,20 @@
  *
  * b[i] = tan(a[i])
  *
+ * Numerical accuracy (measured on x86 SIMD implementations against libm tanf,
+ * relative error): at most ~5e-7 for |x| <= 1, and within the registered QA
+ * tolerance of 1e-2 out to several periods EXCEPT (a) narrow slivers around the
+ * poles (odd multiples of pi/2; at 1e-2 the sliver is within ~7e-6 of the pole,
+ * where tan is astronomically ill-conditioned anyway) and (b) slivers around the
+ * zeros (multiples of pi) that widen as |x| grows. The SIMD paths use a 2-term
+ * single-precision Cody-Waite reduction, so absolute reduction error grows with
+ * |x|: errors beyond 1e-2 away from poles/zeros appear from |x| ~ 3pi upward and
+ * dominate by |x| ~ 1e6; for |x| beyond ~5e8 the vector paths can return NaN
+ * (quadrant accumulator overflow). The scalar tail path calls libm tanf and is
+ * accurate everywhere. The NEON/RVV implementations are separate code paths and
+ * are not covered by these measurements. For accuracy-critical use away from
+ * [-pi/2, pi/2], prefer the generic implementation.
+ *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32f_tan_32f(float* bVector, const float* aVector, unsigned int num_points)
@@ -136,11 +150,15 @@ volk_32f_tan_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int n
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
             fzeroes,
             _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
+        // Sine-sign fixup: flip iff exactly ONE of {sin(|x|) < 0 (q&4), x < 0}
+        // holds -- a bitwise XOR of the two masks. Comparing the masks with
+        // _CMP_NEQ_UQ degenerated to OR: an all-ones mask is NaN, and NaN
+        // compares UNORDERED (true) against everything, so tan(-x) returned
+        // +tan(x) for every negative x with |x| in [pi,2pi) mod 2pi.
+        condition2 = _mm256_xor_ps(
             _mm256_cmp_ps(
                 _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
+            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS));
         condition3 = _mm256_cmp_ps(
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)),
             fzeroes,
@@ -247,11 +265,15 @@ volk_32f_tan_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_p
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
             fzeroes,
             _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
+        // Sine-sign fixup: flip iff exactly ONE of {sin(|x|) < 0 (q&4), x < 0}
+        // holds -- a bitwise XOR of the two masks. Comparing the masks with
+        // _CMP_NEQ_UQ degenerated to OR: an all-ones mask is NaN, and NaN
+        // compares UNORDERED (true) against everything, so tan(-x) returned
+        // +tan(x) for every negative x with |x| in [pi,2pi) mod 2pi.
+        condition2 = _mm256_xor_ps(
             _mm256_cmp_ps(
                 _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
+            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS));
         condition3 = _mm256_cmp_ps(
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)),
             fzeroes,
@@ -352,9 +374,14 @@ volk_32f_tan_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num
 
         condition1 = _mm_cmpneq_ps(
             _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, ones), twos)), fzeroes);
-        condition2 = _mm_cmpneq_ps(
-            _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(q, fours)), fzeroes),
-            _mm_cmplt_ps(aVal, fzeroes));
+        // Sine-sign fixup: flip iff exactly ONE of {sin(|x|) < 0 (q&4), x < 0}
+        // holds -- a bitwise XOR of the two masks. Comparing the masks with
+        // _mm_cmpneq_ps degenerated to OR: an all-ones mask is NaN, and NaN
+        // compares UNORDERED (true) against everything, so tan(-x) returned
+        // +tan(x) for every negative x with |x| in [pi,2pi) mod 2pi.
+        condition2 =
+            _mm_xor_ps(_mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(q, fours)), fzeroes),
+                       _mm_cmplt_ps(aVal, fzeroes));
         condition3 = _mm_cmpneq_ps(
             _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, twos), fours)), fzeroes);
 
@@ -456,11 +483,15 @@ volk_32f_tan_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int n
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
             fzeroes,
             _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
+        // Sine-sign fixup: flip iff exactly ONE of {sin(|x|) < 0 (q&4), x < 0}
+        // holds -- a bitwise XOR of the two masks. Comparing the masks with
+        // _CMP_NEQ_UQ degenerated to OR: an all-ones mask is NaN, and NaN
+        // compares UNORDERED (true) against everything, so tan(-x) returned
+        // +tan(x) for every negative x with |x| in [pi,2pi) mod 2pi.
+        condition2 = _mm256_xor_ps(
             _mm256_cmp_ps(
                 _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
+            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS));
         condition3 = _mm256_cmp_ps(
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)),
             fzeroes,
@@ -567,11 +598,15 @@ volk_32f_tan_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_p
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
             fzeroes,
             _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
+        // Sine-sign fixup: flip iff exactly ONE of {sin(|x|) < 0 (q&4), x < 0}
+        // holds -- a bitwise XOR of the two masks. Comparing the masks with
+        // _CMP_NEQ_UQ degenerated to OR: an all-ones mask is NaN, and NaN
+        // compares UNORDERED (true) against everything, so tan(-x) returned
+        // +tan(x) for every negative x with |x| in [pi,2pi) mod 2pi.
+        condition2 = _mm256_xor_ps(
             _mm256_cmp_ps(
                 _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
+            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS));
         condition3 = _mm256_cmp_ps(
             _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)),
             fzeroes,
@@ -673,9 +708,14 @@ volk_32f_tan_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num
 
         condition1 = _mm_cmpneq_ps(
             _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, ones), twos)), fzeroes);
-        condition2 = _mm_cmpneq_ps(
-            _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(q, fours)), fzeroes),
-            _mm_cmplt_ps(aVal, fzeroes));
+        // Sine-sign fixup: flip iff exactly ONE of {sin(|x|) < 0 (q&4), x < 0}
+        // holds -- a bitwise XOR of the two masks. Comparing the masks with
+        // _mm_cmpneq_ps degenerated to OR: an all-ones mask is NaN, and NaN
+        // compares UNORDERED (true) against everything, so tan(-x) returned
+        // +tan(x) for every negative x with |x| in [pi,2pi) mod 2pi.
+        condition2 =
+            _mm_xor_ps(_mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(q, fours)), fzeroes),
+                       _mm_cmplt_ps(aVal, fzeroes));
         condition3 = _mm_cmpneq_ps(
             _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, twos), fours)), fzeroes);
 


### PR DESCRIPTION
## #110 — tan SIMD sign bug: XOR degenerated to OR

All six x86 SIMD impls computed the sine-sign fixup as `cmpneq(maskA, maskB)` on all-ones float **masks**. All-ones is NaN; NaN compares UNORDERED (true under `CMPNEQ`/`_CMP_NEQ_UQ`) against everything — so the intended XOR was actually **OR**, and **`tan(−x)` returned `+tan(x)` (200% error) for every negative x with |x| ∈ [π,2π) mod 2π** — half the negative axis beyond π. `tan(−5)` → −3.38051 (true +3.38052); `tan(−6)` → −0.291006 (true +0.291006); −1/−8 correct (quadrant bit 0, where OR≡XOR).

### Fix
Bitwise `_mm_xor_ps`/`_mm256_xor_ps` of the two masks (6 sites). Outputs change ONLY where they were wrong; `[−1,1]` (the qa data domain) is bit-identical. sin/cos use a different sign-bit scheme (verified unaffected). NEON is a different algorithm (no condition2) — never had the bug.

### Evidence (per-impl probe vs generic `tanf`, exact harness metric; adversarially re-verified)
- Pre-fix `[1,9]` both-signs scan: 1,570,976 / 8,000,000 points over the 1e-2 QA tol = 19.64% — exactly the sign-band fraction. Post-fix: **226** (the narrow pole/zero slivers the new doc-comment describes).
- Band boundaries verified: flipped at −3.15/−5/−6/−9.43, correct at −1/−6.29/−8/−12.57.
- `[−1,1]` max rel err 4.76e-7 (unchanged); default qa 155/155; full sweep green.
- Doc-comment gains a measured accuracy/domain statement (poles, zeros, Cody-Waite growth, ~5e8 NaN onset, accurate scalar tail).

**Changelog**: shipped numerical output changes (becomes correct) for x<0 with |x| ∈ [π,2π) mod 2π.

Refs #110 (kept open per fork upstream-filing policy). Derivation: `devDoc/volk/adjudication-pins-109-110-112.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
