### PR TITLE
macos codegen symbol mangling

### DIFF
--- a/cmake/CodegenEquivalence.cmake
+++ b/cmake/CodegenEquivalence.cmake
@@ -36,9 +36,9 @@ function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
     # bare keyword (no value) for a tuple whose dispatch relies on the impl
     # existing as a real, separately-dispatchable symbol. When set, the harness
     # treats a not-found label (SymbolNotEmittedError -- genuinely inlined
-    # away, or absent) as a hard failure instead of
-    # skip-with-warning. Omitted -> today's skip-with-warning behavior (subject
-    # to the aggregate zero-coverage guard, mtibbits/volk#165).
+    # away, or absent) as a hard failure instead of skip-with-warning.
+    # Omitted -> today's skip-with-warning behavior (subject to the
+    # aggregate zero-coverage guard, mtibbits/volk#165).
     cmake_parse_arguments(CGE
         "REQUIRE_STANDALONE" "${required_args};REQUIRE_MNEMONIC" "" ${ARGN})
 

--- a/cmake/CodegenEquivalence.cmake
+++ b/cmake/CodegenEquivalence.cmake
@@ -35,7 +35,8 @@ function(ADD_CODEGEN_EQUIVALENCE_TUPLE)
     # REQUIRE_STANDALONE is an OPTIONAL boolean flag (orthogonal axis): pass the
     # bare keyword (no value) for a tuple whose dispatch relies on the impl
     # existing as a real, separately-dispatchable symbol. When set, the harness
-    # treats "inlined away" (SymbolNotEmittedError) as a hard failure instead of
+    # treats a not-found label (SymbolNotEmittedError -- genuinely inlined
+    # away, or absent) as a hard failure instead of
     # skip-with-warning. Omitted -> today's skip-with-warning behavior (subject
     # to the aggregate zero-coverage guard, mtibbits/volk#165).
     cmake_parse_arguments(CGE

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -369,7 +369,8 @@ def extract_function_body(o_file: Path, symbol: str,
     text = _disassemble(o_file, objdump, symbol=label)
     try:
         return extract_function_body_from_text(text, label,
-                                               source_label=str(o_file))
+                                               source_label=str(o_file),
+                                               c_symbol=symbol)
     except SymbolNotEmittedError:
         if not _uses_symbol_filter(objdump):
             raise
@@ -382,11 +383,13 @@ def extract_function_body(o_file: Path, symbol: str,
         # (mtibbits/volk#225).
         text = _disassemble(o_file, objdump)
         return extract_function_body_from_text(text, label,
-                                               source_label=str(o_file))
+                                               source_label=str(o_file),
+                                               c_symbol=symbol)
 
 
 def extract_function_body_from_text(text: str, label: str,
-                                    source_label: str = "<disassembly>") -> list:
+                                    source_label: str = "<disassembly>",
+                                    c_symbol: str = None) -> list:
     """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
     the object-file label `label` in `text` (on Mach-O, callers pass the
     underscore-prefixed label object_symbol_name() produced -- the underscore
@@ -397,7 +400,11 @@ def extract_function_body_from_text(text: str, label: str,
 
     Raises SymbolNotEmittedError if the label is absent (inlined, not emitted
     standalone) and RuntimeError if an in-body line is unparsable and not
-    recognizable padding, or if the body is empty.
+    recognizable padding, or if the body is empty. `c_symbol`, when given and
+    different from `label`, is quoted in the not-found message so a CI-log
+    reader can grep the manifest/tree for the name that actually appears
+    there (the label's underscore is the harness's Mach-O mapping and exists
+    nowhere in the sources).
     """
     in_body = False
     saw_symbol = False
@@ -459,8 +466,10 @@ def extract_function_body_from_text(text: str, label: str,
             hint = f"similar labels present: {shown}{more}"
         else:
             hint = f"no similar labels among {len(labels_seen)} seen"
+        c_note = (f" (C symbol {c_symbol!r})"
+                  if c_symbol and c_symbol != label else "")
         raise SymbolNotEmittedError(
-            f"symbol label {label!r} not found in disassembly of "
+            f"symbol label {label!r}{c_note} not found in disassembly of "
             f"{source_label}. The impl must be emitted standalone (its "
             f"address taken for the dispatch table) for its label to appear "
             f"in the object file; {hint}.")

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -222,6 +222,46 @@ def resolve_object(build_lib_dir: Path, machine_o: str) -> Path:
         f"({len(matches)} matches): {[str(m) for m in matches]}")
 
 
