### PR TITLE
codegen zero coverage guard

### DIFF
--- a/cmake/CodegenEquivalence.cmake
+++ b/cmake/CodegenEquivalence.cmake
@@ -36,7 +36,8 @@ function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
     # bare keyword (no value) for a tuple whose dispatch relies on the impl
     # existing as a real, separately-dispatchable symbol. When set, the harness
     # treats "inlined away" (SymbolNotEmittedError) as a hard failure instead of
-    # skip-with-warning. Omitted -> today's skip-with-warning behavior.
+    # skip-with-warning. Omitted -> today's skip-with-warning behavior (subject
+    # to the aggregate zero-coverage guard, mtibbits/volk#165).
     cmake_parse_arguments(CGE
         "REQUIRE_STANDALONE" "${required_args};REQUIRE_MNEMONIC" "" ${ARGN})
 

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -612,18 +612,27 @@ def main():
             lead = ("Every declared tuple for the named kernel(s) was "
                     "skipped (impl not emitted\nstandalone), leaving them "
                     "unverified while the rest of the run passed.")
-            # Name only the uncovered kernels' tuples: a covered kernel's
-            # incidental skip must not be presented as removable.
-            shown = [tuple_id(t) for t in tuples if t["kernel"] in uncovered]
+            # Name only the uncovered kernels' skips: a covered kernel's
+            # incidental skip must not be presented as removable. Derived from
+            # the skip list itself (not kernel membership) so the label stays
+            # truthful if the uncovered predicate is ever loosened below 100%.
+            shown = [tid for tid in skipped
+                     if tid.split(".", 1)[0] in uncovered]
         print(f"CODEGEN-EQUIVALENCE CHECK FAILED: {headline}",
               file=sys.stderr)
         print("", file=sys.stderr)
         print(lead, file=sys.stderr)
         print("", file=sys.stderr)
