### PR TITLE
dispatch check fail-open and glob scoping

### DIFF
--- a/cmake/check_dispatch_tables.py
+++ b/cmake/check_dispatch_tables.py
@@ -31,8 +31,9 @@ named by --machines (the active configure) against today's kernel defs.
 Stale machine .c files from a prior configure are deliberately ignored
 (named in a stderr note); under an empty --machines nothing is checked
 even when machine files sit on disk (warned, UNCHECKED-named); and the
-correctness of the --machines list itself is cmake's contract
-(available_machines), not this script's.
+correctness of the --machines list itself is cmake's contract (the
+codegen loop's _generated_machines accumulator, derived from
+available_machines), not this script's.
 
 See mtibbits/volk#58 for context; #132 (fail-closed parse guards) and
 #166 (active-machine scoping) for the hardening.
@@ -118,9 +119,12 @@ def check_machine(path: Path, all_kernels, expected_kernels):
         extra = sorted(got_kernels - expected_kernels)
         print(f"error: {path.name}: parsed kernel blocks ({len(got_kernels)}) "
               f"!= gen/volk_kernel_defs kernels ({len(expected_kernels)}); "
-              f"missing={missing[:5]} extra={extra[:5]} -- the impl-array "
-              f"regex no longer matches the generated format; update this "
-              f"parser.", file=sys.stderr)
+              f"missing={missing[:5]} extra={extra[:5]} -- either build/lib "
+              f"is stale (re-run cmake: kernels/volk/*.h is a "
+              f"non-CONFIGURE_DEPENDS glob, so adding/removing a kernel "
+              f"header does not retrigger codegen) or the impl-array regex "
+              f"no longer matches the generated format; update this parser.",
+              file=sys.stderr)
         sys.exit(2)
 
     violations = []
@@ -143,18 +147,28 @@ def check_machine(path: Path, all_kernels, expected_kernels):
 def main():
     ap = argparse.ArgumentParser(
         description="Per-machine impl dispatch-table integrity check",
-        epilog="See mtibbits/volk#58 for context.",
+        epilog="See mtibbits/volk#58 for context; #132/#166 for the "
+               "fail-closed parse guards and active-machine scoping.",
     )
     ap.add_argument("--source-dir", required=True, type=Path,
                     help="Volk source root (the dir with gen/, kernels/, ...)")
     ap.add_argument("--build-lib-dir", required=True, type=Path,
                     help="Build output dir containing volk_machine_*.c files")
     ap.add_argument("--machines", required=True,
-                    help="Semicolon-separated machine names of the active "
-                         "configure (cmake's available_machines). Empty "
-                         "string = nothing to check (static-dispatch or "
-                         "no-machine lane).")
+                    help="Semicolon-separated machine names whose .c the "
+                         "active configure generated (cmake's "
+                         "_generated_machines, accumulated by the codegen "
+                         "loop). Empty string = nothing to check "
+                         "(static-dispatch or no-machine lane).")
     args = ap.parse_args()
+
+    # Cheap wiring sanity (a single stat) kept ahead of the no-op lane so a
+    # typo'd --source-dir is caught even where nothing gets checked; the
+    # expensive kernel-defs import stays below the early exit.
+    gen_dir = args.source_dir / "gen"
+    if not gen_dir.is_dir():
+        print(f"error: gen dir not found at {gen_dir}", file=sys.stderr)
+        sys.exit(2)
 
     # Scope the check to the ACTIVE configure's machine set (mtibbits/volk#166):
     # cmake passes the codegen loop's machine list instead of this script
@@ -190,11 +204,6 @@ def main():
         print(f"note: ignoring {len(orphans)} volk_machine_*.c not in the "
               f"active configure (stale from a prior configure?): "
               f"{', '.join(orphans)}", file=sys.stderr)
-
-    gen_dir = args.source_dir / "gen"
-    if not gen_dir.is_dir():
-        print(f"error: gen dir not found at {gen_dir}", file=sys.stderr)
-        sys.exit(2)
 
     sys.path.insert(0, str(gen_dir))
     try:

--- a/cmake/check_dispatch_tables.py
+++ b/cmake/check_dispatch_tables.py
@@ -76,9 +76,10 @@ def parse_machine_c(path: Path):
     for kernel_name, names_block in block_re.findall(text):
         # Fail-closed, not a bare assert (mtibbits/volk#132): a duplicate
         # block leaves the kernel-name SET unchanged, so the set-equality
-        # guard in check_machine cannot see it, and a bare assert is
-        # stripped under `python -O` -- this print+exit is the only
-        # duplicate cover.
+        # guard in check_machine cannot see it -- this print+exit is the
+        # only duplicate cover. (A bare assert would also vanish under an
+        # ambient PYTHONOPTIMIZE; cmake invokes with -B, never -O, so that
+        # was latent rather than live.)
         if kernel_name in dispatch:
             print(f"error: {path.name}: kernel {kernel_name!r} has multiple "
                   f"impl-name arrays; generator structure changed -- update "

--- a/cmake/check_dispatch_tables.py
+++ b/cmake/check_dispatch_tables.py
@@ -18,13 +18,24 @@ Invoked by lib/CMakeLists.txt as a custom target made an explicit
 dependency of volk_obj.
 
 Exit codes:
-    0  all dispatch tables consistent with their machine's gates,
-       or no machine .c files to check (cross-compile lane)
+    0  all active-configure dispatch tables consistent with their
+       machine's gates, or nothing to check (empty --machines: static
+       dispatch / no-machine lane)
     1  one or more impls are missing from a machine's dispatch
        (prints each violation with machine name, kernel, impl, gates)
