### PR TITLE
volk_32fc_index_min_32u: sse3 first-index tie-break (#213)

### DIFF
--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -15,6 +15,9 @@
  * Returns Argmin_i mag(x[i]). Finds and returns the index which contains the
  * minimum magnitude for complex points in the given vector.
  *
+ * Tie-break: when several points share the minimum magnitude, the kernel returns
+ * the FIRST (lowest) such index.
+ *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32fc_index_min_32u(uint32_t* target, const lv_32fc_t* source, uint32_t
@@ -217,13 +220,15 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
 
         xmm1 = _mm_hadd_ps(xmm1, xmm2);
 
+        // First-index tie-break: a lane adopts the NEW index only where the new
+        // magnitude is STRICTLY below the running min (compared before the update);
+        // on an equal magnitude the earlier index is kept.
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+
         xmm3 = _mm_min_ps(xmm1, xmm3);
 
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_andnot_si128(xmm4.int_vec, xmm9);
 
         xmm9 = _mm_add_epi32(xmm11, xmm12);
 
@@ -242,15 +247,16 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
 
         xmm1 = _mm_hadd_ps(xmm2, xmm2);
 
+        // First-index tie-break (see the main loop): strict-less takes the new
+        // index; an equal magnitude keeps the earlier index.
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+
         xmm3 = _mm_min_ps(xmm1, xmm3);
 
         xmm10 = _mm_setr_epi32(2, 2, 2, 2);
 
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_andnot_si128(xmm4.int_vec, xmm9);
 
         xmm9 = _mm_add_epi32(xmm11, xmm12);
 
@@ -281,14 +287,19 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
     _mm_store_ps((float*)&(holderf.f), xmm3);
     _mm_store_si128(&(holderi.int_vec), xmm9);
 
+    // Horizontal reduce with a first-index tie-break: a lane replaces the running
+    // winner only on a strictly smaller magnitude, or on an equal magnitude with a
+    // smaller index (the per-lane accumulators can hold non-monotonic indices).
     target[0] = holderi.i[0];
     sq_dist = holderf.f[0];
-    target[0] = (holderf.f[1] < sq_dist) ? holderi.i[1] : target[0];
-    sq_dist = (holderf.f[1] < sq_dist) ? holderf.f[1] : sq_dist;
-    target[0] = (holderf.f[2] < sq_dist) ? holderi.i[2] : target[0];
-    sq_dist = (holderf.f[2] < sq_dist) ? holderf.f[2] : sq_dist;
-    target[0] = (holderf.f[3] < sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] < sq_dist) ? holderf.f[3] : sq_dist;
+    for (int lane = 1; lane < 4; ++lane) {
+        if (holderf.f[lane] < sq_dist) {
+            sq_dist = holderf.f[lane];
+            target[0] = holderi.i[lane];
+        } else if (holderf.f[lane] == sq_dist && holderi.i[lane] < target[0]) {
+            target[0] = holderi.i[lane];
+        }
+    }
 }
 
 #endif /*LV_HAVE_SSE3*/


### PR DESCRIPTION
## #213 — index_min_32u a_sse3 first-index tie-break

The min-mirror of #128 (index_max_32u, PR #197): after `min_ps`, the `cmpeq` mask is true for ties with the running minimum, so tying elements overwrote the winning lane indices; the ternary reduce had no cross-lane tie-break. On the kernel's OWN registered all-ties edge set (eight |z|=1 points), generic returns 0 but a_sse3 returned 4 (vlens 6–9) / 8 (vlen 10) — masked at larger vlens by random data, which is why testqa never caught it. Surfaced by the per-kernel-edge sweep mechanism (#109/#112 stack).

### Fix (exact mirror of `01525f76`)
`cmplt` BEFORE the min update (strict-less takes the new index; ties keep the earlier; and/andnot on one mask) in the main loop + 2-wide block; min-index tie-break reduce loop. Odd-tail already first-index-correct (verified) — unchanged. Doc-comment states the contract.

### Evidence
Brute force (all-ties vlens 1..40 + 3000 seeds small-int complex, 120,040 checks): **42,661 mismatches → 0**; returned index always achieves the true minimum both ways (pure tie-selection bug). Sweep row green under registered tie edges; full sweep green; qa 155/155. Adversarially re-verified.

Refs #213 (kept open per fork policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