-        print("If the inlining is expected, remove the affected tuples from "
-              "the manifest\n(or fix the build so the symbols are emitted "
-              "standalone); absent coverage\nis not reported as success. "
-              "See mtibbits/volk#165.", file=sys.stderr)
+        print("Fix the build so the symbols are emitted standalone (see the "
+              "README's\nrequire-standalone notes). Removing the affected "
+              "tuples from the manifest\nsilences the check instead of "
+              "fixing it -- a deliberate de-scoping that\nneeds review, not "
+              "an equivalent outcome. See mtibbits/volk#165.",
+              file=sys.stderr)
+        if checked == 0:
+            print("Note: an emptied manifest prints ok (0 tuples declared); "
+                  "that green means\nzero coverage was accepted, not that "
+                  "codegen was verified.", file=sys.stderr)
         print(f"  skipped: {shown}", file=sys.stderr)
         sys.exit(1)
 

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -29,9 +29,11 @@ Cross-compiler robustness (mtibbits/volk#145): benign codegen noise that differs
 by compiler is normalized away -- trailing alignment NOPs of any encoding and
 trailing `data16` padding are stripped (they pad the next function and belong to
 no function), and a symbol the compiler inlined rather than emitting standalone
-is skipped-with-warning (exit 0) since there is nothing to compare. A genuine
-post-normalization divergence still fails (exit 1); a genuinely unparsable
-non-padding line still errors (exit 2).
+is skipped-with-warning since there is nothing to compare -- exit 0 only while
+real coverage remains: a run where EVERY declared tuple skipped, or a kernel
+whose declared tuples ALL skipped, is a zero-coverage failure (exit 1;
+mtibbits/volk#165). A genuine post-normalization divergence still fails
+(exit 1); a genuinely unparsable non-padding line still errors (exit 2).
 
 Per-tuple opt-in `require_standalone` (bool, default off) flips that inlined-away
 outcome: for a tuple whose dispatch relies on the impl existing as a real,
@@ -40,8 +42,11 @@ hard-fails it (exit 1) instead of skip-with-warning. Orthogonal to
 `require_mnemonic`, which asserts which instructions a present symbol contains.
 
 Exit codes:
-    0  all declared tuples pass (or are skipped/empty); skips warn on stderr
-    1  one or more tuples fail their criterion (per-tuple diff on stderr)
+    0  all declared tuples pass; skips warn on stderr while real coverage
+       remains (an empty manifest -- zero tuples declared -- is also ok)
+    1  one or more tuples fail their criterion (per-tuple diff on stderr),
+       or zero coverage: every declared tuple skipped, or some kernel's
+       declared tuples all skipped (mtibbits/volk#165)
     2  internal error: missing manifest/.o, ambiguous .o, unparsable
        non-padding line, or empty function body
 
@@ -73,9 +78,11 @@ class SymbolNotEmittedError(RuntimeError):
     """The compared symbol is absent from the object file because the compiler
     inlined it rather than emitting it standalone (e.g. macOS clang on some
     impls). There is nothing to compare, so main() skips the tuple with a
-    warning rather than failing the build. Distinct from the other RuntimeError
-    cases (missing/ambiguous .o, unparsable line) which remain hard errors
-    (mtibbits/volk#145).
+    warning rather than failing the build -- subject to the aggregate
+    zero-coverage guard: a run (or a single kernel) whose declared tuples ALL
+    skip fails loudly instead (mtibbits/volk#165). Distinct from the other
+    RuntimeError cases (missing/ambiguous .o, unparsable line) which remain
+    hard errors (mtibbits/volk#145).
     """
 
 
@@ -498,6 +505,7 @@ def main():
     failures = []
     errors = []
     skipped = []
+    skipped_by_kernel = {}
     for t in tuples:
         try:
             a_o = resolve_object(args.build_lib_dir, t["impl_a"]["machine_o"])
@@ -523,6 +531,8 @@ def main():
             print(f"codegen-equivalence: WARNING: skipping {tuple_id(t)}: {e}",
                   file=sys.stderr)
             skipped.append(tuple_id(t))
+            skipped_by_kernel[t["kernel"]] = \
+                skipped_by_kernel.get(t["kernel"], 0) + 1
             continue
         except RuntimeError as e:
             errors.append((tuple_id(t), str(e)))
@@ -573,6 +583,50 @@ def main():
         sys.exit(1)
 
     checked = len(tuples) - len(skipped)
+    if checked == 0:
+        print("CODEGEN-EQUIVALENCE CHECK FAILED: zero coverage",
+              file=sys.stderr)
+        print("", file=sys.stderr)
+        print(f"All {len(tuples)} declared tuples were skipped (impl not "
+              "emitted standalone),", file=sys.stderr)
+        print("so nothing was verified. A toolchain change that inlines "
+              "every compared", file=sys.stderr)
+        print("impl would otherwise turn this check into a silent no-op.",
+              file=sys.stderr)
+        print("", file=sys.stderr)
+        print("If the inlining is expected, remove the affected tuples from "
+              "the manifest", file=sys.stderr)
+        print("(or fix the build so the symbols are emitted standalone); "
+              "absent coverage", file=sys.stderr)
+        print("is not reported as success. See mtibbits/volk#165.",
+              file=sys.stderr)
+        print(f"  skipped: {skipped}", file=sys.stderr)
+        sys.exit(1)
+
+    declared_by_kernel = {}
+    for t in tuples:
+        declared_by_kernel[t["kernel"]] = \
+            declared_by_kernel.get(t["kernel"], 0) + 1
+    uncovered = sorted(
+        k for k, n in declared_by_kernel.items()
+        if skipped_by_kernel.get(k, 0) == n)
+    if uncovered:
+        print("CODEGEN-EQUIVALENCE CHECK FAILED: zero codegen coverage "
+              f"for kernel(s): {', '.join(uncovered)}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Every declared tuple for the named kernel(s) was skipped "
+              "(impl not emitted", file=sys.stderr)
+        print("standalone), leaving them unverified while the rest of the "
+              "run passed.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("If the inlining is expected, remove those kernels' tuples "
+              "from the manifest", file=sys.stderr)
+        print("(or fix the build so the symbols are emitted standalone); "
+              "a kernel with", file=sys.stderr)
+        print("zero checked tuples is not covered. See mtibbits/volk#165.",
+              file=sys.stderr)
+        sys.exit(1)
+
     extra = (f", {len(skipped)} skipped -- not emitted standalone: {skipped}"
              if skipped else "")
     print(f"codegen-equivalence: ok ({checked} tuples checked{extra})")

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -584,26 +584,37 @@ def main():
 
     # Zero-coverage guard (mtibbits/volk#165): a skip is legitimate per-tuple,
     # but declared-yet-unverified coverage must not report success. The global
-    # all-skip case is the per-kernel case with every kernel uncovered; it gets
-    # its own headline because "the check verified nothing at all" is a
-    # different operator situation than one kernel losing coverage.
+    # all-skip case gets its own headline because "the check verified nothing
+    # at all" is a different operator situation than one kernel losing
+    # coverage. (A require_standalone tuple that was inlined away lands in
+    # `failures` -- exited above -- never in `skipped`, so it cannot skew this
+    # accounting.)
     checked = len(tuples) - len(skipped)
     declared_by_kernel = Counter(t["kernel"] for t in tuples)
     uncovered = sorted(k for k, n in declared_by_kernel.items()
                        if skipped_by_kernel[k] == n)
-    if uncovered:
+    # `checked == 0` is tested explicitly rather than relying on it implying
+    # `uncovered` non-empty: that implication is a property of the loop's
+    # current buckets (every tuple checks or skips), not of this guard, and a
+    # future non-skip consumption path must not let a zero-checked run print
+    # ok again.
+    if uncovered or checked == 0:
         if checked == 0:
             headline = "zero coverage"
             lead = (f"All {len(tuples)} declared tuples were skipped (impl "
                     "not emitted standalone),\nso nothing was verified. A "
                     "toolchain change that inlines every compared\nimpl "
                     "would otherwise turn this check into a silent no-op.")
+            shown = skipped
         else:
             headline = ("zero codegen coverage for kernel(s): "
                         + ", ".join(uncovered))
             lead = ("Every declared tuple for the named kernel(s) was "
                     "skipped (impl not emitted\nstandalone), leaving them "
                     "unverified while the rest of the run passed.")
+            # Name only the uncovered kernels' tuples: a covered kernel's
+            # incidental skip must not be presented as removable.
+            shown = [tuple_id(t) for t in tuples if t["kernel"] in uncovered]
         print(f"CODEGEN-EQUIVALENCE CHECK FAILED: {headline}",
               file=sys.stderr)
         print("", file=sys.stderr)
@@ -613,7 +624,7 @@ def main():
               "the manifest\n(or fix the build so the symbols are emitted "
               "standalone); absent coverage\nis not reported as success. "
               "See mtibbits/volk#165.", file=sys.stderr)
-        print(f"  skipped: {skipped}", file=sys.stderr)
+        print(f"  skipped: {shown}", file=sys.stderr)
         sys.exit(1)
 
     extra = (f", {len(skipped)} skipped -- not emitted standalone: {skipped}"

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -71,6 +71,7 @@ import json
 import re
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 
@@ -505,7 +506,7 @@ def main():
     failures = []
     errors = []
     skipped = []
-    skipped_by_kernel = {}
+    skipped_by_kernel = Counter()
     for t in tuples:
         try:
             a_o = resolve_object(args.build_lib_dir, t["impl_a"]["machine_o"])
@@ -531,8 +532,7 @@ def main():
             print(f"codegen-equivalence: WARNING: skipping {tuple_id(t)}: {e}",
                   file=sys.stderr)
             skipped.append(tuple_id(t))
-            skipped_by_kernel[t["kernel"]] = \
-                skipped_by_kernel.get(t["kernel"], 0) + 1
+            skipped_by_kernel[t["kernel"]] += 1
             continue
         except RuntimeError as e:
             errors.append((tuple_id(t), str(e)))
@@ -582,49 +582,38 @@ def main():
             print("", file=sys.stderr)
         sys.exit(1)
 
+    # Zero-coverage guard (mtibbits/volk#165): a skip is legitimate per-tuple,
+    # but declared-yet-unverified coverage must not report success. The global
+    # all-skip case is the per-kernel case with every kernel uncovered; it gets
+    # its own headline because "the check verified nothing at all" is a
+    # different operator situation than one kernel losing coverage.
     checked = len(tuples) - len(skipped)
-    if checked == 0:
-        print("CODEGEN-EQUIVALENCE CHECK FAILED: zero coverage",
+    declared_by_kernel = Counter(t["kernel"] for t in tuples)
+    uncovered = sorted(k for k, n in declared_by_kernel.items()
+                       if skipped_by_kernel[k] == n)
+    if uncovered:
+        if checked == 0:
+            headline = "zero coverage"
+            lead = (f"All {len(tuples)} declared tuples were skipped (impl "
+                    "not emitted standalone),\nso nothing was verified. A "
+                    "toolchain change that inlines every compared\nimpl "
+                    "would otherwise turn this check into a silent no-op.")
+        else:
+            headline = ("zero codegen coverage for kernel(s): "
+                        + ", ".join(uncovered))
+            lead = ("Every declared tuple for the named kernel(s) was "
+                    "skipped (impl not emitted\nstandalone), leaving them "
+                    "unverified while the rest of the run passed.")
+        print(f"CODEGEN-EQUIVALENCE CHECK FAILED: {headline}",
               file=sys.stderr)
         print("", file=sys.stderr)
-        print(f"All {len(tuples)} declared tuples were skipped (impl not "
-              "emitted standalone),", file=sys.stderr)
-        print("so nothing was verified. A toolchain change that inlines "
-              "every compared", file=sys.stderr)
-        print("impl would otherwise turn this check into a silent no-op.",
-              file=sys.stderr)
+        print(lead, file=sys.stderr)
         print("", file=sys.stderr)
         print("If the inlining is expected, remove the affected tuples from "
-              "the manifest", file=sys.stderr)
-        print("(or fix the build so the symbols are emitted standalone); "
-              "absent coverage", file=sys.stderr)
-        print("is not reported as success. See mtibbits/volk#165.",
-              file=sys.stderr)
+              "the manifest\n(or fix the build so the symbols are emitted "
+              "standalone); absent coverage\nis not reported as success. "
+              "See mtibbits/volk#165.", file=sys.stderr)
         print(f"  skipped: {skipped}", file=sys.stderr)
-        sys.exit(1)
-
-    declared_by_kernel = {}
-    for t in tuples:
-        declared_by_kernel[t["kernel"]] = \
-            declared_by_kernel.get(t["kernel"], 0) + 1
-    uncovered = sorted(
-        k for k, n in declared_by_kernel.items()
-        if skipped_by_kernel.get(k, 0) == n)
-    if uncovered:
-        print("CODEGEN-EQUIVALENCE CHECK FAILED: zero codegen coverage "
-              f"for kernel(s): {', '.join(uncovered)}", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("Every declared tuple for the named kernel(s) was skipped "
-              "(impl not emitted", file=sys.stderr)
-        print("standalone), leaving them unverified while the rest of the "
-              "run passed.", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("If the inlining is expected, remove those kernels' tuples "
-              "from the manifest", file=sys.stderr)
-        print("(or fix the build so the symbols are emitted standalone); "
-              "a kernel with", file=sys.stderr)
-        print("zero checked tuples is not covered. See mtibbits/volk#165.",
-              file=sys.stderr)
         sys.exit(1)
 
     extra = (f", {len(skipped)} skipped -- not emitted standalone: {skipped}"

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -133,13 +133,14 @@ tuples to guarantee the instantiation didn't silently fall back to scalar code.
 
 By default, when the compiler inlines an impl rather than emitting it as a
 standalone symbol there is nothing to disassemble, so the tuple is
-**skipped with a warning** and the build stays green — bounded by the
-zero-coverage guard below: aggregate all-skip configurations fail (see
-*Diagnostics* and *Cross-compiler robustness* below). That is the right default for impls whose
-standalone emission is compiler-dependent — but it leaves a masked-regression
-class for impls that the dispatch table relies on existing as real, separately
-dispatchable symbols: if such an impl gets inlined away by a future refactor,
-the symbol silently disappears and the check still passes.
+**skipped with a warning** and the build stays green (see *Diagnostics* and
+*Cross-compiler robustness* below) — bounded by the *Zero-coverage guard*:
+aggregate all-skip configurations fail. That is the right default for impls
+whose standalone emission is compiler-dependent — but it leaves a
+masked-regression class for impls that the dispatch table relies on existing
+as real, separately dispatchable symbols: if such an impl gets inlined away
+by a future refactor, the symbol silently disappears and the check still
+passes while the kernel retains other coverage.
 
 Declare the optional boolean flag `REQUIRE_STANDALONE` (pass the **bare keyword**,
 no value) on such a tuple to flip that outcome: when the impl is inlined away,
@@ -229,6 +230,11 @@ positives on a clean tree.
 - `within_noise comparison FAILED` — either mnemonics differ (compiler chose a
   different instruction) or operand classes differ (e.g. a register operand
   became a memory operand). The offending index is printed.
+- `CHECK FAILED: zero coverage` — every declared tuple was skipped; the run
+  verified nothing (see *Zero-coverage guard*). Exit 1.
+- `CHECK FAILED: zero codegen coverage for kernel(s): <names>` — the named
+  kernels' declared tuples were all skipped while other kernels were checked;
+  only the named kernels' tuples are listed as removable. Exit 1.
 
 ## Adding a tuple, end-to-end
 
@@ -298,6 +304,8 @@ equivalence violation, while still hard-failing on a genuine divergence.
   operand class) → `CHECK FAILED`, exit 1.
 - A missing/ambiguous `.o`, malformed manifest, an unparsable *non-padding*
   in-body line, or an empty function body → `CHECK ERROR`, exit 2.
+- Zero coverage — every declared tuple skipped, or one kernel's declared
+  tuples all skipped (see *Zero-coverage guard*) → `CHECK FAILED`, exit 1.
 
 ## See also
 

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -133,8 +133,9 @@ tuples to guarantee the instantiation didn't silently fall back to scalar code.
 
 By default, when the compiler inlines an impl rather than emitting it as a
 standalone symbol there is nothing to disassemble, so the tuple is
-**skipped with a warning** and the build stays green (see *Diagnostics* and
-*Cross-compiler robustness* below). That is the right default for impls whose
+**skipped with a warning** and the build stays green — bounded by the
+zero-coverage guard below: aggregate all-skip configurations fail (see
+*Diagnostics* and *Cross-compiler robustness* below). That is the right default for impls whose
 standalone emission is compiler-dependent — but it leaves a masked-regression
 class for impls that the dispatch table relies on existing as real, separately
 dispatchable symbols: if such an impl gets inlined away by a future refactor,
@@ -156,7 +157,38 @@ This is an **orthogonal axis** to `REQUIRE_MNEMONIC`: the latter asserts which
 instructions a *present* symbol contains; `REQUIRE_STANDALONE` asserts the symbol
 *exists* as a dispatchable standalone in the first place. The field is **opt-in**:
 tuples without it are unaffected and produce identical manifest JSON to before
-(unmarked tuples keep the skip-with-warning / exit-0 behavior).
+(unmarked tuples keep the skip-with-warning behavior, exit 0 while real
+coverage remains — see *Zero-coverage guard*).
+
+## Zero-coverage guard (mtibbits/volk#165)
+
+Skipping is per-tuple, but success is not unconditional. Two aggregate
+configurations fail loudly (exit 1) instead of reporting `ok`:
+
+- **Global zero coverage** — every declared tuple was skipped
+  (`checked == 0`). The run verified nothing, so it does not report
+  success. Diagnostic: `CHECK FAILED: zero coverage`.
+- **Per-kernel all-skip** — every tuple belonging to one kernel was
+  skipped while other kernels were checked. That kernel has no codegen
+  coverage, so the run fails and names it. Diagnostic:
+  `CHECK FAILED: zero codegen coverage for kernel(s): <names>`.
+  A kernel with at least one checked tuple is covered; its remaining
+  skips stay warnings.
+
+Both diagnostics point at the usual cause — a toolchain change that
+starts inlining the compared impls — and the remedies: fix the build so
+the symbols are emitted standalone, or deliberately remove the affected
+tuples from the manifest. The empty-manifest case is distinct and stays
+green: zero tuples *declared* is a valid configuration
+(`ok (0 tuples declared)`, exit 0); zero tuples *verified out of some
+declared* is not.
+
+**Blind spots (what this guard cannot decide):** coverage is aggregated
+on the bare kernel name, so a kernel checked on one ISA but wholly
+skipped on another still passes (an ISA-level hole); and tuples that
+silently stop being *declared* — e.g. the CMake machine-name gate in
+`lib/CMakeLists.txt` ceasing to match — land in the legitimate
+`ok (0 tuples declared)` path. Both are outside this guard's contract.
 
 ## How the check runs
 
@@ -182,7 +214,8 @@ positives on a clean tree.
 - `symbol '<x>' not found in disassembly of <o>` — the impl was inlined away
   (no address taken, so no symbol emitted), or the symbol is in a different
   `.o` than declared. Skipped-with-warning by default; a hard failure if the
-  tuple declares `REQUIRE_STANDALONE`.
+  tuple declares `REQUIRE_STANDALONE`. Aggregate skips are bounded by the
+  zero-coverage guard (see above).
 - `require_standalone assertion FAILED: implementation was not emitted as a
   standalone dispatchable symbol (inlined away)` — a tuple declaring
   `REQUIRE_STANDALONE` had its impl inlined away; the build fails (exit 1).
@@ -253,7 +286,9 @@ equivalence violation, while still hard-failing on a genuine divergence.
   (`data16 cs nopw …`); treated as padding like the NOP family.
 - **Symbol not emitted standalone** (e.g. macOS clang inlines the impl): there
   is nothing to compare, so the tuple is **skipped with a warning** and the
-  build stays green. The summary line reports `N skipped`. (Exception: a tuple
+  build stays green — unless the skip leaves a kernel (or the whole run) with
+  zero checked tuples, which the zero-coverage guard turns into a hard failure
+  (exit 1). The summary line reports `N skipped`. (Exception: a tuple
   that declares `REQUIRE_STANDALONE` hard-fails instead — see *Require-standalone
   assertion*.)
 

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -532,19 +532,30 @@ def test_require_standalone_inlined_hard_fails():
 
 
 def test_unmarked_inlined_still_skips():
-    """Negative control: the same inlined-away condition WITHOUT the opt-in keeps
-    today's behavior -- skip-with-warning, exit 0 (the build stays green)."""
+    """Negative control: an inlined-away tuple WITHOUT the opt-in keeps
+    skip-with-warning behavior -- exit 0 -- provided the kernel retains real
+    coverage (a second, checked tuple in the SAME kernel). The all-skip
+    configuration is now a zero-coverage failure (mtibbits/volk#165),
+    covered separately."""
     cc, objdump, o = _compile_present_fn_o("reqstandalone_skip")
     if not cc:
         print("  (skip test_unmarked_inlined_still_skips: no cc)")
         return
-    manifest = {"tuples": [{
-        "kernel": "nc", "isa": "avx", "alignment": "a",
-        "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
-        "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
-        "criterion": "byte_identical",
-        # no require_standalone
-    }]}
+    manifest = {"tuples": [
+        {
+            "kernel": "nc", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+            # no require_standalone
+        },
+        {
+            "kernel": "nc", "isa": "avx", "alignment": "u",
+            "impl_a": {"symbol": "present_fn", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+    ]}
     mpath = Path("/tmp/cge_reqstandalone_skip_manifest.json")
     mpath.write_text(json.dumps(manifest))
     result = subprocess.run(
@@ -553,6 +564,159 @@ def test_unmarked_inlined_still_skips():
         capture_output=True, text=True)
     assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
     assert "WARNING: skipping nc.avx.a" in result.stderr, result.stderr
+    assert "1 tuples checked" in result.stdout, result.stdout
+
+
+def test_all_skipped_zero_coverage_fails():
+    """Global zero coverage: every declared tuple skips (inlined away), so
+    nothing was verified -- the run must FAIL loudly, not print
+    `ok (0 tuples checked)` (mtibbits/volk#165)."""
+    cc, objdump, o = _compile_present_fn_o("zerocov_global")
+    if not cc:
+        print("  (skip test_all_skipped_zero_coverage_fails: no cc)")
+        return
+    manifest = {"tuples": [
+        {
+            "kernel": "ka", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+        {
+            "kernel": "kb", "isa": "avx", "alignment": "u",
+            "impl_a": {"symbol": "also_inlined_away", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+    ]}
+    mpath = Path("/tmp/cge_zerocov_global_manifest.json")
+    mpath.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(mpath),
+         "--build-lib-dir", "/tmp", "--objdump", objdump],
+        capture_output=True, text=True)
+    assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+    assert "CHECK FAILED" in result.stderr, result.stderr
+    assert "zero coverage" in result.stderr, result.stderr
+    assert "ok (" not in result.stdout, result.stdout
+
+
+def test_per_kernel_all_skip_fails():
+    """Per-kernel all-skip: kernel `hole` has every tuple skipped while kernel
+    `covd` is checked -- the run must name `hole` in the coverage diagnostic
+    and exit non-zero; `covd` (which has coverage) must not be flagged
+    (mtibbits/volk#165)."""
+    cc, objdump, o = _compile_present_fn_o("zerocov_kernel")
+    if not cc:
+        print("  (skip test_per_kernel_all_skip_fails: no cc)")
+        return
+    manifest = {"tuples": [
+        {
+            "kernel": "hole", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+        {
+            "kernel": "covd", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "present_fn", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+    ]}
+    mpath = Path("/tmp/cge_zerocov_kernel_manifest.json")
+    mpath.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(mpath),
+         "--build-lib-dir", "/tmp", "--objdump", objdump],
+        capture_output=True, text=True)
+    assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+    assert "CHECK FAILED" in result.stderr, result.stderr
+    guard_lines = [l for l in result.stderr.splitlines()
+                   if "zero codegen coverage for kernel(s):" in l]
+    assert guard_lines, result.stderr
+    assert "hole" in guard_lines[0], result.stderr
+    assert "covd" not in guard_lines[0], result.stderr
+
+
+def test_partial_kernel_coverage_ok():
+    """A kernel with >=1 checked tuple is covered even if its other tuples
+    skip: one skip within kernel `pk` (which also has a checked tuple) stays
+    exit 0. Guards the per-kernel check against over-firing
+    (mtibbits/volk#165)."""
+    cc, objdump, o = _compile_present_fn_o("partialcov")
+    if not cc:
+        print("  (skip test_partial_kernel_coverage_ok: no cc)")
+        return
+    manifest = {"tuples": [
+        {
+            "kernel": "pk", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "present_fn", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+        {
+            "kernel": "pk", "isa": "avx", "alignment": "u",
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+    ]}
+    mpath = Path("/tmp/cge_partialcov_manifest.json")
+    mpath.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(mpath),
+         "--build-lib-dir", "/tmp", "--objdump", objdump],
+        capture_output=True, text=True)
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert "1 tuples checked" in result.stdout, result.stdout
+
+
+def test_divergence_precedes_coverage_guard():
+    """Ordering pin: a real divergence in kernel `dv` plus an all-skip kernel
+    `hole2` must report the DIVERGENCE (per-tuple diff, exit 1), not the
+    coverage message -- the guard sits after the failures exit and must never
+    mask a divergence diagnostic (mtibbits/volk#165). Green before and after
+    the guard lands; it pins the guard's position, not its existence."""
+    import shutil
+    cc = shutil.which("cc")
+    if not cc:
+        print("  (skip test_divergence_precedes_coverage_guard: no cc)")
+        return
+    objdump = _which_objdump()
+    add = ("#include <immintrin.h>\n"
+           "__m256 dv_fn(__m256 a,__m256 b){return _mm256_add_ps(a,b);}\n")
+    mul = ("#include <immintrin.h>\n"
+           "__m256 dv_fn(__m256 a,__m256 b){return _mm256_mul_ps(a,b);}\n")
+    a_c = Path("/tmp/cge_dv_a.c"); a_c.write_text(add)
+    b_c = Path("/tmp/cge_dv_b.c"); b_c.write_text(mul)
+    a_o = Path("/tmp/cge_dv_a.o"); b_o = Path("/tmp/cge_dv_b.o")
+    for s, o in ((a_c, a_o), (b_c, b_o)):
+        subprocess.run([cc, "-O3", "-mavx", "-c", str(s), "-o", str(o)],
+                       check=True)
+    manifest = {"tuples": [
+        {
+            "kernel": "dv", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "dv_fn", "machine_o": str(a_o)},
+            "impl_b": {"symbol": "dv_fn", "machine_o": str(b_o)},
+            "criterion": "byte_identical",
+        },
+        {
+            "kernel": "hole2", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(a_o)},
+            "impl_b": {"symbol": "dv_fn", "machine_o": str(a_o)},
+            "criterion": "byte_identical",
+        },
+    ]}
+    mpath = Path("/tmp/cge_dv_guard_manifest.json")
+    mpath.write_text(json.dumps(manifest))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(mpath),
+         "--build-lib-dir", "/tmp", "--objdump", objdump],
+        capture_output=True, text=True)
+    assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+    assert "byte_identical comparison FAILED" in result.stderr, result.stderr
+    assert "zero codegen coverage" not in result.stderr, result.stderr
 
 
 def main():

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -678,33 +678,27 @@ def test_divergence_precedes_coverage_guard():
     coverage message -- the guard sits after the failures exit and must never
     mask a divergence diagnostic (mtibbits/volk#165). Green before and after
     the guard lands; it pins the guard's position, not its existence."""
-    import shutil
-    cc = shutil.which("cc")
+    cc, objdump, o = _compile_present_fn_o("dv_guard")
     if not cc:
         print("  (skip test_divergence_precedes_coverage_guard: no cc)")
         return
-    objdump = _which_objdump()
-    add = ("#include <immintrin.h>\n"
-           "__m256 dv_fn(__m256 a,__m256 b){return _mm256_add_ps(a,b);}\n")
     mul = ("#include <immintrin.h>\n"
-           "__m256 dv_fn(__m256 a,__m256 b){return _mm256_mul_ps(a,b);}\n")
-    a_c = Path("/tmp/cge_dv_a.c"); a_c.write_text(add)
-    b_c = Path("/tmp/cge_dv_b.c"); b_c.write_text(mul)
-    a_o = Path("/tmp/cge_dv_a.o"); b_o = Path("/tmp/cge_dv_b.o")
-    for s, o in ((a_c, a_o), (b_c, b_o)):
-        subprocess.run([cc, "-O3", "-mavx", "-c", str(s), "-o", str(o)],
-                       check=True)
+           "__m256 present_fn(__m256 a,__m256 b){return _mm256_mul_ps(a,b);}\n")
+    b_c = Path("/tmp/cge_dv_mul.c"); b_c.write_text(mul)
+    b_o = Path("/tmp/cge_dv_mul.o")
+    subprocess.run([cc, "-O3", "-mavx", "-c", str(b_c), "-o", str(b_o)],
+                   check=True)
     manifest = {"tuples": [
         {
             "kernel": "dv", "isa": "avx", "alignment": "a",
-            "impl_a": {"symbol": "dv_fn", "machine_o": str(a_o)},
-            "impl_b": {"symbol": "dv_fn", "machine_o": str(b_o)},
+            "impl_a": {"symbol": "present_fn", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(b_o)},
             "criterion": "byte_identical",
         },
         {
             "kernel": "hole2", "isa": "avx", "alignment": "a",
-            "impl_a": {"symbol": "inlined_away", "machine_o": str(a_o)},
-            "impl_b": {"symbol": "dv_fn", "machine_o": str(a_o)},
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
             "criterion": "byte_identical",
         },
     ]}

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -602,9 +602,11 @@ def test_all_skipped_zero_coverage_fails():
 
 
 def test_per_kernel_all_skip_fails():
-    """Per-kernel all-skip: kernel `hole` has every tuple skipped while kernel
-    `covd` is checked -- the run must name `hole` in the coverage diagnostic
-    and exit non-zero; `covd` (which has coverage) must not be flagged
+    """Per-kernel all-skip: kernels `bhole` and `ahole` have every tuple
+    skipped while kernel `covd` is checked (with one additional skip of its
+    own) -- the run must name the hole kernels sorted in the coverage
+    diagnostic and exit non-zero; `covd` (which has coverage) must not be
+    flagged, and its skipped tuple must not be listed as removable
     (mtibbits/volk#165)."""
     cc, objdump, o = _compile_present_fn_o("zerocov_kernel")
     if not cc:
@@ -612,7 +614,13 @@ def test_per_kernel_all_skip_fails():
         return
     manifest = {"tuples": [
         {
-            "kernel": "hole", "isa": "avx", "alignment": "a",
+            "kernel": "bhole", "isa": "avx", "alignment": "a",
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+        {
+            "kernel": "ahole", "isa": "avx", "alignment": "a",
             "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
             "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
             "criterion": "byte_identical",
@@ -620,6 +628,12 @@ def test_per_kernel_all_skip_fails():
         {
             "kernel": "covd", "isa": "avx", "alignment": "a",
             "impl_a": {"symbol": "present_fn", "machine_o": str(o)},
+            "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
+            "criterion": "byte_identical",
+        },
+        {
+            "kernel": "covd", "isa": "avx", "alignment": "u",
+            "impl_a": {"symbol": "inlined_away", "machine_o": str(o)},
             "impl_b": {"symbol": "present_fn", "machine_o": str(o)},
             "criterion": "byte_identical",
         },
@@ -635,8 +649,14 @@ def test_per_kernel_all_skip_fails():
     guard_lines = [ln for ln in result.stderr.splitlines()
                    if "zero codegen coverage for kernel(s):" in ln]
     assert guard_lines, result.stderr
-    assert "hole" in guard_lines[0], result.stderr
+    assert "kernel(s): ahole, bhole" in guard_lines[0], result.stderr
     assert "covd" not in guard_lines[0], result.stderr
+    skip_lines = [ln for ln in result.stderr.splitlines()
+                  if ln.startswith("  skipped:")]
+    assert skip_lines, result.stderr
+    assert "ahole.avx.a" in skip_lines[0], result.stderr
+    assert "bhole.avx.a" in skip_lines[0], result.stderr
+    assert "covd" not in skip_lines[0], result.stderr
 
 
 def test_partial_kernel_coverage_ok():

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -632,8 +632,8 @@ def test_per_kernel_all_skip_fails():
         capture_output=True, text=True)
     assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
     assert "CHECK FAILED" in result.stderr, result.stderr
-    guard_lines = [l for l in result.stderr.splitlines()
-                   if "zero codegen coverage for kernel(s):" in l]
+    guard_lines = [ln for ln in result.stderr.splitlines()
+                   if "zero codegen coverage for kernel(s):" in ln]
     assert guard_lines, result.stderr
     assert "hole" in guard_lines[0], result.stderr
     assert "covd" not in guard_lines[0], result.stderr


### PR DESCRIPTION
## Summary

The codegen-equivalence check (`cmake/check_framework_codegen.py`) could report success while verifying nothing: skips (compiler inlined an impl rather than emitting it standalone) were counted but never judged, so a run where **every** declared tuple skipped — or where **one kernel's** tuples all skipped while others were checked — still printed `ok (0 tuples checked)` and exited 0. A toolchain change that starts inlining the compared impls would silently turn the guard into a no-op (the defect class behind the existing #78/#79/#83 hard-fail paths). This PR adds per-kernel skip accounting and a zero-coverage guard on the otherwise-green path: global all-skip fails with `CHECK FAILED: zero coverage`; a per-kernel hole fails with `CHECK FAILED: zero codegen coverage for kernel(s): <names>`. Both exit 1, name the likely cause (toolchain inlining) and the remedies, and are ordered after the divergence/error exits so a real divergence keeps its per-tuple diff. The legitimate empty-manifest early-out (`ok (0 tuples declared)`, exit 0) and full-coverage runs are byte-for-byte unchanged. The guard's blind spots are documented beside it (bare-kernel aggregation tolerates ISA-level holes; silently-undeclared tuples land in the 0-declared path).

**Known consequence (accepted deliberately):** the `macos-15-intel` CI lane currently sits in the global-zero state — measured on run 30557152264: `ok (0 tuples checked, 1 skipped)`, macOS clang inlines the one production tuple — so that lane will fail once this merges, by design (the guard is the forcing function). The standalone-emission remediation is filed as #225. All Linux x86_64 lanes check 1 tuple and stay green; Windows/static-dispatch/ARM/s390x/ppc64le/macOS-arm64 declare 0 tuples and are unaffected. Note the check is a hard dependency of the `volk` shared-lib target, so the new exit 1 fails the **build itself** — it binds any downstream builder whose toolchain inlines the impl, not only the measured CI lane, and there is deliberately no opt-out. Be explicit about one semantic consequence: with today's single-tuple manifest, the global facet amounts to a mandatory standalone-emission requirement on that tuple for every platform that declares it — i.e. it subsumes #164's opt-in `require_standalone` for the current manifest (the axes only separate once more tuples are declared). Until #225 lands, treat further `macos-15-intel` failures on other PRs as pre-explained by this guard **only** if the failure text is `CHECK FAILED: zero coverage` — any other failure on that lane is new signal, not this guard.

## Related issues

Related: #165 (fork-tracking issue — left open per fork workflow), #145 (parent; deferred both facets to this change), #164 (per-tuple `require_standalone` opt-in — subsumed by the global facet at today's single-tuple manifest; see Summary), #225 (macOS standalone-emission remediation — this guard's forcing-function target, filed before merge).

## Testing

- 5 tests added/updated in `cmake/test_check_framework_codegen.py`: both facets born red against the unguarded script (recorded observed rc 0 + the silent `ok (...)` line) and flipped green by the guard; a partial-coverage control (kernel with ≥1 checked tuple is not flagged); a divergence-precedence pin (divergent kernel + all-skip kernel → per-tuple diff, not the coverage message); the pre-existing unmarked-inline negative control extended with a same-kernel checked tuple so its intent survives. The per-kernel test also pins the sorted multi-kernel headline (`ahole, bhole`) and that a covered kernel's incidental skip is excluded from the removable-tuples list (review fix, itself born red against the pre-fix guard).
- Self-runner suite: 29/29 at `65d0e9cf`, zero `no cc` self-skips (toolchain present — run is non-vacuous). Fresh-context review (opus): 0 Critical, 2 Important (both fixed in `c8588246`), 6 Minor (4 doc fixes applied; 2 record-keeping items applied to the issue artifacts). Fresh-context red-team (opus): 1 blocking (remediation untracked — resolved by filing #225 pre-merge), 2 major (diagnostic remedy ordering fixed in `65d0e9cf`; #164-subsumption framing corrected in this body), 1 minor (skipped-list derivation hardened in `65d0e9cf`), 3 info (accepted as-is).
- Real-manifest smoke: fresh CMake configure+build, `volk_check_framework_codegen` target prints `codegen-equivalence: ok (1 tuples checked)` against the genuinely generated manifest.
- Analyzers (changed lines): cppcheck/cpplint/clang-tidy/scan-build/iwyu/clang-format/cmake-lint/codespell/mypy/compiler clean; ruff/flake8 E741 fixed in `d7a4bb4b`, E702 + bandit B101/B108/B603 dismissed as the test file's pre-existing idiom (asserts + `/tmp` fixtures in a test harness).
- Sanitizers: ASan+UBSan and TSan builds, ctest 256/256 pass each.

## Evidence
<!-- Filled by /devagent:draftmr from the newest analysis/<date>-suite-count.txt
     (run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/run-suite.sh"` first). Machine-checked by preship (#359) — do not
     hand-edit the two lines below. The optional 'born-red:' line is filled from a
     born-red artifact (#362) when present.
     A project with NEITHER bats nor pytest uses the no-framework form instead:
       suite: none @ <sha>
     (preship reconciles it against a `bats: (none)` + `pytest: (none)` artifact — #411). -->
suite: none @ 65d0e9cf505989a3b980eda7a8bfcdbfef7b2a17
files: 4 changed

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`) — 256/256 under ASan+UBSan and TSan
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
