### PR TITLE
volk_32f_atan_32f: document the measured accuracy band for |x| > 1 (#109)

### DIFF
--- a/kernels/volk/volk_32f_atan_32f.h
+++ b/kernels/volk/volk_32f_atan_32f.h
@@ -15,6 +15,20 @@
  *
  * Computes arctan of input vector and stores results in output vector.
  *
+ * Numerical accuracy (measured on x86 SIMD implementations against libm atanf,
+ * relative error): at most ~8e-7 for |x| <= 1 (every implementation, including
+ * the scalar `polynomial` path and all tails). For |x| > 1 the SIMD lanes
+ * compute atan(x) = +-pi/2 - atan(1/x) with a hardware reciprocal
+ * APPROXIMATION (12-bit rcpps; a 14-bit variant on avx512dq), so accuracy
+ * degrades in a band just above |x| = 1: worst-case ~1.9e-4 (sse4_1/avx2/
+ * avx2_fma) or ~2.7e-5 (avx512dq) near |x| ~ 1.007, decaying with |x| and
+ * re-entering 1e-6 beyond |x| ~ 167 (avx512dq: ~32). Large arguments saturate
+ * exactly: atan(+-1e10), atan(+-inf) return +-pi/2; NaN propagates. The scalar
+ * tail path divides exactly and stays at the ~8e-7 level everywhere, as does
+ * the `polynomial` implementation. The NEON/RVV implementations are separate
+ * code paths and are not covered by these measurements. For accuracy-critical
+ * use with |x| > 1, prefer the generic or polynomial implementation.
+ *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32f_atan_32f(float* out, const float* in, unsigned int num_points)


### PR DESCRIPTION
## #109 — atan adjudication: documented accuracy band

**Decision: documented accuracy contract; no kernel or tolerance change.** Measured per-impl against libm `atanf` (relative error, the qa metric): every impl meets ~8e-7 for |x| ≤ 1. For |x| > 1 the SIMD lanes range-reduce via `atan(x) = ±π/2 − atan(1/x)` using the hardware reciprocal **approximation** (12-bit `rcpps`; 14-bit on avx512dq) → an error band just above the hand-off: worst **1.9e-4** (sse4_1/avx2/avx2_fma) / **2.7e-5** (avx512dq) near |x| ≈ 1.007, decaying under 1e-6 beyond |x| ≈ 167 (avx512dq ≈ 32). The band's true peak is at the first floats above 1.0 — NOT at the harness edges (4.97–8, ≤3.41e-5) that surfaced the finding. Saturation is exact (±1e10/±inf → ±π/2), scalar tail + `polynomial` divide exactly (~8e-7 everywhere).

- Registered qa edges (NaN/±inf/0/−0/±1e10/±1) already sample exactly the accurate domain → with the per-kernel-edge sweep mechanism (companion PR) the sweep is deterministically green.
- Loosening the 1e-6 tol instead would blunt in-domain regression detection ~50×. Upstream note: one NR refinement of the reciprocal would collapse the band to ~2e-7 (~1 fma/element); not applied on the fork (changes shipped output).

Doc-comment only (+14 lines). Refs #109 (kept open per fork policy). Derivation: `devDoc/volk/adjudication-pins-109-110-112.md`; adversarially re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