-    2  internal error (parse failure, missing inputs)
+    2  internal error (parse failure/drift, missing inputs, inconsistent
+       build dir)
 
-See mtibbits/volk#58 for context.
+Blind spots (what this check cannot decide): it audits only the machines
+named by --machines (the active configure) against today's kernel defs.
+Stale machine .c files from a prior configure are deliberately ignored
+(named in a stderr note); under an empty --machines nothing is checked
+even when machine files sit on disk (warned, UNCHECKED-named); and the
+correctness of the --machines list itself is cmake's contract
+(available_machines), not this script's.
+
+See mtibbits/volk#58 for context; #132 (fail-closed parse guards) and
+#166 (active-machine scoping) for the hardening.
 """
 
 import argparse
@@ -50,11 +61,8 @@ def parse_machine_c(path: Path):
     # which has no double-quotes, so a string-only brace group can only
     # be the impl-name array.
     #
-    # `dispatch[kernel_name] = names` assigns into a dict: if a kernel
-    # ever had multiple matching blocks (it doesn't today), only the
-    # last would survive. One block per kernel is invariant per the
-    # generator's structure -- but if that ever changes, the assertion
-    # below catches the regression.
+    # One block per kernel is invariant per the generator's structure;
+    # the duplicate guard below fails closed if that ever changes.
     #
     # The inner string-group quantifier is * (not +) so a hypothetical
     # zero-impl kernel still enters the dispatch dict with an empty set,
@@ -65,27 +73,61 @@ def parse_machine_c(path: Path):
     )
     dispatch = {}
     for kernel_name, names_block in block_re.findall(text):
-        assert kernel_name not in dispatch, (
-            f"{path.name}: kernel {kernel_name!r} has multiple impl-name "
-            f"arrays; generator structure changed -- update this parser."
-        )
+        # Fail-closed, not a bare assert (mtibbits/volk#132): a duplicate
+        # block leaves the kernel-name SET unchanged, so the set-equality
+        # guard in check_machine cannot see it, and a bare assert is
+        # stripped under `python -O` -- this print+exit is the only
+        # duplicate cover.
+        if kernel_name in dispatch:
+            print(f"error: {path.name}: kernel {kernel_name!r} has multiple "
+                  f"impl-name arrays; generator structure changed -- update "
+                  f"this parser.", file=sys.stderr)
+            sys.exit(2)
         names = set(re.findall(r'"([^"]+)"', names_block))
         dispatch[kernel_name] = names
     return defined, dispatch
 
 
-def check_machine(path: Path, all_kernels):
-    """Return a list of (machine, kernel, impl, gates) violations for this file."""
+def check_machine(path: Path, all_kernels, expected_kernels):
+    """Check one machine file; exits 2 on parse drift, else returns a list
+    of (machine, kernel, impl, gates) violations.
+
+    expected_kernels is the build-wide {kernel.name} set, computed once in
+    main() -- the set-equality guard compares every machine file against
+    the same constant.
+    """
     defined, dispatch = parse_machine_c(path)
-    violations = []
     machine_name = path.stem.replace("volk_machine_", "")
 
+    # Parse-drift guards (mtibbits/volk#132): both regexes fail OPEN -- a
+    # template-format change that matches nothing makes every kernel skip
+    # and the script print ok while checking nothing. Fail closed instead.
+    # Every machine defines LV_HAVE_GENERIC (tmpl/volk_machine_xxx.tmpl.c
+    # emits one '#define LV_HAVE_<ARCH> 1' per arch and every machine
+    # includes 'generic'), and the generator emits one kernel block per
+    # gen/volk_kernel_defs kernel (verified empirically on all 9 machine
+    # files of a dev/all-prs configure, Issue-Fork-132 U2 probe).
+    if "LV_HAVE_GENERIC" not in defined:
+        print(f"error: {path.name}: no '#define LV_HAVE_GENERIC 1' parsed -- "
+              f"the #define regex no longer matches the generated format; "
+              f"update this parser.", file=sys.stderr)
+        sys.exit(2)
+    got_kernels = set(dispatch)
+    if got_kernels != expected_kernels:
+        missing = sorted(expected_kernels - got_kernels)
+        extra = sorted(got_kernels - expected_kernels)
+        print(f"error: {path.name}: parsed kernel blocks ({len(got_kernels)}) "
+              f"!= gen/volk_kernel_defs kernels ({len(expected_kernels)}); "
+              f"missing={missing[:5]} extra={extra[:5]} -- the impl-array "
+              f"regex no longer matches the generated format; update this "
+              f"parser.", file=sys.stderr)
+        sys.exit(2)
+
+    violations = []
     for kernel in all_kernels:
-        actual_impls = dispatch.get(kernel.name)
-        if actual_impls is None:
-            # Kernel not in this machine .c at all -- should never happen
-            # (every machine includes every kernel header per the template).
-            continue
+        # Direct indexing is safe: the set-equality guard above exits
+        # unless every kernel-defs kernel has exactly one parsed block.
+        actual_impls = dispatch[kernel.name]
         # Reads kernel._impls (the unfiltered list) rather than calling
         # the public kernel.get_impls(archs) because the latter applies
         # the same intersection-with-archs filter we are auditing here;
@@ -107,7 +149,47 @@ def main():
                     help="Volk source root (the dir with gen/, kernels/, ...)")
     ap.add_argument("--build-lib-dir", required=True, type=Path,
                     help="Build output dir containing volk_machine_*.c files")
+    ap.add_argument("--machines", required=True,
+                    help="Semicolon-separated machine names of the active "
+                         "configure (cmake's available_machines). Empty "
+                         "string = nothing to check (static-dispatch or "
+                         "no-machine lane).")
     args = ap.parse_args()
+
+    # Scope the check to the ACTIVE configure's machine set (mtibbits/volk#166):
+    # cmake passes the codegen loop's machine list instead of this script
+    # globbing the build dir, so machine .c files orphaned by a PRIOR configure
+    # are ignored (named on stderr) rather than checked against today's
+    # kernel/arch definitions. The empty-list no-op comes FIRST -- before the
+    # (measured ~150 ms) volk_kernel_defs import it would never use.
+    active = [m for m in args.machines.split(";") if m]
+    on_disk = {p.name for p in args.build_lib_dir.glob("volk_machine_*.c")}
+    if not active:
+        extra = (f"; UNCHECKED on disk: {', '.join(sorted(on_disk))}"
+                 if on_disk else "")
+        print(f"warning: no machines in the active configure (static "
+              f"dispatch or no-machine lane); nothing to check{extra}",
+              file=sys.stderr)
+        sys.exit(0)
+    expected_names = {m: f"volk_machine_{m}.c" for m in active}
+    missing = sorted(m for m, n in expected_names.items() if n not in on_disk)
+    if missing:
+        # None-exist and partial-missing are the SAME failure: cmake supplied
+        # a non-empty active list, so every listed file must exist -- zero
+        # present means a wiped or wrong build/lib, not a lane to wave
+        # through.
+        print(f"error: {len(missing)} of {len(active)} active machine "
+              f"files missing from {args.build_lib_dir}: "
+              f"{', '.join(missing)} (codegen incomplete or wrong "
+              f"--build-lib-dir)", file=sys.stderr)
+        sys.exit(2)
+    machine_files = sorted(args.build_lib_dir / n
+                           for n in expected_names.values())
+    orphans = sorted(on_disk - set(expected_names.values()))
+    if orphans:
+        print(f"note: ignoring {len(orphans)} volk_machine_*.c not in the "
+              f"active configure (stale from a prior configure?): "
+              f"{', '.join(orphans)}", file=sys.stderr)
 
     gen_dir = args.source_dir / "gen"
     if not gen_dir.is_dir():
@@ -142,16 +224,10 @@ def main():
               "-- generator API changed; update this check.", file=sys.stderr)
         sys.exit(2)
 
-    machine_files = sorted(args.build_lib_dir.glob("volk_machine_*.c"))
-    if not machine_files:
-        print(f"warning: no volk_machine_*.c files in {args.build_lib_dir} "
-              f"(nothing to check; likely a cross-compile lane that doesn't "
-              f"produce x86 machine .c)", file=sys.stderr)
-        sys.exit(0)
-
+    expected_kernels = {k.name for k in K.kernels}
     all_violations = []
     for mc in machine_files:
-        all_violations.extend(check_machine(mc, K.kernels))
+        all_violations.extend(check_machine(mc, K.kernels, expected_kernels))
 
     if all_violations:
         print("DISPATCH TABLE INTEGRITY CHECK FAILED", file=sys.stderr)

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -266,7 +266,8 @@ equivalence violation, while still hard-failing on a genuine divergence.
 
 ## See also
 
-- the dispatch-table integrity check (mtibbits/volk#58, PR #59) — the
+- the dispatch-table integrity check (mtibbits/volk#58, PR #59; hardened by
+  #132 fail-closed parse guards and #166 active-machine scoping) — the
   integrity check this harness is modeled on.
 - the fusion-framework epic (mtibbits/volk#77) and its design notes for the
   C/C++ integration approaches (A vs B) that inform whether a given impl pair

--- a/cmake/test_check_dispatch_tables.py
+++ b/cmake/test_check_dispatch_tables.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# Copyright 2026 Free Software Foundation, Inc.
+#
+# This file is part of VOLK
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+"""
+Informal test suite for cmake/check_dispatch_tables.py (mtibbits/volk#132, #166).
+
+Not wired into ctest -- runnable standalone:
+    python3 cmake/test_check_dispatch_tables.py
+
+Drives the real script via subprocess against synthetic source trees
+(a fake gen/volk_kernel_defs.py) and synthetic machine .c fixtures.
+"""
+
+import contextlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+THIS_DIR = Path(__file__).parent
+SCRIPT = THIS_DIR / "check_dispatch_tables.py"
+
+KERNEL_DEFS = textwrap.dedent("""\
+    class _Impl:
+        def __init__(self, name, deps):
+            self.name, self.deps = name, deps
+
+    class _Kernel:
+        def __init__(self, name, impls):
+            self.name, self._impls = name, impls
+
+    kernels = [
+        _Kernel("volk_test_add", [_Impl("generic", ["generic"]),
+                                  _Impl("a_avx", ["avx"])]),
+        _Kernel("volk_test_mul", [_Impl("generic", ["generic"])]),
+    ]
+""")
+
+
+def make_source_tree(tmp):
+    """Write a fake source root with gen/volk_kernel_defs.py; return it."""
+    src = tmp / "src"
+    (src / "gen").mkdir(parents=True)
+    (src / "gen" / "volk_kernel_defs.py").write_text(KERNEL_DEFS)
+    return src
+
+
+def machine_c(defines, blocks):
+    """Render a synthetic machine .c body the script's regexes parse.
+
+    defines: LV_HAVE_* names to '#define <name> 1'
+    blocks:  {kernel_name: [impl names]} -> '"<kernel>",\\n{"i0", "i1"},'
+    """
+    lines = [f"#define {d} 1" for d in defines]
+    for kern, impls in blocks.items():
+        impl_strs = ", ".join(f'"{i}"' for i in impls)
+        lines.append(f'"{kern}",')
+        lines.append("{%s}," % impl_strs)
+    return "\n".join(lines) + "\n"
+
+
+def run_check(source_dir, build_lib_dir, machines=None):
+    cmd = [sys.executable, str(SCRIPT),
+           "--source-dir", str(source_dir),
+           "--build-lib-dir", str(build_lib_dir)]
+    if machines is not None:
+        cmd += ["--machines", machines]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+ALL_GOOD = {
+    "volk_test_add": ["generic", "a_avx"],
+    "volk_test_mul": ["generic"],
+}
+
+# a_avx gated on defined LV_HAVE_AVX but absent from the dispatch array --
+# the canonical violation fixture.
+MISSING_AVX = dict(ALL_GOOD, volk_test_add=["generic"])
+
+
+@contextlib.contextmanager
+def env():
+    """Fixture tree: fake source root + empty build lib dir."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        src = make_source_tree(tmp)
+        lib = tmp / "lib"
+        lib.mkdir()
+        yield src, lib
+
+
+def test_clean_pass():
+    """Both kernels' gated impls present -> exit 0, ok line counts machines."""
+    with env() as (src, lib):
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 0, r.stderr
+        assert "ok (1 machines checked)" in r.stdout, r.stdout
+
+
+def test_violation_detected():
+    """a_avx gated on defined LV_HAVE_AVX but absent from array -> exit 1."""
+    with env() as (src, lib):
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 1, (r.returncode, r.stderr)
+        assert "volk_test_add.a_avx" in r.stderr, r.stderr
+
+
+def test_drift_defines_fails_closed():
+    """#define format drift -> regex parses no macros -> must exit 2 (#132).
+
+    Born-red verified (2026-07-30): unfixed script exited 0 here -- the
+    fail-open defect this test pins (analysis/2026-07-30-fail-open-demo.txt).
+    """
+    with env() as (src, lib):
+        # Same info, drifted shape: '#define LV_HAVE_X (1)' -- the regex
+        # (which requires a bare '1') parses NO macros from this.
+        body = ("#define LV_HAVE_GENERIC (1)\n#define LV_HAVE_AVX (1)\n"
+                + machine_c([], ALL_GOOD))
+        (lib / "volk_machine_avx_64.c").write_text(body)
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+        assert "no '#define LV_HAVE_GENERIC 1' parsed" in r.stderr, r.stderr
+
+
+def test_drift_blocks_fails_closed():
+    """Impl-array format drift -> zero kernel blocks parse -> must exit 2 (#132).
+
+    Born-red verified (2026-07-30): unfixed script exited 0 ("ok") here while
+    checking nothing (analysis/2026-07-30-fail-open-demo.txt).
+    """
+    with env() as (src, lib):
+        # Same info, drifted shape: impl arrays use ( ) not { } braces.
+        body = machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], {})
+        body += '"volk_test_add",\n("generic", "a_avx"),\n'
+        body += '"volk_test_mul",\n("generic"),\n'
+        (lib / "volk_machine_avx_64.c").write_text(body)
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+        assert "parsed kernel blocks (" in r.stderr, r.stderr
+
+
+def test_kernel_set_mismatch_fails_closed():
+    """File parses but lists only a subset of kernel-defs kernels -> exit 2.
+
+    Guard form is set-equality per the U2 probe (all 9 real machine files
+    parse to exactly the 154-kernel defs set --
+    analysis/2026-07-30-u2-kernel-set-probe.txt: VERDICT equality HOLDS).
+    """
+    with env() as (src, lib):
+        only_add = {"volk_test_add": ["generic", "a_avx"]}  # volk_test_mul absent
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], only_add))
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+        assert "parsed kernel blocks (" in r.stderr, r.stderr
+        assert "volk_test_mul" in r.stderr, r.stderr
+
+
+def test_duplicate_kernel_block_fails_closed():
+    """Duplicate kernel block -> exit 2. Set-equality does NOT catch this
+    (duplicates leave the key set equal), so the duplicate guard in
+    parse_machine_c -- converted from a bare `assert` (strippable under
+    python -O, i.e. a live fail-open) to an exit-2 print -- is the only
+    cover; this test proves it fires."""
+    with env() as (src, lib):
+        body = machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD)
+        body += machine_c([], {"volk_test_add": ["generic"]})  # 2nd block
+        (lib / "volk_machine_avx_64.c").write_text(body)
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+        assert "has multiple impl-name arrays" in r.stderr, r.stderr
+
+
+def test_orphan_ignored_and_count_reflects_active():
+    """A stale machine file with a REAL violation, absent from --machines,
+    is ignored (exit 0) and the ok-count reflects the active set (#166 AC1+AC2)."""
+    with env() as (src, lib):
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
+        # Orphan from a "previous configure": violation-bearing (a_avx gated
+        # satisfied, missing from array) -- the exact 2026-06-24 symptom.
+        (lib / "volk_machine_stale_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 0, (r.returncode, r.stderr)
+        assert "ok (1 machines checked)" in r.stdout, r.stdout
+        assert "volk_machine_stale_64.c" in r.stderr, r.stderr  # the note names it
+
+
+def test_empty_machines_list_noop():
+    """--machines "" (static-dispatch / no-machine lane) -> warning + exit 0."""
+    with env() as (src, lib):
+        # Even with a stale violation-bearing file on disk:
+        (lib / "volk_machine_stale_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
+        r = run_check(src, lib, machines="")
+        assert r.returncode == 0, (r.returncode, r.stderr)
+        assert "no machines in the active configure" in r.stderr, r.stderr
+        # The empty-list lane must NOT be a silent fail-open: the warning
+        # names the on-disk files it is not checking.
+        assert "UNCHECKED on disk:" in r.stderr, r.stderr
+        assert "volk_machine_stale_64.c" in r.stderr, r.stderr
+
+
+def test_all_expected_missing_fails_closed():
+    """Active list names machines but NO listed file exists -> exit 2.
+    (Unified with partial-missing: with cmake supplying the list, zero
+    files present means a wiped/wrong build/lib -- the same root cause.
+    #166 AC4's exit-0-with-warning lane is the EMPTY-list lane above;
+    disposition operator-ratified 2026-07-30.)"""
+    with env() as (src, lib):
+        r = run_check(src, lib, machines="avx_64;sse_64")
+        assert r.returncode == 2, (r.returncode, r.stderr)
+        assert "missing from" in r.stderr, r.stderr
+        assert "avx_64" in r.stderr and "sse_64" in r.stderr, r.stderr
+
+
+def test_partial_missing_fails_closed():
+    """SOME listed machine files missing -> exit 2 (inconsistent build dir)."""
+    with env() as (src, lib):
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
+        r = run_check(src, lib, machines="avx_64;sse_64")
+        assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+        assert "sse_64" in r.stderr and "missing from" in r.stderr, r.stderr
+
+
+def test_multi_machine_clean_pass():
+    """Two active machines, both clean -> exit 0, count == 2 (#166 AC3)."""
+    with env() as (src, lib):
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
+        (lib / "volk_machine_sse_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC"], ALL_GOOD))
+        r = run_check(src, lib, machines="avx_64;sse_64")
+        assert r.returncode == 0, (r.returncode, r.stderr)
+        assert "ok (2 machines checked)" in r.stdout, r.stdout
+
+
+def test_active_violation_still_detected():
+    """Scoping must not swallow a violation in an ACTIVE machine (the #58 core)."""
+    with env() as (src, lib):
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
+        (lib / "volk_machine_stale_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
+        r = run_check(src, lib, machines="avx_64")
+        assert r.returncode == 1, (r.returncode, r.stderr)
+        assert "avx_64: volk_test_add.a_avx" in r.stderr, r.stderr
+        # Discriminating: the orphan's VIOLATION LINE must be absent even
+        # though its filename appears in the ignore note.
+        assert "stale_64: volk_test_add" not in r.stderr, r.stderr
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/test_check_dispatch_tables.py
+++ b/cmake/test_check_dispatch_tables.py
@@ -84,7 +84,7 @@ MISSING_AVX = dict(ALL_GOOD, volk_test_add=["generic"])
 
 
 @contextlib.contextmanager
-def env():
+def fixture_tree():
     """Fixture tree: fake source root + empty build lib dir."""
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
@@ -96,17 +96,19 @@ def env():
 
 def test_clean_pass():
     """Both kernels' gated impls present -> exit 0, ok line counts machines."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         (lib / "volk_machine_avx_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
         r = run_check(src, lib, machines="avx_64")
         assert r.returncode == 0, r.stderr
         assert "ok (1 machines checked)" in r.stdout, r.stdout
+        # Negative pin: no orphans on disk -> the ignore note must be absent.
+        assert "note: ignoring" not in r.stderr, r.stderr
 
 
 def test_violation_detected():
     """a_avx gated on defined LV_HAVE_AVX but absent from array -> exit 1."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         (lib / "volk_machine_avx_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
         r = run_check(src, lib, machines="avx_64")
@@ -120,7 +122,7 @@ def test_drift_defines_fails_closed():
     Born-red verified (2026-07-30): unfixed script exited 0 here -- the
     fail-open defect this test pins (analysis/2026-07-30-fail-open-demo.txt).
     """
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         # Same info, drifted shape: '#define LV_HAVE_X (1)' -- the regex
         # (which requires a bare '1') parses NO macros from this.
         body = ("#define LV_HAVE_GENERIC (1)\n#define LV_HAVE_AVX (1)\n"
@@ -137,7 +139,7 @@ def test_drift_blocks_fails_closed():
     Born-red verified (2026-07-30): unfixed script exited 0 ("ok") here while
     checking nothing (analysis/2026-07-30-fail-open-demo.txt).
     """
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         # Same info, drifted shape: impl arrays use ( ) not { } braces.
         body = machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], {})
         body += '"volk_test_add",\n("generic", "a_avx"),\n'