+# Mach-O object-file magics (as the first 4 bytes appear on disk): thin
+# 64-/32-bit little-endian, and fat/universal (big-endian on disk) 32/64.
+_MACHO_MAGICS = {
+    b"\xcf\xfa\xed\xfe",  # MH_MAGIC_64
+    b"\xce\xfa\xed\xfe",  # MH_MAGIC
+    b"\xca\xfe\xba\xbe",  # FAT_MAGIC
+    b"\xca\xfe\xba\xbf",  # FAT_MAGIC_64
+}
+
+
+def object_symbol_name(o_file: Path, symbol: str) -> str:
+    """Map a C-level symbol name to the label it carries in this object file.
+
+    Mach-O (Darwin ABI) prepends an underscore to every C symbol, so the
+    disassembly label for volk_32f_x2_add_32f_a_avx is
+    _volk_32f_x2_add_32f_a_avx; ELF and COFF-x64 use the C name unchanged.
+    Keyed on the object file's magic bytes rather than the host platform so a
+    cross-compiled Mach-O object resolves correctly anywhere
+    (mtibbits/volk#225 -- on macOS the unprefixed lookup made the bootstrap
+    tuple skip as 'symbol not found', zero coverage under the #165 guard).
+
+    Blind-spot shape (what this helper CANNOT decide): detection is a
+    positive Mach-O check on 4 magics (thin LE 32/64 + fat 32/64).
+    Anything else -- ELF, COFF (which has no single 4-byte magic), or a
+    format outside the support set -- keeps the C name unchanged, which is
+    correct for every non-Mach-O lane CI builds today. Big-endian thin
+    Mach-O (ppc-era) is deliberately not recognized: no such target exists
+    in the CI matrix or support set. If a misclassification ever happens,
+    SymbolNotEmittedError's similar-labels report is the loud signal (the
+    underscored twin shows up there).
+    """
+    if not o_file.is_file():
+        raise RuntimeError(f"object file not found: {o_file}")
+    with o_file.open("rb") as f:
+        magic = f.read(4)
+    if magic in _MACHO_MAGICS:
+        return "_" + symbol
+    return symbol
+
+
 def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
     if not o_file.is_file():
         raise RuntimeError(f"object file not found: {o_file}")

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -29,7 +29,9 @@ Cross-compiler robustness (mtibbits/volk#145): benign codegen noise that differs
 by compiler is normalized away -- trailing alignment NOPs of any encoding and
 trailing `data16` padding are stripped (they pad the next function and belong to
 no function), and a symbol the compiler inlined rather than emitting standalone
-is skipped-with-warning since there is nothing to compare -- exit 0 only while
+is skipped-with-warning since there is nothing to compare (symbol names are
+first mapped to the object format's labels -- Mach-O prepends an underscore to
+C symbols, mtibbits/volk#225) -- exit 0 only while
 real coverage remains: a run where EVERY declared tuple skipped, or a kernel
 whose declared tuples ALL skipped, is a zero-coverage failure (exit 1;
 mtibbits/volk#165). A genuine post-normalization divergence still fails
@@ -76,14 +78,23 @@ from pathlib import Path
 
 
 class SymbolNotEmittedError(RuntimeError):
-    """The compared symbol is absent from the object file because the compiler
-    inlined it rather than emitting it standalone (e.g. macOS clang on some
-    impls). There is nothing to compare, so main() skips the tuple with a
-    warning rather than failing the build -- subject to the aggregate
-    zero-coverage guard: a run (or a single kernel) whose declared tuples ALL
-    skip fails loudly instead (mtibbits/volk#165). Distinct from the other
-    RuntimeError cases (missing/ambiguous .o, unparsable line) which remain
-    hard errors (mtibbits/volk#145).
+    """The compared label is absent from the object file's disassembly --
+    the compiler inlined the impl rather than emitting it standalone, or the
+    label genuinely is not there. There is nothing to compare, so main()
+    skips the tuple with a warning rather than failing the build -- subject
+    to the aggregate zero-coverage guard: a run (or a single kernel) whose
+    declared tuples ALL skip fails loudly instead (mtibbits/volk#165).
+    Distinct from the other RuntimeError cases (missing/ambiguous .o,
+    unparsable line) which remain hard errors (mtibbits/volk#145).
+
+    NOTE (mtibbits/volk#225): "not found" once had a second, non-inlining
+    cause -- Mach-O's leading-underscore C mangling made the unprefixed
+    lookup miss labels that WERE present (measured on a Linux cross-compile
+    probe: an address-taken static-inline impl compiled for
+    x86_64-apple-macos was emitted standalone as _volk_32f_x2_add_32f_a_avx).
+    object_symbol_name() now maps C name -> object-file label per the file's
+    magic, and the error text reports similar labels seen, so a naming
+    mismatch is loud instead of masquerading as inlining.
     """
 
 
@@ -581,7 +592,7 @@ def main():
                 failures.append((tuple_id(t), msg))
                 continue
             # Default: compiler inlined the impl rather than emitting it
-            # standalone (e.g. macOS clang): nothing to compare, so skip with a
+            # standalone: nothing to compare, so skip with a
             # loud warning instead of failing the build. A present-but-divergent
             # body is unaffected -- it still fails below.
             print(f"codegen-equivalence: WARNING: skipping {tuple_id(t)}: {e}",

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -30,9 +30,9 @@ by compiler is normalized away -- trailing alignment NOPs of any encoding and
 trailing `data16` padding are stripped (they pad the next function and belong to
 no function), and a symbol the compiler inlined rather than emitting standalone
 is skipped-with-warning since there is nothing to compare (symbol names are
-first mapped to the object format's labels -- Mach-O prepends an underscore to
-C symbols, mtibbits/volk#225) -- exit 0 only while
-real coverage remains: a run where EVERY declared tuple skipped, or a kernel
+first mapped to the object format's labels -- Mach-O prepends an underscore
+to C symbols, mtibbits/volk#225) -- exit 0 only while real coverage remains:
+a run where EVERY declared tuple skipped, or a kernel
 whose declared tuples ALL skipped, is a zero-coverage failure (exit 1;
 mtibbits/volk#165). A genuine post-normalization divergence still fails
 (exit 1); a genuinely unparsable non-padding line still errors (exit 2).
@@ -360,7 +360,10 @@ def extract_function_body(o_file: Path, symbol: str,
     callers and tests can pass a file path + objdump. On a not-found label
     after a FILTERED fast-path disassembly, retries unfiltered so the
     similar-labels report is computed from the whole object, not from
-    filter-emptied output.
+    filter-emptied output. The retry is behavior, not just diagnostics: if
+    the symbol filter fails to match a label that whole-object disassembly
+    does render (an objdump version/symbol-table quirk), the retry recovers
+    the extraction instead of skipping the tuple.
     """
     label = object_symbol_name(o_file, symbol)
     text = _disassemble(o_file, objdump, symbol=label)
@@ -447,7 +450,13 @@ def extract_function_body_from_text(text: str, label: str,
         near = [seen for seen in labels_seen
                 if label in seen or seen in label]
         if near:
-            hint = f"similar labels present: {sorted(near)[:8]}"
+            # Closest-length first so the exact underscore twin cannot be
+            # truncated out of the window; say when truncation happened.
+            near = sorted(near, key=lambda seen: (abs(len(seen) - len(label)),
+                                                  seen))
+            shown = near[:8]
+            more = f" (+{len(near) - len(shown)} more)" if len(near) > 8 else ""
+            hint = f"similar labels present: {shown}{more}"
         else:
             hint = f"no similar labels among {len(labels_seen)} seen"
         raise SymbolNotEmittedError(
@@ -625,9 +634,9 @@ def main():
                 failures.append((tuple_id(t), msg))
                 continue
             # Default: compiler inlined the impl rather than emitting it
-            # standalone: nothing to compare, so skip with a
-            # loud warning instead of failing the build. A present-but-divergent
-            # body is unaffected -- it still fails below.
+            # standalone: nothing to compare, so skip with a loud warning
+            # instead of failing the build. A present-but-divergent body is
+            # unaffected -- it still fails below.
             print(f"codegen-equivalence: WARNING: skipping {tuple_id(t)}: {e}",
                   file=sys.stderr)
             skipped.append(tuple_id(t))

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -444,7 +444,8 @@ def extract_function_body_from_text(text: str, label: str,
             instrs.append(_instr_from_match(mi))
 
     if not saw_symbol:
-        near = [l for l in labels_seen if label in l or l in label]
+        near = [seen for seen in labels_seen
+                if label in seen or seen in label]
         if near:
             hint = f"similar labels present: {sorted(near)[:8]}"
         else:

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -638,19 +638,20 @@ def main():
             b_instrs = extract_function_body(
                 b_o, t["impl_b"]["symbol"], objdump=args.objdump)
         except SymbolNotEmittedError as e:
-            # Opt-in (require_standalone): for tuples whose dispatch relies on the
-            # impl existing as a real, separately-dispatchable symbol, "inlined
-            # away" is a regression, not an acceptable outcome -- hard-fail it.
+            # Opt-in (require_standalone): for tuples whose dispatch relies
+            # on the impl existing as a real, separately-dispatchable symbol,
+            # a not-found label (inlined away, or absent under the name
+            # looked up) is a regression, not acceptable -- hard-fail it.
             if t.get("require_standalone"):
                 msg = ("require_standalone assertion FAILED: implementation "
                        "was not emitted as a standalone dispatchable symbol. "
                        f"{e}")
                 failures.append((tuple_id(t), msg))
                 continue
-            # Default: compiler inlined the impl rather than emitting it
-            # standalone: nothing to compare, so skip with a loud warning
-            # instead of failing the build. A present-but-divergent body is
-            # unaffected -- it still fails below.
+            # Default: no matching label in the object file -- inlined away,
+            # or emitted under a name we did not look up; nothing to compare,
+            # so skip with a loud warning instead of failing the build. A
+            # present-but-divergent body is unaffected -- it still fails below.
             print(f"codegen-equivalence: WARNING: skipping {tuple_id(t)}: {e}",
                   file=sys.stderr)
             skipped.append(tuple_id(t))
@@ -754,7 +755,8 @@ def main():
         print("Fix the build so the symbols are emitted standalone, or the "
               "harness's\nname->label mapping if the WARNING lines show the "
               "impl present under\nanother name (see the README's "
-              "require-standalone and object-label notes).\nRemoving the "
+              "'Object-file labels' and 'Require-standalone\nassertion' "
+              "sections). Removing the "
               "affected tuples from the manifest silences the check "
               "instead\nof fixing it -- a deliberate de-scoping that needs "
               "review, not an\nequivalent outcome. See mtibbits/volk#165.",

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -328,33 +328,42 @@ def _instr_from_match(m) -> dict:
 def extract_function_body(o_file: Path, symbol: str,
                           objdump: str = "llvm-objdump") -> list:
     """Disassemble `symbol` in o_file and return its whole-body instruction list.
-    Thin wrapper over extract_function_body_from_text (see it for the parse
-    contract); kept so callers and tests can pass a file path + objdump.
+    Maps the C name to the object file's label first (Mach-O prepends an
+    underscore, mtibbits/volk#225), then thin wrapper over
+    extract_function_body_from_text (see it for the parse contract); kept so
+    callers and tests can pass a file path + objdump.
     """
-    text = _disassemble(o_file, objdump, symbol=symbol)
-    return extract_function_body_from_text(text, symbol, source_label=str(o_file))
+    label = object_symbol_name(o_file, symbol)
+    text = _disassemble(o_file, objdump, symbol=label)
+    return extract_function_body_from_text(text, label,
+                                           source_label=str(o_file))
 
 
-def extract_function_body_from_text(text: str, symbol: str,
+def extract_function_body_from_text(text: str, label: str,
                                     source_label: str = "<disassembly>") -> list:
     """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
-    `symbol` in `text`: every instruction line from the `<symbol>:` header up to
-    (exclusive) the next symbol header or a blank line that ends the block.
-    Trailing inter-function padding (alignment NOPs / data16) is stripped.
+    the object-file label `label` in `text` (on Mach-O, callers pass the
+    underscore-prefixed label object_symbol_name() produced -- the underscore
+    is the harness's mapping, not part of the C name): every instruction line
+    from the `<label>:` header up to (exclusive) the next symbol header or a
+    blank line that ends the block. Trailing inter-function padding
+    (alignment NOPs / data16) is stripped.
 
-    Raises SymbolNotEmittedError if the symbol is absent (inlined, not emitted
+    Raises SymbolNotEmittedError if the label is absent (inlined, not emitted
     standalone) and RuntimeError if an in-body line is unparsable and not
     recognizable padding, or if the body is empty.
     """
     in_body = False
     saw_symbol = False
     instrs = []
+    labels_seen = []
 
     for line in text.splitlines():
         m = _label_line.match(line)
         if m:
-            label = m.group(1)
-            if label == symbol:
+            label_name = m.group(1)
+            labels_seen.append(label_name)
+            if label_name == label:
                 in_body = True
                 saw_symbol = True
                 continue
@@ -387,15 +396,21 @@ def extract_function_body_from_text(text: str, symbol: str,
                 # silently dropped: a dropped instruction would weaken the
                 # comparison without anyone noticing.
                 raise RuntimeError(
-                    f"unparsable disassembly line for {symbol!r} in "
+                    f"unparsable disassembly line for {label!r} in "
                     f"{source_label}: {line!r}")
             instrs.append(_instr_from_match(mi))
 
     if not saw_symbol:
+        near = [l for l in labels_seen if label in l or l in label]
+        if near:
+            hint = f"similar labels present: {sorted(near)[:8]}"
+        else:
+            hint = f"no similar labels among {len(labels_seen)} seen"
         raise SymbolNotEmittedError(
-            f"symbol {symbol!r} not found in disassembly of {source_label}. "
-            f"The impl must be emitted standalone (its address taken for the "
-            f"dispatch table) for its symbol to appear in the object file.")
+            f"symbol label {label!r} not found in disassembly of "
+            f"{source_label}. The impl must be emitted standalone (its "
+            f"address taken for the dispatch table) for its label to appear "
+            f"in the object file; {hint}.")
     # Strip trailing padding (NOP family + data16): bytes emitted after the
     # function's final control-flow terminator to align the NEXT function. They
     # belong to no function and vary with inter-function layout, so they are not
@@ -405,7 +420,7 @@ def extract_function_body_from_text(text: str, symbol: str,
         instrs.pop()
     if not instrs:
         raise RuntimeError(
-            f"symbol {symbol!r} found in {source_label} but its body is empty")
+            f"symbol {label!r} found in {source_label} but its body is empty")
     return instrs
 
 

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -37,9 +37,10 @@ whose declared tuples ALL skipped, is a zero-coverage failure (exit 1;
 mtibbits/volk#165). A genuine post-normalization divergence still fails
 (exit 1); a genuinely unparsable non-padding line still errors (exit 2).
 
-Per-tuple opt-in `require_standalone` (bool, default off) flips that inlined-away
+Per-tuple opt-in `require_standalone` (bool, default off) flips that not-found
 outcome: for a tuple whose dispatch relies on the impl existing as a real,
-separately-dispatchable symbol, "inlined away" is a regression, so the checker
+separately-dispatchable symbol, a not-found label (genuinely inlined away, or
+absent) is a regression, so the checker
 hard-fails it (exit 1) instead of skip-with-warning. Orthogonal to
 `require_mnemonic`, which asserts which instructions a present symbol contains.
 
@@ -75,6 +76,7 @@ import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
+from typing import Optional
 
 
 class SymbolNotEmittedError(RuntimeError):
@@ -363,7 +365,9 @@ def extract_function_body(o_file: Path, symbol: str,
     filter-emptied output. The retry is behavior, not just diagnostics: if
     the symbol filter fails to match a label that whole-object disassembly
     does render (an objdump version/symbol-table quirk), the retry recovers
-    the extraction instead of skipping the tuple.
+    the extraction instead of skipping the tuple. (Defensive: no such
+    objdump has been observed in this matrix -- the retry exists for the
+    diagnostic, and the recovery is a free consequence.)
     """
     label = object_symbol_name(o_file, symbol)
     text = _disassemble(o_file, objdump, symbol=label)
@@ -377,10 +381,11 @@ def extract_function_body(o_file: Path, symbol: str,
         # The fast path FILTERED the disassembly to the requested label; when
         # that label is wrong the output contains zero labels, which would
         # starve the similar-labels diagnostic ("no similar labels among 0
-        # seen"). Retry unfiltered -- error path only, so the extra
-        # disassembly costs nothing on a passing build -- so the raised
-        # error can report what the object file actually contains
-        # (mtibbits/volk#225).
+        # seen"). Retry unfiltered so the raised error can report what the
+        # object file actually contains (mtibbits/volk#225). Cost: skip path
+        # only -- a build whose tuples all resolve never pays it; each
+        # SKIPPED tuple (skips are exit-0) pays one whole-object disassembly.
+        # Fine at current tuple counts; memoise per .o if skips ever grow.
         text = _disassemble(o_file, objdump)
         return extract_function_body_from_text(text, label,
                                                source_label=str(o_file),
@@ -389,7 +394,7 @@ def extract_function_body(o_file: Path, symbol: str,
 
 def extract_function_body_from_text(text: str, label: str,
                                     source_label: str = "<disassembly>",
-                                    c_symbol: str = None) -> list:
+                                    c_symbol: Optional[str] = None) -> list:
     """Return [{address, bytes, mnemonic, operands}, ...] for the whole body of
     the object-file label `label` in `text` (on Mach-O, callers pass the
     underscore-prefixed label object_symbol_name() produced -- the underscore
@@ -718,17 +723,23 @@ def main():
     if uncovered or checked == 0:
         if checked == 0:
             headline = "zero coverage"
-            lead = (f"All {len(tuples)} declared tuples were skipped (impl "
-                    "not emitted standalone),\nso nothing was verified. A "
-                    "toolchain change that inlines every compared\nimpl "
-                    "would otherwise turn this check into a silent no-op.")
+            lead = (f"All {len(tuples)} declared tuples were skipped (no "
+                    "matching label in the object file:\nthe impl was "
+                    "inlined away, or its label does not match the name "
+                    "looked up --\nthe per-tuple WARNING lines above report "
+                    "the labels actually present),\nso nothing was verified. "
+                    "A toolchain change that inlines or renames every\n"
+                    "compared impl would otherwise turn this check into a "
+                    "silent no-op.")
             shown = skipped
         else:
             headline = ("zero codegen coverage for kernel(s): "
                         + ", ".join(uncovered))
             lead = ("Every declared tuple for the named kernel(s) was "
-                    "skipped (impl not emitted\nstandalone), leaving them "
-                    "unverified while the rest of the run passed.")
+                    "skipped (no matching label\nin the object file -- "
+                    "inlined away, or a label/name mismatch; see the\n"
+                    "per-tuple WARNING lines), leaving them unverified while "
+                    "the rest of the\nrun passed.")
             # Name only the uncovered kernels' skips: a covered kernel's
             # incidental skip must not be presented as removable. Derived from
             # the skip list itself (not kernel membership) so the label stays
@@ -740,11 +751,13 @@ def main():
         print("", file=sys.stderr)
         print(lead, file=sys.stderr)
         print("", file=sys.stderr)
-        print("Fix the build so the symbols are emitted standalone (see the "
-              "README's\nrequire-standalone notes). Removing the affected "
-              "tuples from the manifest\nsilences the check instead of "
-              "fixing it -- a deliberate de-scoping that\nneeds review, not "
-              "an equivalent outcome. See mtibbits/volk#165.",
+        print("Fix the build so the symbols are emitted standalone, or the "
+              "harness's\nname->label mapping if the WARNING lines show the "
+              "impl present under\nanother name (see the README's "
+              "require-standalone and object-label notes).\nRemoving the "
+              "affected tuples from the manifest silences the check "
+              "instead\nof fixing it -- a deliberate de-scoping that needs "
+              "review, not an\nequivalent outcome. See mtibbits/volk#165.",
               file=sys.stderr)
         if checked == 0:
             print("Note: an emptied manifest prints ok (0 tuples declared); "

--- a/cmake/check_framework_codegen.py
+++ b/cmake/check_framework_codegen.py
@@ -233,6 +233,14 @@ def resolve_object(build_lib_dir: Path, machine_o: str) -> Path:
         f"({len(matches)} matches): {[str(m) for m in matches]}")
 
 
+def _require_object_file(o_file: Path):
+    """Single owner of the missing-object diagnostic (exit-2 class), shared by
+    every seam that touches the file so the message cannot drift between
+    copies."""
+    if not o_file.is_file():
+        raise RuntimeError(f"object file not found: {o_file}")
+
+
 # Mach-O object-file magics (as the first 4 bytes appear on disk): thin
 # 64-/32-bit little-endian, and fat/universal (big-endian on disk) 32/64.
 _MACHO_MAGICS = {
@@ -264,8 +272,7 @@ def object_symbol_name(o_file: Path, symbol: str) -> str:
     SymbolNotEmittedError's similar-labels report is the loud signal (the
     underscored twin shows up there).
     """
-    if not o_file.is_file():
-        raise RuntimeError(f"object file not found: {o_file}")
+    _require_object_file(o_file)
     with o_file.open("rb") as f:
         magic = f.read(4)
     if magic in _MACHO_MAGICS:
@@ -273,9 +280,17 @@ def object_symbol_name(o_file: Path, symbol: str) -> str:
     return symbol
 
 
+def _uses_symbol_filter(objdump: str) -> bool:
+    """True when _disassemble will pass --disassemble-symbols for this tool
+    (llvm-objdump only; GNU objdump has no equivalent). Shared predicate so
+    extract_function_body can know its fast-path output was FILTERED -- a
+    filtered disassembly of a wrong label contains zero labels, which would
+    starve the similar-labels diagnostic (mtibbits/volk#225)."""
+    return "llvm" in Path(objdump).name
+
+
 def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
-    if not o_file.is_file():
-        raise RuntimeError(f"object file not found: {o_file}")
+    _require_object_file(o_file)
     # NOTE: deliberately NOT using --symbolize-operands. It makes llvm-objdump
     # synthesize <L0>/<L1> branch labels that collide with the _label_line
     # parser. Plain --disassemble shows symbol headers as clean <name>: lines.
@@ -283,7 +298,7 @@ def _disassemble(o_file: Path, objdump: str, symbol: str = None) -> str:
     # Efficiency: llvm-objdump can disassemble a single symbol, skipping the
     # hundreds of other kernels in a machine .o. GNU objdump has no equivalent,
     # so only use it for llvm-objdump and fall back to whole-object otherwise.
-    if symbol and "llvm" in Path(objdump).name:
+    if symbol and _uses_symbol_filter(objdump):
         cmd.append(f"--disassemble-symbols={symbol}")
     cmd.append(str(o_file))
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
@@ -342,12 +357,29 @@ def extract_function_body(o_file: Path, symbol: str,
     Maps the C name to the object file's label first (Mach-O prepends an
     underscore, mtibbits/volk#225), then thin wrapper over
     extract_function_body_from_text (see it for the parse contract); kept so
-    callers and tests can pass a file path + objdump.
+    callers and tests can pass a file path + objdump. On a not-found label
+    after a FILTERED fast-path disassembly, retries unfiltered so the
+    similar-labels report is computed from the whole object, not from
+    filter-emptied output.
     """
     label = object_symbol_name(o_file, symbol)
     text = _disassemble(o_file, objdump, symbol=label)
-    return extract_function_body_from_text(text, label,
-                                           source_label=str(o_file))
+    try:
+        return extract_function_body_from_text(text, label,
+                                               source_label=str(o_file))
+    except SymbolNotEmittedError:
+        if not _uses_symbol_filter(objdump):
+            raise
+        # The fast path FILTERED the disassembly to the requested label; when
+        # that label is wrong the output contains zero labels, which would
+        # starve the similar-labels diagnostic ("no similar labels among 0
+        # seen"). Retry unfiltered -- error path only, so the extra
+        # disassembly costs nothing on a passing build -- so the raised
+        # error can report what the object file actually contains
+        # (mtibbits/volk#225).
+        text = _disassemble(o_file, objdump)
+        return extract_function_body_from_text(text, label,
+                                               source_label=str(o_file))
 
 
 def extract_function_body_from_text(text: str, label: str,
@@ -587,8 +619,8 @@ def main():
             # away" is a regression, not an acceptable outcome -- hard-fail it.
             if t.get("require_standalone"):
                 msg = ("require_standalone assertion FAILED: implementation "
-                       "was not emitted as a standalone dispatchable symbol "
-                       f"(inlined away). {e}")
+                       "was not emitted as a standalone dispatchable symbol. "
+                       f"{e}")
                 failures.append((tuple_id(t), msg))
                 continue
             # Default: compiler inlined the impl rather than emitting it

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -229,8 +229,9 @@ positives on a clean tree.
   if the tuple declares `REQUIRE_STANDALONE`. Aggregate skips are bounded by
   the zero-coverage guard (see above).
 - `require_standalone assertion FAILED: implementation was not emitted as a
-  standalone dispatchable symbol (inlined away)` — a tuple declaring
-  `REQUIRE_STANDALONE` had its impl inlined away; the build fails (exit 1).
+  standalone dispatchable symbol` — a tuple declaring `REQUIRE_STANDALONE`
+  had no standalone impl to compare; the build fails (exit 1). The appended
+  exception text carries the not-found label and its similar-labels report.
 - `object file '<x>' not found under <dir>` — the `MACHINE_O` name does not
   match any compiled object; check the build actually produced it.
 - `object file '<x>' is ambiguous` — more than one `.o` with that name exists;
@@ -306,9 +307,8 @@ mismatch; actual tuple coverage on macOS starts with #225.)
   (`data16 cs nopw …`); treated as padding like the NOP family.
 - **Symbol not emitted standalone** (a compiler that genuinely inlines an
   address-free impl; note the macOS "not found" case was a naming mismatch,
-  mapped since mtibbits/volk#225): there
-  is nothing to compare, so the tuple is **skipped with a warning** and the
-  build stays green — unless the skip leaves a kernel (or the whole run) with
+  mapped since mtibbits/volk#225): there is nothing to compare, so the tuple
+  is **skipped with a warning** and the build stays green — unless the skip leaves a kernel (or the whole run) with
   zero checked tuples, which the zero-coverage guard turns into a hard failure
   (exit 1). The summary line reports `N skipped`. (Exception: a tuple
   that declares `REQUIRE_STANDALONE` hard-fails instead — see *Require-standalone

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -272,9 +272,11 @@ tuple ids without disassembling, useful for inspecting a generated manifest.
 
 ## Limitations
 
-- If any tuple **errors** (a missing symbol or `.o`), the harness exits 2 and
-  reports only the errors — accumulated codegen **failures** from other tuples
-  are not shown until the erroring entry is fixed. Fix manifest errors first.
+- If any tuple **errors** (a missing or ambiguous `.o`, an unparsable
+  disassembly line), the harness exits 2 and reports only the errors —
+  accumulated codegen **failures** from other tuples are not shown until the
+  erroring entry is fixed. Fix manifest errors first. (A missing *symbol* is
+  a skip-with-warning, not an error — see *Diagnostics*.)
 - `MACHINE_O` is resolved by bare-name recursive search under the build tree,
   which assumes the object name is unique there. If a future build compiles the
   same source into more than one OBJECT-library dir, give `MACHINE_O` as a path
@@ -308,7 +310,8 @@ mismatch; actual tuple coverage on macOS starts with #225.)
 - **Symbol not emitted standalone** (a compiler that genuinely inlines an
   address-free impl; note the macOS "not found" case was a naming mismatch,
   mapped since mtibbits/volk#225): there is nothing to compare, so the tuple
-  is **skipped with a warning** and the build stays green — unless the skip leaves a kernel (or the whole run) with
+  is **skipped with a warning** and the build stays green — unless the skip
+  leaves a kernel (or the whole run) with
   zero checked tuples, which the zero-coverage guard turns into a hard failure
   (exit 1). The summary line reports `N skipped`. (Exception: a tuple
   that declares `REQUIRE_STANDALONE` hard-fails instead — see *Require-standalone

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -137,10 +137,11 @@ actually present. The field is **opt-in**: tuples without it are unaffected and
 produce identical manifest JSON to before. Use it on framework-instantiation
 tuples to guarantee the instantiation didn't silently fall back to scalar code.
 
-## Require-standalone assertion (inlined-away guard)
+## Require-standalone assertion (not-found guard)
 
-By default, when the compiler inlines an impl rather than emitting it as a
-standalone symbol there is nothing to disassemble, so the tuple is
+By default, when the impl has no matching label in the object file —
+inlined away, or absent under the name looked up — there is nothing to
+disassemble, so the tuple is
 **skipped with a warning** and the build stays green (see *Diagnostics* and
 *Cross-compiler robustness* below) — bounded by the *Zero-coverage guard*:
 aggregate all-skip configurations fail. That is the right default for impls
@@ -151,9 +152,10 @@ by a future refactor, the symbol silently disappears and the check still
 passes while the kernel retains other coverage.
 
 Declare the optional boolean flag `REQUIRE_STANDALONE` (pass the **bare keyword**,
-no value) on such a tuple to flip that outcome: when the impl is inlined away,
-the checker reports a **hard failure** (exit 1) for that tuple instead of
-skip-with-warning.
+no value) on such a tuple to flip that outcome: when the impl has no
+matching label in the object file (inlined away, or absent under the name
+looked up), the checker reports a **hard failure** (exit 1) for that tuple
+instead of skip-with-warning.
 
 ```cmake
 ADD_CODEGEN_EQUIVALENCE_TUPLE(
@@ -184,13 +186,30 @@ configurations fail loudly (exit 1) instead of reporting `ok`:
   A kernel with at least one checked tuple is covered; its remaining
   skips stay warnings.
 
-Both diagnostics point at the usual cause — a toolchain change that
-starts inlining the compared impls — and the remedies: fix the build so
-the symbols are emitted standalone, or deliberately remove the affected
-tuples from the manifest. The empty-manifest case is distinct and stays
-green: zero tuples *declared* is a valid configuration
-(`ok (0 tuples declared)`, exit 0); zero tuples *verified out of some
-declared* is not.
+Both diagnostics name the two causes — a toolchain change that starts
+inlining the compared impls, or a label/name mismatch (the impl is present
+under a name the harness did not look up; the per-tuple WARNING lines
+report the labels actually seen) — and the remedies: fix the build so the
+symbols are emitted standalone, fix the harness's name→label mapping if
+the WARNINGs show the impl present under another name (see *Object-file
+labels* below), or deliberately remove the affected tuples from the
+manifest. The empty-manifest case is distinct and stays green: zero tuples
+*declared* is a valid configuration (`ok (0 tuples declared)`, exit 0);
+zero tuples *verified out of some declared* is not.
+
+### Object-file labels (mtibbits/volk#225)
+
+Symbol names are looked up as the object format's own labels: Mach-O
+prepends an underscore to every C symbol (`volk_32f_x2_add_32f_a_avx` is
+emitted as `_volk_32f_x2_add_32f_a_avx`), while ELF and COFF-x64 use the C
+name unchanged. `object_symbol_name()` maps C name → label, keyed on the
+object file's magic bytes (thin LE 32/64-bit Mach-O + fat 32/64 — so
+cross-compiled objects resolve correctly on any host; any other format
+keeps the C name, which is its documented blind spot). Before #225 the
+unprefixed lookup made every macOS tuple skip as "symbol not found" — a
+naming mismatch that presented as inlining. If a zero-coverage failure's
+WARNING lines show similar labels present, suspect the mapping, not the
+compiler.
 
 **Blind spots (what this guard cannot decide):** coverage is aggregated
 on the bare kernel name, so a kernel checked on one ISA but wholly

--- a/cmake/check_framework_codegen_README.md
+++ b/cmake/check_framework_codegen_README.md
@@ -48,7 +48,15 @@ Requirements on a compared impl:
   file. Volk's dispatch-table kernels satisfy this automatically because their
   address is taken for the dispatch array. A purely-inlined-away `static
   inline` with no address taken would have no symbol to find (the harness
-  errors clearly: "symbol not found").
+  errors clearly: "symbol label not found").
+  Symbol names are compared against the object format's own labels: on
+  Mach-O every C symbol carries a leading underscore
+  (`_volk_32f_x2_add_32f_a_avx`), and the harness maps this automatically
+  (keyed on the object file's magic bytes, so cross-compiled objects resolve
+  correctly). Before mtibbits/volk#225 the unprefixed lookup made the
+  macOS bootstrap tuple skip as "symbol not found" — a naming mismatch
+  that presented as inlining (a cross-compile probe showed the impl
+  emitted standalone under the underscored label).
 - Trailing NOP-family padding after the function's final `ret`/`jmp` is
   alignment padding for the *next* function; the harness strips it before
   comparing, so inter-function layout differences do not cause false failures.
@@ -212,11 +220,14 @@ positives on a clean tree.
 
 ## Diagnostics
 
-- `symbol '<x>' not found in disassembly of <o>` — the impl was inlined away
-  (no address taken, so no symbol emitted), or the symbol is in a different
-  `.o` than declared. Skipped-with-warning by default; a hard failure if the
-  tuple declares `REQUIRE_STANDALONE`. Aggregate skips are bounded by the
-  zero-coverage guard (see above).
+- `symbol label '<x>' not found in disassembly of <o>` — the impl was inlined
+  away (no address taken, so no symbol emitted), or the symbol is in a
+  different `.o` than declared. (A third cause — the object format's label
+  mangling, e.g. Mach-O's leading underscore — is mapped automatically since
+  mtibbits/volk#225; the message's similar-labels report identifies any
+  residual naming mismatch.) Skipped-with-warning by default; a hard failure
+  if the tuple declares `REQUIRE_STANDALONE`. Aggregate skips are bounded by
+  the zero-coverage guard (see above).
 - `require_standalone assertion FAILED: implementation was not emitted as a
   standalone dispatchable symbol (inlined away)` — a tuple declaring
   `REQUIRE_STANDALONE` had its impl inlined away; the build fails (exit 1).
@@ -277,6 +288,9 @@ The harness runs across the full CI compiler matrix (gcc-11..14, clang-14..19,
 macOS clang, static builds, with either `llvm-objdump` or GNU `objdump`). It
 normalizes away codegen *noise* that differs by compiler but is not a real
 equivalence violation, while still hard-failing on a genuine divergence.
+(Measured caveat: on macOS x86_64 the harness *ran* but checked **zero**
+tuples before mtibbits/volk#225 — every tuple skipped on the Mach-O label
+mismatch; actual tuple coverage on macOS starts with #225.)
 
 **Stripped / tolerated (not a failure):**
 
@@ -290,7 +304,9 @@ equivalence violation, while still hard-failing on a genuine divergence.
   a hot loop) are *preserved* — only the trailing run is stripped.
 - **Trailing `data16` padding** — how GNU objdump renders a multi-byte NOP pad
   (`data16 cs nopw …`); treated as padding like the NOP family.
-- **Symbol not emitted standalone** (e.g. macOS clang inlines the impl): there
+- **Symbol not emitted standalone** (a compiler that genuinely inlines an
+  address-free impl; note the macOS "not found" case was a naming mismatch,
+  mapped since mtibbits/volk#225): there
   is nothing to compare, so the tuple is **skipped with a warning** and the
   build stays green — unless the skip leaves a kernel (or the whole run) with
   zero checked tuples, which the zero-coverage guard turns into a hard failure

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -348,6 +348,48 @@ def test_symbol_not_standalone_raises_typed():
     assert issubclass(mod.SymbolNotEmittedError, RuntimeError)
 
 
+def test_object_symbol_name_macho_prefixes():
+    """Mach-O mangles C symbols with a leading underscore; the label the
+    disassembler shows is '_sym'. Detection is by file magic, not host
+    platform, so a cross-compiled Mach-O .o on a Linux host resolves
+    correctly (mtibbits/volk#225)."""
+    mod = _load_module()
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        o = Path(td) / "m.o"
+        o.write_bytes(b"\xcf\xfa\xed\xfe" + b"\x00" * 28)  # MH_MAGIC_64 (LE)
+        assert mod.object_symbol_name(o, "fwk_fn") == "_fwk_fn"
+        o32 = Path(td) / "m32.o"
+        o32.write_bytes(b"\xce\xfa\xed\xfe" + b"\x00" * 28)  # MH_MAGIC (LE)
+        assert mod.object_symbol_name(o32, "fwk_fn") == "_fwk_fn"
+
+
+def test_object_symbol_name_elf_and_coff_unchanged():
+    """Non-Mach-O objects keep the C name: ELF (Linux lanes) and a non-magic
+    blob (COFF has no single 4-byte magic; absence of Mach-O magic must mean
+    'no prefix', preserving today's behavior everywhere else)."""
+    mod = _load_module()
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        o = Path(td) / "e.o"
+        o.write_bytes(b"\x7fELF" + b"\x00" * 28)
+        assert mod.object_symbol_name(o, "fwk_fn") == "fwk_fn"
+        c = Path(td) / "c.obj"
+        c.write_bytes(b"\x64\x86\x00\x00" + b"\x00" * 28)
+        assert mod.object_symbol_name(c, "fwk_fn") == "fwk_fn"
+
+
+def test_object_symbol_name_missing_file_raises():
+    """Missing .o keeps the established 'object file not found' diagnostic
+    (exit-2 class), now raised at the naming seam which runs first."""
+    mod = _load_module()
+    try:
+        mod.object_symbol_name(Path("/nonexistent/x.o"), "fwk_fn")
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert "object file not found" in str(e), str(e)
+
+
 def test_padding_strip_does_not_swallow_real_instruction():
     """Negative control: a trailing NON-padding instruction (an extra vaddps)
     must remain and still cause a divergence -- the strip is padding-only."""

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -17,9 +17,11 @@ assemble tiny fixtures with the system toolchain, so they require `cc` and
 a disassembler (llvm-objdump or objdump) on PATH.
 """
 
+import contextlib
 import json
 import subprocess
 import sys
+import tempfile
 from importlib import util
 from pathlib import Path
 
@@ -39,6 +41,18 @@ def _which_objdump():
         if subprocess.run(["which", cand], capture_output=True).returncode == 0:
             return cand
     raise RuntimeError("no disassembler found (llvm-objdump / objdump)")
+
+
+@contextlib.contextmanager
+def _patched_disassemble(mod, fake):
+    """Swap mod._disassemble for `fake` and guarantee restoration -- a leaked
+    monkeypatch would silently poison every later extraction test."""
+    real = mod._disassemble
+    mod._disassemble = fake
+    try:
+        yield
+    finally:
+        mod._disassemble = real
 
 
 def test_manifest_parse():
@@ -358,7 +372,6 @@ def test_object_symbol_name_macho_prefixes():
     platform, so a cross-compiled Mach-O .o on a Linux host resolves
     correctly (mtibbits/volk#225)."""
     mod = _load_module()
-    import tempfile
     with tempfile.TemporaryDirectory() as td:
         o = Path(td) / "m.o"
         o.write_bytes(b"\xcf\xfa\xed\xfe" + b"\x00" * 28)  # MH_MAGIC_64 (LE)
@@ -373,7 +386,6 @@ def test_object_symbol_name_elf_and_coff_unchanged():
     blob (COFF has no single 4-byte magic; absence of Mach-O magic must mean
     'no prefix', preserving today's behavior everywhere else)."""
     mod = _load_module()
-    import tempfile
     with tempfile.TemporaryDirectory() as td:
         o = Path(td) / "e.o"
         o.write_bytes(b"\x7fELF" + b"\x00" * 28)
@@ -494,23 +506,18 @@ def test_extract_function_body_macho_wiring_real_capture():
     a real produced artifact fed through the consumer, not a hand-written
     format claim (mtibbits/volk#225)."""
     mod = _load_module()
-    import tempfile
     with tempfile.TemporaryDirectory() as td:
         o = Path(td) / "m.o"
         o.write_bytes(b"\xcf\xfa\xed\xfe" + b"\x00" * 28)
         seen = {}
-        real = mod._disassemble
 
         def fake_disassemble(o_file, objdump, symbol=None):
             seen["symbol"] = symbol
             return _MACHO_REAL_DISASM
 
-        mod._disassemble = fake_disassemble
-        try:
+        with _patched_disassemble(mod, fake_disassemble):
             instrs = mod.extract_function_body(
                 o, "volk_32f_x2_add_32f_a_avx", objdump="llvm-objdump")
-        finally:
-            mod._disassemble = real
     assert seen["symbol"] == "_volk_32f_x2_add_32f_a_avx", seen
     # Structural pins, stable across a toolchain re-capture: whole real
     # body parses, prologue/epilogue mnemonics, and the AVX payload.
@@ -526,12 +533,10 @@ def test_extract_function_body_elf_label_unchanged():
     end-to-end, so no prefix leaks into non-Mach-O lookups and Linux-lane
     results stay byte-identical (AC2)."""
     mod = _load_module()
-    import tempfile
     with tempfile.TemporaryDirectory() as td:
         o = Path(td) / "e.o"
         o.write_bytes(b"\x7fELF" + b"\x00" * 28)
         seen = {}
-        real = mod._disassemble
 
         def fake_disassemble(o_file, objdump, symbol=None):
             seen["symbol"] = symbol
@@ -540,13 +545,47 @@ def test_extract_function_body_elf_label_unchanged():
                 "       0: c3                           \tretq\n"
             )
 
-        mod._disassemble = fake_disassemble
-        try:
+        with _patched_disassemble(mod, fake_disassemble):
             instrs = mod.extract_function_body(o, "fwk_fn", objdump="llvm-objdump")
-        finally:
-            mod._disassemble = real
     assert seen["symbol"] == "fwk_fn", seen
     assert [i["mnemonic"] for i in instrs] == ["retq"], instrs
+
+
+def test_not_found_retries_unfiltered_for_similar_labels():
+    """The llvm fast path FILTERS disassembly to the requested label
+    (--disassemble-symbols), so a wrong label yields output with ZERO labels
+    -- which would starve the similar-labels diagnostic into 'no similar
+    labels among 0 seen'. On not-found, extract_function_body must retry
+    UNFILTERED so the raised error reports what the object actually contains
+    (mtibbits/volk#225 quality pass)."""
+    mod = _load_module()
+    with tempfile.TemporaryDirectory() as td:
+        o = Path(td) / "m.o"
+        o.write_bytes(b"\xcf\xfa\xed\xfe" + b"\x00" * 28)
+        calls = []
+
+        def fake_disassemble(o_file, objdump, symbol=None):
+            calls.append(symbol)
+            if symbol is not None:
+                # llvm-objdump behavior for a missing symbol: header only,
+                # zero label lines, rc=0 (measured).
+                return "m.o:\tfile format mach-o 64-bit x86-64\n"
+            return (
+                "m.o:\tfile format mach-o 64-bit x86-64\n"
+                "\n"
+                "0000000000000000 <_wanted_fn_v2>:\n"
+                "       0: c3                           \tretq\n"
+            )
+
+        with _patched_disassemble(mod, fake_disassemble):
+            try:
+                mod.extract_function_body(o, "wanted_fn", objdump="llvm-objdump")
+                assert False, "expected SymbolNotEmittedError"
+            except mod.SymbolNotEmittedError as e:
+                assert "similar labels present" in str(e), str(e)
+                assert "_wanted_fn_v2" in str(e), str(e)
+    # First call filtered (the mapped label), second call the unfiltered retry.
+    assert calls == ["_wanted_fn", None], calls
 
 
 def test_symbol_not_emitted_reports_similar_labels():

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -343,6 +343,10 @@ def test_symbol_not_standalone_raises_typed():
         assert False, "expected SymbolNotEmittedError"
     except mod.SymbolNotEmittedError as e:
         assert "inlined_away" in str(e), str(e)
+        # The fixture's only label is the unrelated <other>, so the
+        # similar-labels report must state there is nothing similar
+        # (mtibbits/volk#225).
+        assert "no similar labels" in str(e), str(e)
     # It must be a RuntimeError subclass so existing `except RuntimeError`
     # callers still see it if they do not special-case it.
     assert issubclass(mod.SymbolNotEmittedError, RuntimeError)
@@ -388,6 +392,178 @@ def test_object_symbol_name_missing_file_raises():
         assert False, "expected RuntimeError"
     except RuntimeError as e:
         assert "object file not found" in str(e), str(e)
+
+
+# REAL captured llvm-objdump-18 output of a cross-compiled Mach-O object
+# (clang -target x86_64-apple-macos12 -O3 -mavx on a machine-TU-shaped
+# fixture: static inline impl, address taken in a dispatch table). The
+# Mach-O label carries the Darwin ABI's leading underscore. Captured for
+# mtibbits/volk#225; regeneration recipe in that issue's plan.
+_MACHO_REAL_DISASM = """\
+
+probe_macho.o:	file format mach-o 64-bit x86-64
+
+Disassembly of section __TEXT,__text:
+
+0000000000000000 <_volk_32f_x2_add_32f_a_avx>:
+       0: 55                           	pushq	%rbp
+       1: 48 89 e5                     	movq	%rsp, %rbp
+       4: 85 c9                        	testl	%ecx, %ecx
+       6: 0f 84 57 01 00 00            	je	0x163 <_volk_32f_x2_add_32f_a_avx+0x163>
+       c: 89 c8                        	movl	%ecx, %eax
+       e: 83 f9 20                     	cmpl	$0x20, %ecx
+      11: 0f 83 a8 00 00 00            	jae	0xbf <_volk_32f_x2_add_32f_a_avx+0xbf>
+      17: 31 c9                        	xorl	%ecx, %ecx
+      19: 49 89 c1                     	movq	%rax, %r9
+      1c: 49 89 c8                     	movq	%rcx, %r8
+      1f: 49 83 e1 03                  	andq	$0x3, %r9
+      23: 74 25                        	je	0x4a <_volk_32f_x2_add_32f_a_avx+0x4a>
+      25: 49 89 c8                     	movq	%rcx, %r8
+      28: 0f 1f 84 00 00 00 00 00      	nopl	(%rax,%rax)
+      30: c4 a1 7a 10 04 86            	vmovss	(%rsi,%r8,4), %xmm0
+      36: c4 a1 7a 58 04 82            	vaddss	(%rdx,%r8,4), %xmm0, %xmm0
+      3c: c4 a1 7a 11 04 87            	vmovss	%xmm0, (%rdi,%r8,4)
+      42: 49 ff c0                     	incq	%r8
+      45: 49 ff c9                     	decq	%r9
+      48: 75 e6                        	jne	0x30 <_volk_32f_x2_add_32f_a_avx+0x30>
+      4a: 48 29 c1                     	subq	%rax, %rcx
+      4d: 48 83 f9 fc                  	cmpq	$-0x4, %rcx
+      51: 0f 87 0c 01 00 00            	ja	0x163 <_volk_32f_x2_add_32f_a_avx+0x163>
+      57: 66 0f 1f 84 00 00 00 00 00   	nopw	(%rax,%rax)
+      60: c4 a1 7a 10 04 86            	vmovss	(%rsi,%r8,4), %xmm0
+      66: c4 a1 7a 58 04 82            	vaddss	(%rdx,%r8,4), %xmm0, %xmm0
+      6c: c4 a1 7a 11 04 87            	vmovss	%xmm0, (%rdi,%r8,4)
+      72: c4 a1 7a 10 44 86 04         	vmovss	0x4(%rsi,%r8,4), %xmm0
+      79: c4 a1 7a 58 44 82 04         	vaddss	0x4(%rdx,%r8,4), %xmm0, %xmm0
+      80: c4 a1 7a 11 44 87 04         	vmovss	%xmm0, 0x4(%rdi,%r8,4)
+      87: c4 a1 7a 10 44 86 08         	vmovss	0x8(%rsi,%r8,4), %xmm0
+      8e: c4 a1 7a 58 44 82 08         	vaddss	0x8(%rdx,%r8,4), %xmm0, %xmm0
+      95: c4 a1 7a 11 44 87 08         	vmovss	%xmm0, 0x8(%rdi,%r8,4)
+      9c: c4 a1 7a 10 44 86 0c         	vmovss	0xc(%rsi,%r8,4), %xmm0
+      a3: c4 a1 7a 58 44 82 0c         	vaddss	0xc(%rdx,%r8,4), %xmm0, %xmm0
+      aa: c4 a1 7a 11 44 87 0c         	vmovss	%xmm0, 0xc(%rdi,%r8,4)
+      b1: 49 83 c0 04                  	addq	$0x4, %r8
+      b5: 4c 39 c0                     	cmpq	%r8, %rax
+      b8: 75 a6                        	jne	0x60 <_volk_32f_x2_add_32f_a_avx+0x60>
+      ba: e9 a4 00 00 00               	jmp	0x163 <_volk_32f_x2_add_32f_a_avx+0x163>
+      bf: 49 89 f8                     	movq	%rdi, %r8
+      c2: 49 29 f0                     	subq	%rsi, %r8
+      c5: 31 c9                        	xorl	%ecx, %ecx
+      c7: 49 81 f8 80 00 00 00         	cmpq	$0x80, %r8
+      ce: 0f 82 45 ff ff ff            	jb	0x19 <_volk_32f_x2_add_32f_a_avx+0x19>
+      d4: 49 89 f8                     	movq	%rdi, %r8
+      d7: 49 29 d0                     	subq	%rdx, %r8
+      da: 49 81 f8 80 00 00 00         	cmpq	$0x80, %r8
+      e1: 0f 82 32 ff ff ff            	jb	0x19 <_volk_32f_x2_add_32f_a_avx+0x19>
+      e7: 89 c1                        	movl	%eax, %ecx
+      e9: 83 e1 e0                     	andl	$-0x20, %ecx
+      ec: 4c 8d 04 85 00 00 00 00      	leaq	(,%rax,4), %r8
+      f4: 49 83 e0 80                  	andq	$-0x80, %r8
+      f8: 45 31 c9                     	xorl	%r9d, %r9d
+      fb: 0f 1f 44 00 00               	nopl	(%rax,%rax)
+     100: c4 a1 7c 10 04 0e            	vmovups	(%rsi,%r9), %ymm0
+     106: c4 a1 7c 10 4c 0e 20         	vmovups	0x20(%rsi,%r9), %ymm1
+     10d: c4 a1 7c 10 54 0e 40         	vmovups	0x40(%rsi,%r9), %ymm2
+     114: c4 a1 7c 10 5c 0e 60         	vmovups	0x60(%rsi,%r9), %ymm3
+     11b: c4 a1 7c 58 04 0a            	vaddps	(%rdx,%r9), %ymm0, %ymm0
+     121: c4 a1 74 58 4c 0a 20         	vaddps	0x20(%rdx,%r9), %ymm1, %ymm1
+     128: c4 a1 6c 58 54 0a 40         	vaddps	0x40(%rdx,%r9), %ymm2, %ymm2
+     12f: c4 a1 64 58 5c 0a 60         	vaddps	0x60(%rdx,%r9), %ymm3, %ymm3
+     136: c4 a1 7c 11 04 0f            	vmovups	%ymm0, (%rdi,%r9)
+     13c: c4 a1 7c 11 4c 0f 20         	vmovups	%ymm1, 0x20(%rdi,%r9)
+     143: c4 a1 7c 11 54 0f 40         	vmovups	%ymm2, 0x40(%rdi,%r9)
+     14a: c4 a1 7c 11 5c 0f 60         	vmovups	%ymm3, 0x60(%rdi,%r9)
+     151: 49 83 e9 80                  	subq	$-0x80, %r9
+     155: 4d 39 c8                     	cmpq	%r9, %r8
+     158: 75 a6                        	jne	0x100 <_volk_32f_x2_add_32f_a_avx+0x100>
+     15a: 48 39 c1                     	cmpq	%rax, %rcx
+     15d: 0f 85 b6 fe ff ff            	jne	0x19 <_volk_32f_x2_add_32f_a_avx+0x19>
+     163: 5d                           	popq	%rbp
+     164: c5 f8 77                     	vzeroupper
+     167: c3                           	retq
+"""
+
+
+def test_extract_function_body_macho_wiring_real_capture():
+    """extract_function_body maps the C name to its Mach-O label BEFORE
+    disassembly: the label reaches --disassemble-symbols (else llvm-objdump
+    silently disassembles nothing for the unprefixed name, rc=0 measured)
+    and the header match. The disassembly text is the REAL captured
+    llvm-objdump-18 output of a cross-compiled Mach-O machine-TU-shaped
+    fixture (static inline impl, address taken in a dispatch table) --
+    a real produced artifact fed through the consumer, not a hand-written
+    format claim (mtibbits/volk#225)."""
+    mod = _load_module()
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        o = Path(td) / "m.o"
+        o.write_bytes(b"\xcf\xfa\xed\xfe" + b"\x00" * 28)
+        seen = {}
+        real = mod._disassemble
+
+        def fake_disassemble(o_file, objdump, symbol=None):
+            seen["symbol"] = symbol
+            return _MACHO_REAL_DISASM
+
+        mod._disassemble = fake_disassemble
+        try:
+            instrs = mod.extract_function_body(
+                o, "volk_32f_x2_add_32f_a_avx", objdump="llvm-objdump")
+        finally:
+            mod._disassemble = real
+    assert seen["symbol"] == "_volk_32f_x2_add_32f_a_avx", seen
+    # Structural pins, stable across a toolchain re-capture: whole real
+    # body parses, prologue/epilogue mnemonics, and the AVX payload.
+    assert len(instrs) >= 50, len(instrs)
+    assert instrs[0]["mnemonic"] == "pushq", instrs[0]
+    assert instrs[-1]["mnemonic"] == "retq", instrs[-1]
+    assert any(i["mnemonic"] == "vaddps" for i in instrs)
+
+
+def test_extract_function_body_elf_label_unchanged():
+    """Regression pin for the untouched branch (GREEN before and after the
+    fix -- declared, not born-red): an ELF object keeps the C name
+    end-to-end, so no prefix leaks into non-Mach-O lookups and Linux-lane
+    results stay byte-identical (AC2)."""
+    mod = _load_module()
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        o = Path(td) / "e.o"
+        o.write_bytes(b"\x7fELF" + b"\x00" * 28)
+        seen = {}
+        real = mod._disassemble
+
+        def fake_disassemble(o_file, objdump, symbol=None):
+            seen["symbol"] = symbol
+            return (
+                "0000000000000000 <fwk_fn>:\n"
+                "       0: c3                           \tretq\n"
+            )
+
+        mod._disassemble = fake_disassemble
+        try:
+            instrs = mod.extract_function_body(o, "fwk_fn", objdump="llvm-objdump")
+        finally:
+            mod._disassemble = real
+    assert seen["symbol"] == "fwk_fn", seen
+    assert [i["mnemonic"] for i in instrs] == ["retq"], instrs
+
+
+def test_symbol_not_emitted_reports_similar_labels():
+    """When the requested label is absent but a near-name IS present (the
+    Mach-O underscore family of failures), the error must say so -- one
+    line separates 'emitted under a name we didn't ask for' from 'not
+    emitted', so the skip warning discriminates at the source instead of
+    forcing stderr archaeology (mtibbits/volk#225)."""
+    mod = _load_module()
+    text = ("0000000000000000 <_wanted_fn>:\n"
+            "       0: c3                           \tretq\n")
+    try:
+        mod.extract_function_body_from_text(text, "wanted_fn")
+        assert False, "expected SymbolNotEmittedError"
+    except mod.SymbolNotEmittedError as e:
+        assert "similar labels present" in str(e), str(e)
+        assert "_wanted_fn" in str(e), str(e)
 
 
 def test_padding_strip_does_not_swallow_real_instruction():

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -590,8 +590,44 @@ def test_not_found_retries_unfiltered_for_similar_labels():
             except mod.SymbolNotEmittedError as e:
                 assert "similar labels present" in str(e), str(e)
                 assert "_wanted_fn_v2" in str(e), str(e)
+                # The C name is what a reader can actually grep the manifest
+                # and tree for -- the label's underscore exists nowhere there.
+                assert "(C symbol 'wanted_fn')" in str(e), str(e)
     # First call filtered (the mapped label), second call the unfiltered retry.
     assert calls == ["_wanted_fn", None], calls
+
+
+def test_not_found_retry_recovers_extraction():
+    """The retry is behavior, not just diagnostics: when the symbol filter
+    misses a label that whole-object disassembly DOES render (an objdump
+    version/symbol-table quirk), the unfiltered retry must recover the
+    extraction -- returning instructions where the pre-retry harness would
+    have skipped the tuple. This is the branch that can turn a former skip
+    into a real comparison, so it must be executed, not just described
+    (mtibbits/volk#225 red-team)."""
+    mod = _load_module()
+    with tempfile.TemporaryDirectory() as td:
+        o = Path(td) / "m.o"
+        o.write_bytes(b"\xcf\xfa\xed\xfe" + b"\x00" * 28)
+        calls = []
+
+        def fake_disassemble(o_file, objdump, symbol=None):
+            calls.append(symbol)
+            if symbol is not None:
+                # Filter misses: header only, zero label lines, rc=0.
+                return "m.o:\tfile format mach-o 64-bit x86-64\n"
+            return (
+                "m.o:\tfile format mach-o 64-bit x86-64\n"
+                "\n"
+                "0000000000000000 <_wanted_fn>:\n"
+                "       0: c3                           \tretq\n"
+            )
+
+        with _patched_disassemble(mod, fake_disassemble):
+            instrs = mod.extract_function_body(o, "wanted_fn",
+                                               objdump="llvm-objdump")
+    assert calls == ["_wanted_fn", None], calls
+    assert [i["mnemonic"] for i in instrs] == ["retq"], instrs
 
 
 def test_not_found_no_retry_when_unfiltered():

--- a/cmake/test_check_framework_codegen.py
+++ b/cmake/test_check_framework_codegen.py
@@ -379,6 +379,12 @@ def test_object_symbol_name_macho_prefixes():
         o32 = Path(td) / "m32.o"
         o32.write_bytes(b"\xce\xfa\xed\xfe" + b"\x00" * 28)  # MH_MAGIC (LE)
         assert mod.object_symbol_name(o32, "fwk_fn") == "_fwk_fn"
+        fat = Path(td) / "fat.o"
+        fat.write_bytes(b"\xca\xfe\xba\xbe" + b"\x00" * 28)  # FAT_MAGIC
+        assert mod.object_symbol_name(fat, "fwk_fn") == "_fwk_fn"
+        fat64 = Path(td) / "fat64.o"
+        fat64.write_bytes(b"\xca\xfe\xba\xbf" + b"\x00" * 28)  # FAT_MAGIC_64
+        assert mod.object_symbol_name(fat64, "fwk_fn") == "_fwk_fn"
 
 
 def test_object_symbol_name_elf_and_coff_unchanged():
@@ -586,6 +592,34 @@ def test_not_found_retries_unfiltered_for_similar_labels():
                 assert "_wanted_fn_v2" in str(e), str(e)
     # First call filtered (the mapped label), second call the unfiltered retry.
     assert calls == ["_wanted_fn", None], calls
+
+
+def test_not_found_no_retry_when_unfiltered():
+    """GNU objdump has no symbol filter, so the first disassembly was already
+    whole-object -- a not-found there must raise WITHOUT a second disassembly
+    (on macOS, which resolves Apple's non-'llvm'-named objdump, a retry would
+    re-disassemble the whole machine .o for identical text on every skip)."""
+    mod = _load_module()
+    with tempfile.TemporaryDirectory() as td:
+        o = Path(td) / "e.o"
+        o.write_bytes(b"\x7fELF" + b"\x00" * 28)
+        calls = []
+
+        def fake_disassemble(o_file, objdump, symbol=None):
+            calls.append(symbol)
+            return (
+                "0000000000000000 <other_fn>:\n"
+                "       0: c3                           \tretq\n"
+            )
+
+        with _patched_disassemble(mod, fake_disassemble):
+            try:
+                mod.extract_function_body(o, "wanted_fn", objdump="objdump")
+                assert False, "expected SymbolNotEmittedError"
+            except mod.SymbolNotEmittedError:
+                pass
+    # Exactly one disassembly: unfiltered tools get no retry.
+    assert calls == ["wanted_fn"], calls
 
 
 def test_symbol_not_emitted_reports_similar_labels():


### PR DESCRIPTION
## Summary

`build-macos (macos-15-intel)` has zero codegen-equivalence coverage: the one
production tuple skips with `symbol 'volk_32f_x2_add_32f_a_avx' not found`,
and once the #165 zero-coverage guard is active that skip is a hard build
failure — this PR is the remediation that lane is red to force.

The issue's working diagnosis ("Apple clang inlines the bootstrap impl") is
**corrected by measurement**: a Linux cross-compile probe (upstream clang 18,
`-target x86_64-apple-macos12`, a machine-TU-shaped fixture with the impl's
address taken for a dispatch table) shows the impl IS emitted standalone — as
`_volk_32f_x2_add_32f_a_avx`. Mach-O prepends an underscore to every C
symbol; the harness looked up the unprefixed name, so the label match missed
and the tuple skipped. The fix is therefore harness-side, not codegen
shaping: a new `object_symbol_name()` maps C name → object-file label, keyed
on the object file's magic bytes (correct for cross-compiled objects), wired
at the single file-aware seam (`extract_function_body`) so both the
`--disassemble-symbols` fast path and the header match use the right label.
Production codegen is untouched on every platform, and non-Mach-O *label
resolution* is unchanged (ELF/COFF names map to themselves; the measured
Linux `codegen-equivalence:` summary line is byte-identical
baseline-vs-branch). One deliberate behavior change on the error path: for
any llvm-named objdump, a not-found label now retries disassembly unfiltered
— `--disassemble-symbols` with a wrong label emits zero labels, which would
starve the diagnostic below — and can recover an extraction the symbol
filter missed (tested; unfiltered tools like GNU objdump get no retry,
also tested).

Two hardening pieces ride the same mechanism: `SymbolNotEmittedError` now
reports similar labels the disassembly DID contain, next to the manifest's C
symbol name (one line that separates "emitted under a name we didn't ask
for" from "not emitted" — a naming mismatch can never again masquerade as
inlining, and the C name is the grep-able thread back to the declaration).
Stale "macOS clang inlines it" framing is corrected across the harness
docstrings, README (including a new *Object-file labels* section the guard
message now points at, and the zero-coverage / require-standalone sections'
causes-and-remedies prose), `CodegenEquivalence.cmake`, and the #165
zero-coverage guard's operator-facing message (which now names both causes
and points at the per-tuple label reports; its `CHECK FAILED` /
`zero coverage` headline tokens are byte-unchanged), worded to the measured
evidence (Apple's own toolchain behavior is confirmed by this PR's
macos-15-intel lane). Three small quality-pass refactors ride along, each
removing a duplicated guard rather than adding a pattern:
`_require_object_file()` (dedup of the missing-object diagnostic),
`_uses_symbol_filter()` (shared fast-path predicate), and a
`_patched_disassemble` test contextmanager (monkeypatch scaffold dedup).

## Related issues

Closes #225
Related: #165 (zero-coverage guard whose red macos-15-intel lane this
remediates), #164 (`REQUIRE_STANDALONE` — detection axis, unchanged), #145
(cross-compiler robustness), #78 (harness).

## Testing

- Suite: 38/38 (`python3 cmake/test_check_framework_codegen.py`), 9 new test
  functions + 1 pre-existing test extended: magic→label mapping (Mach-O
  thin 64/32 + fat 32/64, ELF, COFF-blob, missing-file), a wiring test whose
  fixture is the REAL captured llvm-objdump output of the cross-compiled
  Mach-O probe object (75 instructions), an ELF regression pin (no prefix
  leaks into non-Mach-O lookups), a similar-labels + C-symbol report test,
  an unfiltered-retry diagnostic test, a retry-recovers-extraction test, and
  a no-retry-for-unfiltered-tools test.
- Born-red discipline: the plan's new tests were observed red against the
  unfixed tree at pinned tallies (29/32 after Task 1's tests, 32/35 after
  Task 2's); the three retry-contract tests added by the quality/review/
  red-team passes are each mutation-checked (deleting the guarded branch
  fails exactly them).
- Linux end-to-end (out-of-tree builds) at this branch head: branch and
  `dev/all-prs` baseline both print `codegen-equivalence: ok (1 tuples
  checked)` — summary lines byte-identical, so passing platforms are
  unaffected. (Measured at the final SHA; captured in the issue's
  `analysis/2026-08-06-e2e-final.txt`.)
- Analyzers — measurement bases stated per sweep:
  - Sanitizers, scan-build and the C/C++ tools were swept at `47e438e8`,
    and no commit on this branch touches C at all (the whole diff is
    Python/Markdown/CMake-comment): ASan+UBSan pass; TSan pass;
    scan-build pass; cppcheck/cpplint/clang-tidy/iwyu/clang-format/
    compiler clean.
  - Non-C text tools and Python analyzers re-measured at/near the final
    SHA (red-team round 3): codespell 0 findings; cmake-lint 7 total /
    0 novel, none on changed lines; bandit novel findings are B101
    (`assert`) only — the test suite's standard idiom; ruff/flake8
    clean on the harness (the sweep's E741 was fixed in its own
    commit; a transient implicit-Optional mypy error introduced
    mid-branch was caught by red-team round 2 and fixed with a proper
    `Optional[str]` annotation); 2 residual mypy notes predate this
    branch (`_disassemble`'s legacy signature, an unannotated list).
- AC3 (guard not weakened): the branch edits the #165 guard's *message
  strings only* — the `checked == 0` / per-kernel conditions, the
  headline tokens (`CHECK FAILED`, `zero coverage`, `zero codegen
  coverage for kernel(s):`) and `sys.exit(1)` are byte-identical to
  baseline; the four guard tests are unmodified and pass in the 38/38
  run.
- AC1 (macos-15-intel prints `ok (1 tuples checked)`, lane green) is
  verified by THIS PR's CI — the lane is the designated probe for Apple's
  toolchain behavior; every red shape has a pre-assigned reading in the
  issue plan's validation table.

## Evidence

suite: none @ e53720ac0b254e37a8fa18acf25c74ce386aa148
files: 4 changed

(The codegen-equivalence suite is a standalone Python runner — neither bats
nor pytest — hence the no-framework form; its own count is 38/38 as above.)

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (38/38 standalone suite; harness not wired into ctest)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
