### PR TITLE
neon asm tail counter init

### DIFF
--- a/kernels/volk/asm/neon/volk_32f_x2_add_32f_a_neonasm.s
+++ b/kernels/volk/asm/neon/volk_32f_x2_add_32f_a_neonasm.s
@@ -20,6 +20,7 @@ volk_32f_x2_add_32f_a_neonasm:
 	stmfd	sp!, {r7, r8, sl}	@ prologue - save register states
 
 	movs quarterPoints, num_points, lsr #2
+	moveq	number, #0	@ no main-loop iterations here: tail counter starts at 0
 	beq .loop2 @ if zero into quarterPoints
 
 	mov	number, #0	@ number, 0

--- a/kernels/volk/asm/neon/volk_32f_x2_add_32f_a_neonpipeline.s
+++ b/kernels/volk/asm/neon/volk_32f_x2_add_32f_a_neonpipeline.s
@@ -21,6 +21,7 @@ volk_32f_x2_add_32f_a_neonpipeline:
 	pld [bVector, #128] @ pre-load hint - this is implementation specific!
 
 	movs quarterPoints, num_points, lsr #2
+	moveq	number, #0	@ no main-loop iterations here: tail counter starts at 0
 	beq .loop2 @ if zero into quarterPoints
 
 	mov number, quarterPoints

--- a/kernels/volk/asm/neon/volk_32f_x2_dot_prod_32f_a_neonasm.s
+++ b/kernels/volk/asm/neon/volk_32f_x2_dot_prod_32f_a_neonasm.s
@@ -21,6 +21,7 @@ volk_32f_x2_dot_prod_32f_a_neonasm:
 
     veor.32 q0, q0, q0
 	movs quarterPoints, num_points, lsr #2
+	moveq	number, #0	@ no main-loop iterations here: tail counter starts at 0
 	beq .loop2 @ if zero into quarterPoints
 
 	mov	number, #0	@ number, 0

--- a/kernels/volk/asm/neon/volk_32fc_32f_dot_prod_32fc_a_neonasm.s
+++ b/kernels/volk/asm/neon/volk_32fc_32f_dot_prod_32fc_a_neonasm.s
@@ -32,6 +32,7 @@
     veor realAccQ, realAccQ @ zero out accumulators
     veor compAccQ, compAccQ @ zero out accumulators
     movs quarterPoints, num_points, lsr #2
+    moveq number, #0 @ no main-loop iterations here: tail counter starts at 0
     beq .loop2 @ if zero into quarterPoints
     
     mov number, quarterPoints

--- a/kernels/volk/asm/neon/volk_32fc_32f_dot_prod_32fc_a_neonasmvmla.s
+++ b/kernels/volk/asm/neon/volk_32fc_32f_dot_prod_32fc_a_neonasmvmla.s
@@ -32,6 +32,7 @@ volk_32fc_32f_dot_prod_32fc_a_neonasmvmla:
 	veor realAccQ, realAccQ @ zero out accumulators
 	veor compAccQ, compAccQ @ zero out accumulators
 	movs quarterPoints, num_points, lsr #2
+	moveq	number, #0	@ no main-loop iterations here: tail counter starts at 0
 	beq .loop2 @ if zero into quarterPoints
 
 	mov number, quarterPoints

--- a/kernels/volk/asm/neon/volk_32fc_32f_dot_prod_32fc_a_neonpipeline.s
+++ b/kernels/volk/asm/neon/volk_32fc_32f_dot_prod_32fc_a_neonpipeline.s
@@ -35,7 +35,7 @@ volk_32fc_32f_dot_prod_32fc_a_neonpipeline:
 	veor realAccQ, realAccQ @ zero out accumulators
 	veor compAccQ, compAccQ @ zero out accumulators
 	movs quarterPoints, num_points, lsr #2
-	beq .loop2 @ if zero into quarterPoints
+	beq .tail @ if zero into quarterPoints: skip main loop, enter the guarded tail
 
 	@mov number, quarterPoints
 	mov number, #0
@@ -73,6 +73,7 @@ volk_32fc_32f_dot_prod_32fc_a_neonpipeline:
     vadd.f32 compAccS, s4, s5 @ sum the contents of d2 together (compAccQ)
 
     @ critical values are now in s0 (realAccS), s4 (realAccQ)
+.tail:
 	mov	number, quarterPoints, asl #2
 	cmp num_points, number
 	beq	.done


### PR DESCRIPTION
## Summary

The hand-written ARMv7 NEON kernels under `kernels/volk/asm/neon/` alias their scalar-tail
counter to `r8`, which is callee-saved, and place every write to it *after* the `beq .loop2`
taken when `num_points < 4`. On that path the tail compares `num_points` against whatever the
caller left in `r8`, so it runs a caller-dependent number of times — typically zero.
`volk_32f_x2_add_32f` leaves its output buffer **unwritten**; the dot products return a **short
sum**, for `num_points` 1..3. Six registered, selectable `LV_HAVE_NEONV7` impls across three
kernels are affected. The fix initializes the counter with `moveq number, #0` immediately after
the `movs` that computes `quarterPoints`: it executes only on the small-vector path (the `eq`
condition reads the `movs` flags), needs no separate branch, and leaves the flags intact for the
following `beq`. The main path initializes the counter itself before `.loop1`.

`volk_32fc_32f_dot_prod_32fc_a_neonpipeline` needs a different shape: its guard sits above the
`.loop2` label and the small-vector `beq` jumped *past* it into a do-while body, so this PR
retargets that `beq` to the guard instead of adding a counter init.

**Two clarifications relative to the issue as filed:**

1. **The issue's `## Fix` prescription would hang.** It says to initialize "at the `.loop2`
   entry", but `.loop2` is the target of the tail's own backward branch (`b .loop2`) —
   initializing there resets the counter every iteration, an infinite loop with an unbounded OOB
   write. This PR initializes before the branch instead. (Recorded here because the fix landed;
   per convention the issue body should describe the problem, not prescribe a solution.)
2. **The affected set is six impls, not five.** `volk_32fc_32f_dot_prod_32fc_a_neonpipeline`
   (`volk_32fc_32f_dot_prod_32fc.h:854`) is registered and carries the same defect; the issue
   does not name it.

**Scope:** this PR fixes only the uninitialized-`r8` tail-counter defect — exactly what #149
describes. During the fix, `volk_32fc_32f_dot_prod_32fc_a_neonpipeline` was found to carry a
*second, independent* defect (an unguarded main loop that over-reads one quad at `num_points`
4..7). That is a different root cause with a different failure range and is fixed in a **separate
PR** against its own issue, not bundled here.

**Severity: live in the default dispatch path of any unprofiled neonv7 build.** `volk_profile` is
an optional post-install step. With no `volk_config`, `volk_rank_archs`
(`lib/volk_rank_archs.c:100-120`) falls back to the largest-deps impl **among *aligned* impls**,
and `generic` is not aligned (no `<alignment>` in `gen/archs.xml`; `is_aligned = name.startswith('a_')`).
For `volk_32f_x2_add_32f` on armhf the only aligned candidates are `a_neonasm` and
`a_neonpipeline` — both defective — so an aligned call on a neonv7 box whose user never ran
`volk_profile` dispatches straight into the broken code. That is the common configuration. (A
*profiled* Pi 4 happens to route around it: across 10 runs `volk_profile` chose `generic` or the
intrinsic `neon` for all three kernels, because this hand-written assembly measures slower than
generic C — 31.0 ms generic vs 40.3 ms `a_neonasm` for the add. That narrows exposure for
profiled hosts only.)

## Related issues

Related: #149

<!-- Deliberately NOT "Closes #149": per the fork convention, fork issues stay OPEN on
     completion to feed the upstream-filing queue. Evidence is posted as a comment instead. -->

## Testing

Static analysis is **structurally blind to this diff**, so its clean result is vacuous rather than
a pass: no tool in the family parses A32 assembly, and an x86 build never assembles these files at
all — `lib/CMakeLists.txt:484-490` globs them only when `ASM_ARCH STREQUAL "neonv7"`. That gap is
why the verification below is a purpose-built harness rather than the standard suite.

- **Born-red harness.** Calls each of the six impls through an AAPCS trampoline that sets `r8` to
  a chosen sentinel on entry, over the same 300 cases in both trees (5 sentinels
  `{0, 1, 0x7f7f7f7f, 0x80000000, 0xffffffff}` × `num_points` 0..9), asserting per-element values
  plus a check that nothing past `num_points` was over-written. Each case runs in a forked child,
  because the unfixed tree segfaults.
  - **Unfixed:** 95 failing cases, **4 SIGSEGV**.
  - **This PR:** **0 SIGSEGV; files 1–5 fully clean; `neonpipeline` correct for `num_points` < 4.**
    The 20 failures that remain are all `neonpipeline` at `num_points` 4..7 — the *separate*
    one-quad defect handled in the follow-up PR, not the `r8` defect this PR fixes.
  - Per the commit messages: the five tail-counter kernels fail 60 cases across `num_points` 1..3
    before this change and 0 after.
- **Controlling `r8` buys determinism, not visibility.** The `r8` defect's symptom depends
  entirely on the caller's leftover `r8`: at sentinel 0 the five tail-counter impls pass, and any
  *nonzero* sentinel fails them for `num_points` 1..3. VOLK's own harness can see this — it is how
  #149 was found — but only by luck of the ambient `r8`. The trampoline makes it reproducible.
- **Real silicon (Pi 4, armhf, native gcc 14.2.0):** identical to qemu in both directions. The
  four segfaults are real hardware faults — `neonpipeline` at `r8=0x80000000`, `num_points` 0..3:
  the tail's `blt` is **signed**, so a sign-bit `r8` drives ~2³¹ iterations off the ends of
  `taps`/`input`.
- **No measurable performance change** (`volk_profile --benchmark -i 5000 -v 8192`, 5 alternating
  reps per tree, governor pinned, `get_throttled=0x0`, 43–45 °C). The six modified impls moved by
  at most **0.35%**; the eight *untouched* impls — byte-identical machine code in both trees, i.e.
  the control — moved by up to **2.79%**, and run-to-run spread reaches 7.5%. Every changed impl
  sits an order of magnitude below its own noise floor, consistent with the added `moveq` being
  a single conditional instruction outside the hot loop.

**Not run: `ctest`.** It is available on the armhf silicon, but for the `r8` defect it is a
*weaker* check than the harness above — VOLK's test path calls the kernels without controlling
`r8`, so it observes the defect only when the ambient `r8` happens to be nonzero, exactly the
nondeterminism the harness removes. Recorded as a gap, not claimed as a pass; happy to add an
armhf `ctest` run if wanted.

Full data: `analysis/2026-07-17-pi4-armhf-prA-moveq.txt`, `-born-red-prA.txt`, `-pi4-armhf-summary.md`, `-pi4-benchmark.md`,
`-analyze-coverage-note.md`.

## Evidence

suite: none @ 9795dd14d9ce89312fa6afdc42d29cb1e956968c
files: 6 changed
born-red: FAIL at baseline (95 failing cases incl. 4 SIGSEGV) → r8 defect eliminated on branch (0 SIGSEGV; 20 residual failures are the separate one-quad defect, tracked in the follow-up PR)

## Checklist
- [x] Builds cleanly (`cmake --build`) — both trees on Pi 4 armhf, `-Wall -Werror`, `Detected neon architecture; enabling ASM`, 13 asm files added
- [ ] Tests pass (`ctest`) — not run; see Testing. The harness is the substantive check; an armhf `ctest` run is a weaker additional check, available on request.
- [x] Commits are signed off (`git commit -s`) — 2/2, subjects ≤70 chars, bodies ≤72
- [x] PR does one thing — the uninitialized-`r8` tail-counter defect only; the independent one-quad defect is a separate PR
