### PR TITLE
harness: impl-mode sweep judges kernels on their registered edge cases (Refs #109 #112)

### DIFF
--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -1288,6 +1288,21 @@ int main(int argc, char* argv[])
         const lv_32fc_t kscalar = kp.scalar();
         const float ktol = ref ? tol : kp.tol();
         const bool kabs = ref ? false : kp.absolute_mode();
+        // Edge cases complete the per-kernel contract (#109/#112, the edge analog
+        // of #106's tol): an impl-mode kernel that registers edge cases in
+        // kernel_tests.h is judged on THOSE (they encode its documented input
+        // domain — e.g. invsqrt deliberately samples x>0 and excludes -0.0, whose
+        // out-of-domain result is formulation-dependent); kernels without a
+        // registered set keep the shared adversarial edges. Ref-mode kernels
+        // always keep the shared edges: their oracle bounds were derived with
+        // them (README reduction-tolerance methodology), so swapping the data
+        // distribution would invalidate the derived tolerances.
+        const std::vector<float>& kfedges = (!ref && !kp.float_edge_cases().empty())
+                                                ? kp.float_edge_cases()
+                                                : kFloatEdges;
+        const std::vector<lv_32fc_t>& kcedges = (!ref && !kp.complex_edge_cases().empty())
+                                                    ? kp.complex_edge_cases()
+                                                    : kComplexEdges;
         std::vector<unsigned int> bad;
         std::set<std::string> impls_seen;
         std::map<std::string, std::vector<unsigned int>> impl_fails;
@@ -1304,8 +1319,8 @@ int main(int argc, char* argv[])
                           kabs,
                           iter,
                           v,
-                          kFloatEdges,
-                          kComplexEdges,
+                          kfedges,
+                          kcedges,
                           report ? &impls_seen : nullptr,
                           report ? &impl_fails : nullptr,
                           &ref_applied,


### PR DESCRIPTION
## Harness: impl-mode sweep judges kernels on their registered edge cases (Refs #109 #112)

Completes the per-kernel contract that #106 started: the sweep already used each kernel's registered **tolerance**; it now also uses each kernel's registered **edge cases** (float + complex independently) when a registration exists — the kernel's documented input domain — else the shared adversarial `kFloatEdges`/`kComplexEdges`. Ref-mode kernels always keep the shared edges (their oracle bounds were derived with them, per the README reduction-tolerance methodology). The shared lists are untouched, so the #92 planted-kernel negative controls are unaffected (they pass their own edge lists explicitly; `HARNESS_COMBINED_NC` verified OK).

### Measured consequences (HARNESS_SEED=42, before → after)
- `volk_32f_atan_32f`: FAIL (8 impls) → **ok** on its registered set (see #109 PR).
- `volk_32f_invsqrt_32f`: FAIL (recip_sqrt every vlen + SIMD small vlens) → **ok** on its registered positive-domain set (see #112 PR).
- `volk_32fc_index_min_16u/_32u a_sse3`: ok → **FAIL** at vlens 6–9 under the kernels' OWN registered all-ties edges — **two real latent first-index tie-break bugs surfaced by the mechanism** (the min-mirrors of #127/#128), filed as #212/#213 and fixed in companion PRs so the default sweep stays green.
- 38 result-level (pass/fail) changes total, all accounted for. Note: other rows' `max_err` values shift under a fixed seed — the seeded RNG is one shared stream, so changing a kernel's edge COUNT advances the stream for downstream fills (202 raw diff lines; every one still ok).

### Integration (with the 5 companion PRs)
Full sweep exit 0, **0/128 kernels failed** (seed 42); default qa **155/155**; result-level diff vs base = exactly the intended rows. Adversarially re-verified end-to-end (independent probe recompiles, brute-force re-runs, CSV re-diffs).

Merge order: after #214/#215/#216 (and the #109/#112 doc PRs), so dev/all-prs stays green at every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
