### PR TITLE
canary TU UBSan alignment exemption

### DIFF
--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -223,7 +223,10 @@ Retention: latest snapshot only — a new snapshot replaces the old files
   (`qa_canary_kernel.cc`) is compiled with `-fno-sanitize=alignment` so a strict
   UBSan lane (`halt_on_error=1`) can run the misaligned mode — the planted
   `movaps` still faults; only the pre-fault UBSan report is suppressed, and only
-  for that one test-only TU (#221).
+  for that one test-only TU (#221). The exemption follows the ASAN build type
+  only: a UBSan build configured another way (e.g. `-DCMAKE_BUILD_TYPE=Debug`
+  with `-fsanitize=undefined` in `CMAKE_CXX_FLAGS`) still reports the planted
+  load under `halt_on_error=1`.
 - **Default qa:** `volk_test_all` and the per-kernel `qa_volk_*` ctests are
   byte-for-byte unaffected by every capability here; all harness behavior is
   opt-in via the env toggles.

--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -219,7 +219,11 @@ Retention: latest snapshot only — a new snapshot replaces the old files
   mode compiles to an explicit skip (no POSIX signals); everything else —
   including the combined negative control ctest — runs.
 - **ASan builds:** canary far-past demo is gated to ASan; misaligned mode needs
-  the `ASAN_OPTIONS` above.
+  the `ASAN_OPTIONS` above. Under the ASAN build type the control-kernel TU
+  (`qa_canary_kernel.cc`) is compiled with `-fno-sanitize=alignment` so a strict
+  UBSan lane (`halt_on_error=1`) can run the misaligned mode — the planted
+  `movaps` still faults; only the pre-fault UBSan report is suppressed, and only
+  for that one test-only TU (#221).
 - **Default qa:** `volk_test_all` and the per-kernel `qa_volk_*` ctests are
   byte-for-byte unaffected by every capability here; all harness behavior is
   opt-in via the env toggles.

--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -29,7 +29,7 @@ environment variable:
 | `HARNESS_CANARY=1` | output-buffer canary: guarded own-malloc buffers, two-sentinel over/under-write + unwritten-element checks | #89 |
 | `HARNESS_CANARY_ASAN_DEMO=1` | (with `HARNESS_CANARY`, ASan build only) far-past over-run demo proving the guarded buffers are ASan-bracketed | #89 |
 | `HARNESS_IMMUTABLE=1` | input-immutability canary: byte-exact post-run compare of every input against its pristine pre-image | #90 |
-| `HARNESS_MISALIGNED=1` | misaligned `_u_`-variant runs: every unaligned impl on deliberately misaligned buffers, with scoped signal trapping (POSIX only) | #91 |
+| `HARNESS_MISALIGNED=1` | misaligned `_u_`-variant runs: every unaligned impl on deliberately misaligned buffers, with scoped signal trapping (POSIX only); strict-UBSan regression detector is the ctest `qa_strict_misaligned_canary` (ASAN build type only) | #91 / #221 |
 | `HARNESS_COMBINED_NC=1` | combined negative control (the ctest `qa_harness_negative_control`) | #92 |
 | `HARNESS_REPORT=path` | write the per-kernel × per-impl CSV (format below) in any mode | #87 / #92 |
 | `HARNESS_VERBOSE=1` | unmute the per-impl stdout of the underlying qa runs | — |
@@ -223,7 +223,9 @@ Retention: latest snapshot only — a new snapshot replaces the old files
   (`qa_canary_kernel.cc`) is compiled with `-fno-sanitize=alignment` so a strict
   UBSan lane (`halt_on_error=1`) can run the misaligned mode — the planted
   `movaps` still faults; only the pre-fault UBSan report is suppressed, and only
-  for that one test-only TU (#221). The exemption follows the ASAN build type
+  for that one test-only TU (#221). The ctest `qa_strict_misaligned_canary`
+  (registered on ASAN builds only) runs the strict misaligned mode and goes red
+  if the exemption is ever lost. The exemption follows the ASAN build type
   only: a UBSan build configured another way (e.g. `-DCMAKE_BUILD_TYPE=Debug`
   with `-fsanitize=undefined` in `CMAKE_CXX_FLAGS`) still reports the planted
   load under `halt_on_error=1`.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -898,10 +898,22 @@ if(ENABLE_TESTING)
     # TU under the sanitizer build type (#221; details: harness README,
     # Platform notes). A function-level no_sanitize attribute does NOT work
     # here -- GCC generates the check inside the always-inlined _mm_load_ps.
-    if(CBTU STREQUAL "ASAN")
-        set_source_files_properties(
-            ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
-            PROPERTIES COMPILE_OPTIONS "-fno-sanitize=alignment")
+    # The qa_strict_misaligned_canary ctest is the regression detector: it
+    # goes red if the exemption is dropped, stops reaching the compile line,
+    # or the canary stops faulting (NC-LOST exit 2).
+    if(NOT WIN32 AND CBTU STREQUAL "ASAN")
+        set_property(
+            SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
+            APPEND
+            PROPERTY COMPILE_OPTIONS "-fno-sanitize=alignment")
+        add_test(NAME qa_strict_misaligned_canary
+                 COMMAND volk_test_correctness volk_32f_x3_sum_of_poly_32f)
+        set_tests_properties(
+            qa_strict_misaligned_canary
+            PROPERTIES
+                ENVIRONMENT
+                "HARNESS_MISALIGNED=1;UBSAN_OPTIONS=halt_on_error=1;ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1"
+        )
     endif()
     target_link_libraries(volk_test_all fmt::fmt)
     target_link_libraries(volk_test_correctness fmt::fmt)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -892,6 +892,19 @@ if(ENABLE_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_buffer_roles.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk)
     endif()
+    # The planted negative-control kernel (volk_32f_misalignedfault_32f)
+    # deliberately executes an alignment-checked load (movaps) on misaligned
+    # memory. UBSan's alignment check reports it before the deliberate fault
+    # fires, so a strict lane (halt_on_error=1) exits at the report and the
+    # misaligned mode never completes (#221). Exempt this one test-only TU
+    # from the alignment check under the sanitizer build type; the raw movaps
+    # is retained, so the fault-recording proof and the NC-LOST exit-2 path
+    # are unchanged.
+    if(CBTU STREQUAL "ASAN")
+        set_source_files_properties(
+            ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
+            PROPERTIES COMPILE_OPTIONS "-fno-sanitize=alignment")
+    endif()
     target_link_libraries(volk_test_all fmt::fmt)
     target_link_libraries(volk_test_correctness fmt::fmt)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -892,14 +892,12 @@ if(ENABLE_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_buffer_roles.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk)
     endif()
-    # The planted negative-control kernel (volk_32f_misalignedfault_32f)
-    # deliberately executes an alignment-checked load (movaps) on misaligned
-    # memory. UBSan's alignment check reports it before the deliberate fault
-    # fires, so a strict lane (halt_on_error=1) exits at the report and the
-    # misaligned mode never completes (#221). Exempt this one test-only TU
-    # from the alignment check under the sanitizer build type; the raw movaps
-    # is retained, so the fault-recording proof and the NC-LOST exit-2 path
-    # are unchanged.
+    # The planted misaligned-fault control must keep its raw movaps, but
+    # UBSan's alignment check reports it BEFORE the deliberate fault, so a
+    # strict lane (halt_on_error=1) dies pre-sweep. Exempt this one test-only
+    # TU under the sanitizer build type (#221; details: harness README,
+    # Platform notes). A function-level no_sanitize attribute does NOT work
+    # here — GCC generates the check inside the always-inlined _mm_load_ps.
     if(CBTU STREQUAL "ASAN")
         set_source_files_properties(
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -897,7 +897,7 @@ if(ENABLE_TESTING)
     # strict lane (halt_on_error=1) dies pre-sweep. Exempt this one test-only
     # TU under the sanitizer build type (#221; details: harness README,
     # Platform notes). A function-level no_sanitize attribute does NOT work
-    # here — GCC generates the check inside the always-inlined _mm_load_ps.
+    # here -- GCC generates the check inside the always-inlined _mm_load_ps.
     if(CBTU STREQUAL "ASAN")
         set_source_files_properties(
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc

--- a/lib/qa_canary_kernel.cc
+++ b/lib/qa_canary_kernel.cc
@@ -7,6 +7,10 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+// Under the ASAN build type this TU is compiled with -fno-sanitize=alignment
+// (see lib/CMakeLists.txt, #221): UBSan will NOT report misaligned access from
+// anything added to this file — the planted faults must stay real faults.
+
 #include "qa_canary_kernel.h"
 
 #include "volk/volk_complex.h" // lv_32fc_t/lv_cmake (planted power pair, #92)


### PR DESCRIPTION
## Summary

Under the fork's ASAN build type (`-fsanitize=address -fsanitize=undefined`), the planted negative-control kernel `volk_32f_misalignedfault_32f` deliberately executes an alignment-checked load (`movaps`) on misaligned memory — and UBSan's alignment check reports it *before* the deliberate fault runs. With the strict lane setting `UBSAN_OPTIONS=halt_on_error=1`, UBSan exits at that report, so the `HARNESS_MISALIGNED` mode cannot complete at all (#221). This PR compiles the one test-only control-kernel TU (`lib/qa_canary_kernel.cc`) with `-fno-sanitize=alignment`, scoped to the ASAN build type via `set_source_files_properties`, and extends the harness README's ASan platform note accordingly. The raw `movaps` is retained: the deliberate SIGSEGV still fires and is recorded, and the NC-LOST `exit 2` fail-loud path still trips when the fault is lost (mutation-verified below). A new ASAN-gated ctest, `qa_strict_misaligned_canary`, ships with the fix as its regression detector — it runs the strict misaligned mode and goes red if the exemption is ever dropped, stops reaching the compile line, or the canary stops faulting. Function-level `no_sanitize` attributes and UBSan suppression files were both verified ineffective in the issue (GCC generates the check inside the always-inlined `_mm_load_ps`; suppressions key on the report site `xmmintrin.h`), so the TU-scoped flag is the smallest working change — the CMake comment now records this so the attribute non-fix doesn't get "re-simplified" back in later.

## Related issues

Closes #221

## Testing

Before (baseline `8c0886a2`, unfixed) vs after (this branch), all runs with `ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1`:

- **Before, strict** (`UBSAN_OPTIONS=halt_on_error=1 HARNESS_MISALIGNED=1`, single kernel): exit 1 at the UBSan report, no sweep output —
  ```
  xmmintrin.h:933:21: runtime error: load of misaligned address ... for type '__m128'
  ```
- **After, strict single kernel**: exit 0, zero `runtime error` lines, `misaligned negative control OK: ok-kernel clean, aligned-load kernel crash recorded and the run continued.`
- **After, strict full sweep**: exit 0 —
  ```
  misaligned sweep: 0 kernels crashed, 0 diverged, of 113 tested (unaligned impls only)
  ```
- **Flag scope (AC4)**: `compile_commands.json` shows `-fno-sanitize=alignment` on exactly 1 compile entry (`qa_canary_kernel.cc`), ordered after `-fsanitize=undefined`.
- **Release untouched (AC2)**: Release-configure `compile_commands.json` contains 0 occurrences of the flag, and `ctest -N` in the Release build registers 0 instances of the new regression test; the shipped diff is `lib/CMakeLists.txt`, the harness README note, and a marker comment atop `qa_canary_kernel.cc`.
- **NC-LOST fail-loud still live (AC3)**: with the canary temporarily mutated to `_mm_loadu_ps`, the strict run exits 2 with `NEGATIVE CONTROL LOST: the planted aligned-load kernel volk_32f_misalignedfault_32f did not produce a recorded crash`; restored, exit 0 again. Mutation never committed.
- **Sibling controls**: the `qa_harness_negative_control` ctest (power/tanh controls in the same TU) passes with identical verdicts before and after — this pins the harness's own verdicts for those controls; none of the sibling controls ever depended on a UBSan alignment report, so alignment reporting for them was not separately measured (the TU-wide flag suppresses it by construction, which is what the new marker comment in the TU warns future control authors about).
- **Regression detector (new)**: `qa_strict_misaligned_canary` — ASAN-build-type-gated ctest running the strict misaligned mode, named in the harness README beside the mode it guards. Mutation-proven live (artifact `analysis/mutation-ctest-red.log`): with the exemption property neutered, `ctest` reports `1/1 failed` (exit 8); restored, `1/1 passed` (exit 0).
- **Regression hygiene** (branch-wide, not strict-mode coverage — those builds don't carry the flag and never set `HARNESS_MISALIGNED`): cppcheck/cpplint/clang-tidy/iwyu/clang-format/cmake-lint/codespell/ruff/flake8/bandit/mypy/compiler — 0 novel findings on changed lines; scan-build, ASan+UBSan, TSan passes all green.
- **Scope decision (stated per red-team)**: the gate deliberately keys on the ASAN build type — the configuration #221's own repro, prescription, and AC1 are written against — and the README states explicitly that a UBSan build configured via `CMAKE_CXX_FLAGS` on another build type still reports. Widening the gate to a flag-sniffing condition is an unverified mechanism and is deferred as a tracked follow-up (see the issue's future-enhancements record; to be promoted via the fork's reap pipeline). All five acceptance criteria of #221 as filed are met, hence `Closes`.

## Evidence

suite: none @ 2fe671ded5f63903d6c48885073ab8528d3a900e
files: 3 changed

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
