### PR TITLE
volk_32f_invsqrt_32f: document the formulation-dependent special-value contract (#112)

### DIFF
--- a/kernels/volk/volk_32f_invsqrt_32f.h
+++ b/kernels/volk/volk_32f_invsqrt_32f.h
@@ -16,6 +16,29 @@
  * Computes the inverse square root of the input vector and stores
  * result in the output vector.
  *
+ * Domain contract (measured on x86): for POSITIVE NORMAL inputs
+ * (FLT_MIN <= x <= FLT_MAX) every implementation agrees with 1/sqrt(x) to
+ * within ~2.4e-7 relative error, and x = +0.0 returns +inf everywhere.
+ * Outside that domain the implementations use three different formulations --
+ * generic computes sqrtf(1.0f/x), the recip_sqrt implementation and every SIMD
+ * tail compute 1.0f/sqrtf(x), and the SIMD vector lanes use a hardware
+ * reciprocal-square-root with one Newton-Raphson step -- and their IEEE
+ * special-value results legitimately DIFFER:
+ * \li x = -0.0: NaN (generic: sqrtf(-inf)) vs -inf (1/sqrtf paths) vs NaN
+ *     (vector lanes; the NR step produces NaN, which matches generic).
+ * \li x = -inf: -0.0 (generic: sqrtf(1/-inf) = sqrtf(-0.0)) vs NaN (all others).
+ * \li negative finite x: NaN everywhere (agreement).
+ * \li x = +inf: +0.0 everywhere (agreement). NaN propagates everywhere.
+ * \li denormals and x < FLT_MIN: generic overflows to +inf below 1/FLT_MAX
+ *     (its 1/x overflows); sse/avx/avx2 vector lanes return -inf below
+ *     ~FLT_MIN (rsqrtps flushes the input, the NR step drives the sign);
+ *     the scalar 1/sqrtf paths and avx512f stay finite and accurate.
+ * The registered QA edge cases deliberately sample the agreement domain
+ * (positive normals plus the agreed specials -1, 0, +inf); results for -0.0,
+ * -inf, and sub-FLT_MIN inputs are formulation-dependent and NOT part of the
+ * kernel's cross-implementation contract. The NEON/RVV implementations are
+ * separate code paths and are not covered by these measurements.
+ *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32f_invsqrt_32f(float* cVector, const float* aVector, unsigned int


### PR DESCRIPTION
## #112 — invsqrt adjudication: formulation-dependent special-value contract

**Decision: documented domain contract; no kernel change.** Three formulations coexist — generic `sqrtf(1.0f/x)`, recip_sqrt + every SIMD tail `1.0f/sqrtf(x)`, SIMD vectors `rsqrt`+NR — and the failures are exactly the shared `−0.0` edge hitting the `1/sqrtf` paths: generic → NaN, scalar/tails → **−inf**, vector NR → NaN (agrees with generic). That explains the precise shape: recip_sqrt (all-scalar) failed every vlen; SIMD impls failed only BELOW their vector width.

Pinned boundaries (dense log scan 1e-44..3e38, per impl, vector and tail separately):
- **Agreement domain: positive normals [FLT_MIN, FLT_MAX]** — all impls ≤ ~2.4e-7 rel; `+0 → +inf` everywhere; negatives → NaN; `+inf → +0`; NaN propagates.
- Below FLT_MIN the formulations split 3 ways: generic overflows +inf below 1/FLT_MAX ≈ 2.94e-39; sse/avx/avx2 vector lanes → −inf below ≈FLT_MIN (rsqrtps flushes denormals, NR drives the sign); scalar paths + avx512f stay finite. `x=−inf`: generic → −0.0, all others NaN.
- Registered qa edges {−1, 1, 0, inf, 1e-2, 1e2, 1e-10, 1e10} already sample exactly the agreement domain (deliberately no −0.0) → with the per-kernel-edge mechanism (companion PR) the sweep is deterministically green, including recip_sqrt.

Doc-comment only (+23 lines). Refs #112 (kept open per fork policy). Derivation: `devDoc/volk/adjudication-pins-109-110-112.md`; adversarially re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