@@ -155,7 +157,7 @@ def test_kernel_set_mismatch_fails_closed():
     parse to exactly the 154-kernel defs set --
     analysis/2026-07-30-u2-kernel-set-probe.txt: VERDICT equality HOLDS).
     """
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         only_add = {"volk_test_add": ["generic", "a_avx"]}  # volk_test_mul absent
         (lib / "volk_machine_avx_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], only_add))
@@ -171,7 +173,7 @@ def test_duplicate_kernel_block_fails_closed():
     parse_machine_c -- converted from a bare `assert` (strippable under
     python -O, i.e. a live fail-open) to an exit-2 print -- is the only
     cover; this test proves it fires."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         body = machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD)
         body += machine_c([], {"volk_test_add": ["generic"]})  # 2nd block
         (lib / "volk_machine_avx_64.c").write_text(body)
@@ -183,7 +185,7 @@ def test_duplicate_kernel_block_fails_closed():
 def test_orphan_ignored_and_count_reflects_active():
     """A stale machine file with a REAL violation, absent from --machines,
     is ignored (exit 0) and the ok-count reflects the active set (#166 AC1+AC2)."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         (lib / "volk_machine_avx_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
         # Orphan from a "previous configure": violation-bearing (a_avx gated
@@ -198,7 +200,7 @@ def test_orphan_ignored_and_count_reflects_active():
 
 def test_empty_machines_list_noop():
     """--machines "" (static-dispatch / no-machine lane) -> warning + exit 0."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         # Even with a stale violation-bearing file on disk:
         (lib / "volk_machine_stale_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
@@ -217,7 +219,7 @@ def test_all_expected_missing_fails_closed():
     files present means a wiped/wrong build/lib -- the same root cause.
     #166 AC4's exit-0-with-warning lane is the EMPTY-list lane above;
     disposition operator-ratified 2026-07-30.)"""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         r = run_check(src, lib, machines="avx_64;sse_64")
         assert r.returncode == 2, (r.returncode, r.stderr)
         assert "missing from" in r.stderr, r.stderr
@@ -226,7 +228,7 @@ def test_all_expected_missing_fails_closed():
 
 def test_partial_missing_fails_closed():
     """SOME listed machine files missing -> exit 2 (inconsistent build dir)."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         (lib / "volk_machine_avx_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
         r = run_check(src, lib, machines="avx_64;sse_64")
@@ -236,7 +238,7 @@ def test_partial_missing_fails_closed():
 
 def test_multi_machine_clean_pass():
     """Two active machines, both clean -> exit 0, count == 2 (#166 AC3)."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         (lib / "volk_machine_avx_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
         (lib / "volk_machine_sse_64.c").write_text(
@@ -248,7 +250,7 @@ def test_multi_machine_clean_pass():
 
 def test_active_violation_still_detected():
     """Scoping must not swallow a violation in an ACTIVE machine (the #58 core)."""
-    with env() as (src, lib):
+    with fixture_tree() as (src, lib):
         (lib / "volk_machine_avx_64.c").write_text(
             machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], MISSING_AVX))
         (lib / "volk_machine_stale_64.c").write_text(
@@ -259,6 +261,19 @@ def test_active_violation_still_detected():
         # Discriminating: the orphan's VIOLATION LINE must be absent even
         # though its filename appears in the ignore note.
         assert "stale_64: volk_test_add" not in r.stderr, r.stderr
+
+
+def test_machines_flag_required():
+    """Omitting --machines entirely -> argparse exit 2 (fail-closed CLI).
+
+    Pins the required=True decision: a future "optional with legacy glob
+    fallback" edit must consciously delete this test."""
+    with fixture_tree() as (src, lib):
+        (lib / "volk_machine_avx_64.c").write_text(
+            machine_c(["LV_HAVE_GENERIC", "LV_HAVE_AVX"], ALL_GOOD))
+        r = run_check(src, lib)   # machines=None omits the flag
+        assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+        assert "--machines" in r.stderr, r.stderr
 
 
 def main():

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,8 +73,10 @@ This is a class of bug VOLK's own ctest cannot detect, because the
 `qa_<kernel>` test harness bypasses the per-machine dispatch arrays
 production callers use. See mtibbits/volk#58 for background.
 
-The check is scoped to the machines of the *active* configure (cmake
-passes `available_machines` via `--machines`), so stale
+The check is scoped to the machines whose `.c` the *active* configure
+actually generated (cmake passes the codegen loop's `_generated_machines`
+accumulator — derived from `available_machines`, and empty under
+`VOLK_STATIC_DISPATCH` — via `--machines`), so stale
 `volk_machine_*.c` files left in a reused build directory by a previous
 configure are ignored (a `note:` on stderr names them) rather than
 checked — see mtibbits/volk#166. If the generated-file format drifts so

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,6 +73,17 @@ This is a class of bug VOLK's own ctest cannot detect, because the
 `qa_<kernel>` test harness bypasses the per-machine dispatch arrays
 production callers use. See mtibbits/volk#58 for background.
 
+The check is scoped to the machines of the *active* configure (cmake
+passes `available_machines` via `--machines`), so stale
+`volk_machine_*.c` files left in a reused build directory by a previous
+configure are ignored (a `note:` on stderr names them) rather than
+checked — see mtibbits/volk#166. If the generated-file format drifts so
+the script's parser no longer matches it, the check fails the build
+(exit 2) instead of silently passing — see mtibbits/volk#132.
+
+The check's own test suite is `cmake/test_check_dispatch_tables.py`
+(standalone, not wired into ctest): `python3 cmake/test_check_dispatch_tables.py`.
+
 ## The Buddy Principle: Submit One, Review One
 
 When you've submitted a pull request, please take the time to review another

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,7 +81,12 @@ accumulator — derived from `available_machines`, and empty under
 configure are ignored (a `note:` on stderr names them) rather than
 checked — see mtibbits/volk#166. If the generated-file format drifts so
 the script's parser no longer matches it, the check fails the build
-(exit 2) instead of silently passing — see mtibbits/volk#132.
+(exit 2) instead of silently passing — see mtibbits/volk#132. One
+everyday consequence: because `kernels/volk/*.h` is a
+non-`CONFIGURE_DEPENDS` glob, adding or removing a kernel header
+requires re-running `cmake`; until you do, the check fails the build
+(exit 2, its message names this cause) rather than letting the build
+silently omit the kernel from every dispatch array.
 
 The check's own test suite is `cmake/test_check_dispatch_tables.py`
 (standalone, not wired into ctest): `python3 cmake/test_check_dispatch_tables.py`.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -474,12 +474,18 @@ set(COMPILER_INFO
     "${CMAKE_C_COMPILER}:::${CMAKE_C_FLAGS_${GRCBTU}} ${CMAKE_C_FLAGS}\n${CMAKE_CXX_COMPILER}:::${CMAKE_CXX_FLAGS_${GRCBTU}} ${CMAKE_CXX_FLAGS}\n"
 )
 
+# Machines whose .c the loop below actually generates -- consumed by the
+# volk_check_dispatch_tables target (#166). Accumulated INSIDE the loop so
+# it is correct by construction: under VOLK_STATIC_DISPATCH the loop never
+# runs and the list stays empty (the check then no-ops).
+set(_generated_machines "")
 if(NOT VOLK_STATIC_DISPATCH)
     foreach(machine_name ${available_machines})
         #generate machine source
         set(machine_source ${CMAKE_CURRENT_BINARY_DIR}/volk_machine_${machine_name}.c)
         gen_template(${PROJECT_SOURCE_DIR}/tmpl/volk_machine_xxx.tmpl.c ${machine_source}
                      ${machine_name})
+        list(APPEND _generated_machines ${machine_name})
 
         #determine machine flags
         execute_process(
@@ -621,12 +627,17 @@ endif()
 
 # Verify per-machine dispatch-table integrity after codegen, before
 # compiling any machine .c file. See mtibbits/volk#58
-# for the bug class this catches.
+# for the bug class this catches; #132/#166 for the fail-closed parse
+# guards and active-machine scoping. The machine list is
+# _generated_machines, accumulated by the codegen loop itself, so the
+# check audits exactly the files THIS configure generates -- empty (and
+# the check a no-op) under VOLK_STATIC_DISPATCH by construction.
 add_custom_target(volk_check_dispatch_tables
     COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_DASH_B}
             ${PROJECT_SOURCE_DIR}/cmake/check_dispatch_tables.py
             --source-dir ${PROJECT_SOURCE_DIR}
             --build-lib-dir ${PROJECT_BINARY_DIR}/lib
+            --machines "${_generated_machines}"
     DEPENDS ${volk_gen_sources}
     COMMENT "Checking per-machine impl dispatch-table integrity"
     VERBATIM
@@ -782,7 +793,10 @@ endif()
 # make the shared lib depend on it so a regression in a framework
 # instantiation's machine code breaks the build. With zero tuples declared the
 # manifest is empty and the check is a no-op (zero false positives on
-# origin/main). Mirrors the volk_check_dispatch_tables wiring (PR #59 / B15).
+# origin/main). Mirrors the volk_check_dispatch_tables target/DEPENDS wiring
+# (PR #59 / B15); the dispatch check additionally takes --machines (fed by
+# the codegen loop's _generated_machines accumulator, #132/#166) with no
+# analogue here.
 FINALIZE_CODEGEN_EQUIVALENCE_HARNESS()
 if(_cge_bootstrap_enabled)
     add_dependencies(volk_check_framework_codegen volk_codegen_bootstrap_ref)


### PR DESCRIPTION
## Summary

Hardens the dispatch-table integrity check (`cmake/check_dispatch_tables.py`,
#58/PR #59) against both of its known robustness defect classes, in one
coordinated change. **Fail-open on parse drift (#132):** the script derived
everything from two regexes over generated machine `.c` files; a template
format change that matched nothing made every kernel skip and the check print
`ok` while checking nothing. It now fails closed (exit 2) unless each machine
file yields `LV_HAVE_GENERIC`, exactly the `gen/volk_kernel_defs` kernel set
(one block per kernel — duplicate blocks are their own exit-2 guard, converted
from a `python -O`-strippable bare `assert`), all verified against real
generated files before the guard form was locked. **Unscoped glob (#166):** the
check globbed `build/lib/volk_machine_*.c`, so machine files orphaned by a
prior configure produced false failures (the 2026-06-24 `volk_profile` build
block reproduced in #132's comment). CMake now passes the machine list via
`--machines`, accumulated as `_generated_machines` inside the codegen loop
itself, so the check audits exactly the files this configure generates —
orphans are ignored by name (`note:` on stderr), and the list is empty under
`VOLK_STATIC_DISPATCH` by construction (the check then no-ops with a warning
that names any unchecked files on disk). Why now: this script is the only
coverage for per-machine dispatch tables (the qa suite bypasses them), and
both defect classes undermine exactly the "red means something" property the
serial plan's later work relies on.

One everyday consequence to know before merging: adding or removing a kernel
header and running `ninja` without re-running cmake now fails the build
(exit 2) instead of silently omitting the kernel from every dispatch array —
`kernels/volk/*.h` is a non-`CONFIGURE_DEPENDS` glob, so codegen does not
re-fire until cmake reruns, while the check reads today's kernel defs. The
guard's message names this cause first, and the new CONTRIBUTING paragraph
documents it.

Deviation from #166's AC4 as literally written, ratified at plan review: the
old "no machine files found → warning + exit 0" branch is removed rather than
preserved. With CMake supplying a non-empty list, any listed-but-missing file
(including all of them) is the same broken-build-dir state → exit 2; AC4's
exits-0-with-warning lane survives as the empty-list (static-dispatch) path.
A CI-lane inventory (all ~14 configure invocations across the workflows)
confirmed no lane can legitimately reach the new exit-2 branches.

Residual, disclosed: the `--machines` one-argument delivery is
probe-verified on Unix Makefiles and Ninja (plus `ninja -t commands`
inspection of the real wiring); the Windows/MSBuild generator could not be
probed locally. The checking passes narrowed this to a fail-closed residual:
the empty-argument path is only ever exercised by the static-dispatch lane
(Linux/Unix-Makefiles), and on MSBuild any word-split or dropped argument
fails loudly (argparse rejects stray positionals; `--machines` is required)
— the only silently-degraded shape would be a truncated single token, which
no generator produces. Self-contained check on the windows log: the
`Available machines:` STATUS line and the `ok (N machines checked)` line
must agree on the machine count.

## Related issues

Addresses #132 (both checkboxes) and #166 (all five acceptance criteria; AC4
per the ratified disposition above). Both issues stay open per the fork's
upstream-submission-queue convention. Context: #58 / PR #59 (the check being
hardened), #53 (the machine consolidation whose restack orphaned the files in
the original incident).

## Testing

- New standalone suite `cmake/test_check_dispatch_tables.py` (mirrors the
  `test_check_framework_codegen.py` precedent; not ctest-wired): **13/13** —
  2 baseline (clean pass with a no-orphan-note negative pin / violation still
  detected), 4 parse-drift guards (drifted defines, drifted impl-arrays,
  kernel-set mismatch, duplicate block), 6 scoping (orphan ignored + count
  reflects active set, empty-list no-op with UNCHECKED-naming, all-missing
  exit 2, partial-missing exit 2, multi-machine clean,
  active-violation-not-swallowed with a discriminating
  no-orphan-violation-line assert), 1 CLI contract (`--machines` required —
  omitting it exits 2).
- Born-red discipline: every new behavior was run against the UNFIXED script
  first with the failure reason recorded — the two drift fixtures and the
  kernel-set fixture observed **exit 0** ("ok" while checking nothing; the
  demo artifact pins it), the duplicate fixture an AssertionError traceback;
  argparse rejection was explicitly excluded as a red cause.
- Real-build validation, twice: at the implement commit `34b88242` (clean
  configure → `ok (9 machines checked)` with N equal to the configure log's
  `Available machines:` count; a planted violation-bearing orphan
  (`volk_machine_avx512cd_64_mmx_orc.c`, generic impl stripped) proven to
  FIRE when listed (`FAILED`, exit 1) and ignored by name when not (exit 0 +
  `note:`); static-dispatch configure no-ops (warning, exit 0), and with a
  stray file on disk the warning names it (`UNCHECKED on disk:`)) — and
  re-run at the final SHA `2c1e6456` (normal lane `ok (9)`, static-dispatch
  no-op covering the review-fix reorder of the gen-dir check, suite 13/13).
- Analyzers: changed-line scope is clean where it applies (cppcheck/cpplint/
  clang-tidy/iwyu/clang-format/codespell/cmake-lint/ruff/flake8/mypy); the
  sanitizer/compiler lines are whole-tree regression baselines, not
  changed-line evidence — this diff has zero C/C++ lines (scan-build,
  compiler `-Werror`, ASan+UBSan, TSan all pass). bandit reports 32 low
  findings, all in the new **test** file (B101 asserts in tests, B404/B603
  subprocess — the suite's mechanism, same pattern as the sibling suite).
- Empty-`--machines` no-op lane measured ~150 ms faster than a naive
  placement (the kernel-defs import is skipped when nothing will be checked).

## Evidence

suite: none @ 2c1e6456240d47354eff16ce31d696481ec96f0f
files: 5 changed

(The 13-test suite above is a standalone script, not a bats/pytest framework
run — hence the no-framework form; 13/13 at the final SHA is recorded in
Issue-Fork-132/analysis/2026-07-30-realbuild-validation.txt, "@2c1e6456".)

## Checklist
- [x] Builds cleanly (`cmake --build`) — real-configure validation above
- [x] Tests pass (`ctest`) — no C/C++ change reachable by ctest; the check
      script's own suite passes 13/13
- [x] Step-15 review findings 4/5 (redundant derived arg; duplicate-entry
      count nit) accepted as robustness nits, deliberately not applied —
      recorded in actualWork Follow-up
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — the two issues share one script and were
      operator-prescribed as one coordinated change; no unrelated edits
