### PR TITLE
misaligned puppet fault isolation coverage

### DIFF
--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -134,26 +134,38 @@ the kernel's numbers and cite this section.
   aligned/misaligned/compare cycle runs in a forked child; a fault kills only
   the child and the parent records it from the wait status + a phase pipe
   (fail-closed: an impl whose fork setup fails is not counted, so an
-  all-failed kernel reports `skip`, never `ok`). Puppet rows carry a
-  `(fork-isolated)` stdout tag so the routing is observable. One policy
-  exclusion remains: `volk_8u_conv_k7_r2puppet_8u` prints
-  `skip … (excluded: #96 conv_k7)` until its decision-buffer overflow (#96)
-  lands — the corruption is child-contained but would hard-red every ASan
-  lane for a known, tracked defect. A second negative-control pair (the same
-  planted ok/fault kernels routed through the fork path) runs in **every**
-  misaligned invocation, including the `qa_strict_misaligned_canary` lane;
-  losing it aborts with exit 2. This pair is the regression proof for the
-  #101 defect class (an unaligned fault in a puppet-only worker), pinned in
-  CI by the ctest `qa_misaligned_puppet_control` (POSIX, plain + sanitizer
-  builds), whose pass/fail regexes require the rotator2 puppet's fork-routed
-  `ok` row and forbid FAIL rows or NC loss ("covered AND clean").
+  all-failed kernel reports `skip (fork setup failed: N impl-runs)`, never
+  `ok`; partial losses print a `setup-failed impl-runs: N` qualifier on the
+  row). Puppet rows carry a `(fork-isolated)` stdout tag derived from the
+  summary the fork branch itself reports — the tag observes the routing that
+  happened, not the predicate that selects it. One policy exclusion remains:
+  `volk_8u_conv_k7_r2puppet_8u` prints `skip … (excluded: #96 conv_k7)`
+  until its decision-buffer overflow (#96) lands — the corruption is
+  child-contained but would hard-red every ASan lane for a known, tracked
+  defect. A fork-path negative-control **trio** (planted ok, fault, and
+  alignment-sensitive-diverging kernels routed through forked children) runs
+  in **every** misaligned invocation, including the
+  `qa_strict_misaligned_canary` lane; losing any of the three verdict
+  transports (ok / crash / diverged) aborts with exit 2. The fault twin is
+  the regression proof for the #101 defect class (an unaligned fault in a
+  puppet-only worker), pinned by the ctest `qa_misaligned_puppet_control`,
+  whose pass/fail regexes require the rotator2 puppet's fork-routed `ok` row
+  and forbid FAIL rows, NC loss, or setup-failed qualifiers ("covered AND
+  clean"). That ctest registers by default on **Linux x86_64 only** (the
+  validated platform; CMake option `VOLK_MISALIGNED_PUPPET_CTEST`, opt-in
+  elsewhere) and never on static-dispatch builds, where
+  `volk_get_alignment()` is 1 and the mode's degenerate-alignment guard
+  fails closed by design — broadening to other arches/OSes after a
+  cross-platform probe is a tracked follow-up.
 - **Mapping-completeness note (#162):** for each puppet the sweep compares the
   master kernel's impl-name list against the puppet's wrappers and prints a
   stderr `note` for any master impl with no same-named wrapper — a stale
   puppet silently caps coverage for its whole kernel class (the
   gnuradio/volk#570 popcnt lesson). Advisory, name-set only: a wrapper that
   exists but calls the *wrong* master impl is a source-level property this
-  check cannot see.
+  check cannot see. The computation is self-checked at mode start against
+  hand-built descs (must fire on a planted gap AND stay quiet on a complete
+  pair; any misclassification is NC-LOST exit 2).
 - **ASan note:** run with
   `ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1`
   or ASan's handler wins and aborts on the first planted fault.

--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -29,7 +29,7 @@ environment variable:
 | `HARNESS_CANARY=1` | output-buffer canary: guarded own-malloc buffers, two-sentinel over/under-write + unwritten-element checks | #89 |
 | `HARNESS_CANARY_ASAN_DEMO=1` | (with `HARNESS_CANARY`, ASan build only) far-past over-run demo proving the guarded buffers are ASan-bracketed | #89 |
 | `HARNESS_IMMUTABLE=1` | input-immutability canary: byte-exact post-run compare of every input against its pristine pre-image | #90 |
-| `HARNESS_MISALIGNED=1` | misaligned `_u_`-variant runs: every unaligned impl on deliberately misaligned buffers, with scoped signal trapping (POSIX only); strict-UBSan regression detector is the ctest `qa_strict_misaligned_canary` (ASAN build type only) | #91 / #221 |
+| `HARNESS_MISALIGNED=1` | misaligned `_u_`-variant runs: every unaligned impl on deliberately misaligned buffers, with scoped signal trapping (POSIX only); puppet kernels run under fork isolation with `(fork-isolated)`-tagged rows (ctest `qa_misaligned_puppet_control`); strict-UBSan regression detector is the ctest `qa_strict_misaligned_canary` (ASAN build type only) | #91 / #221 / #162 |
 | `HARNESS_COMBINED_NC=1` | combined negative control (the ctest `qa_harness_negative_control`) | #92 |
 | `HARNESS_REPORT=path` | write the per-kernel × per-impl CSV (format below) in any mode | #87 / #92 |
 | `HARNESS_VERBOSE=1` | unmute the per-impl stdout of the underlying qa runs | — |
@@ -126,9 +126,34 @@ the kernel's numbers and cite this section.
   element-aligned but vector-misaligned buffers; SIGSEGV/SIGBUS/SIGILL are
   trapped with a scoped handler (one crashing impl = one recorded FAIL, the
   run continues) and output is compared against the same impl's aligned run.
-  POSIX-only (compiled out to an explicit skip on Windows). Puppet kernels are
-  excluded by design (no internal-allocation impls under the signal guard) —
-  defects reachable only through puppets are outside this mode's coverage.
+  POSIX-only (compiled out to an explicit skip on Windows).
+- **Puppet kernels (#162):** covered via **fork isolation**, not the signal
+  guard — puppets may allocate internally (3 of the 15 registered puppets do,
+  incl. encodepolar's 7 `volk_malloc` sites), which would make
+  `longjmp`-under-signal-guard recovery unsound. Each puppet impl's whole
+  aligned/misaligned/compare cycle runs in a forked child; a fault kills only
+  the child and the parent records it from the wait status + a phase pipe
+  (fail-closed: an impl whose fork setup fails is not counted, so an
+  all-failed kernel reports `skip`, never `ok`). Puppet rows carry a
+  `(fork-isolated)` stdout tag so the routing is observable. One policy
+  exclusion remains: `volk_8u_conv_k7_r2puppet_8u` prints
+  `skip … (excluded: #96 conv_k7)` until its decision-buffer overflow (#96)
+  lands — the corruption is child-contained but would hard-red every ASan
+  lane for a known, tracked defect. A second negative-control pair (the same
+  planted ok/fault kernels routed through the fork path) runs in **every**
+  misaligned invocation, including the `qa_strict_misaligned_canary` lane;
+  losing it aborts with exit 2. This pair is the regression proof for the
+  #101 defect class (an unaligned fault in a puppet-only worker), pinned in
+  CI by the ctest `qa_misaligned_puppet_control` (POSIX, plain + sanitizer
+  builds), whose pass/fail regexes require the rotator2 puppet's fork-routed
+  `ok` row and forbid FAIL rows or NC loss ("covered AND clean").
+- **Mapping-completeness note (#162):** for each puppet the sweep compares the
+  master kernel's impl-name list against the puppet's wrappers and prints a
+  stderr `note` for any master impl with no same-named wrapper — a stale
+  puppet silently caps coverage for its whole kernel class (the
+  gnuradio/volk#570 popcnt lesson). Advisory, name-set only: a wrapper that
+  exists but calls the *wrong* master impl is a source-level property this
+  check cannot see.
 - **ASan note:** run with
   `ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1`
   or ASan's handler wins and aborts on the first planted fault.

--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -244,16 +244,17 @@ Retention: latest snapshot only — a new snapshot replaces the old files
   mode compiles to an explicit skip (no POSIX signals); everything else —
   including the combined negative control ctest — runs.
 - **ASan builds:** canary far-past demo is gated to ASan; misaligned mode needs
-  the `ASAN_OPTIONS` above. Under the ASAN build type the control-kernel TU
-  (`qa_canary_kernel.cc`) is compiled with `-fno-sanitize=alignment` so a strict
-  UBSan lane (`halt_on_error=1`) can run the misaligned mode — the planted
-  `movaps` still faults; only the pre-fault UBSan report is suppressed, and only
-  for that one test-only TU (#221). The ctest `qa_strict_misaligned_canary`
-  (registered on ASAN builds only) runs the strict misaligned mode and goes red
-  if the exemption is ever lost. The exemption follows the ASAN build type
-  only: a UBSan build configured another way (e.g. `-DCMAKE_BUILD_TYPE=Debug`
-  with `-fsanitize=undefined` in `CMAKE_CXX_FLAGS`) still reports the planted
-  load under `halt_on_error=1`.
+  the `ASAN_OPTIONS` above. The control-kernel TU (`qa_canary_kernel.cc`) is
+  compiled with `-fno-sanitize=alignment` on **every** non-Windows build
+  (#221, gate widened by #162) so any UBSan-enabled lane (`halt_on_error=1`)
+  can run the misaligned mode — the planted `movaps` still faults; only the
+  pre-fault UBSan report is suppressed, and only for that one test-only TU.
+  The flag is an accepted no-op when no sanitizer is enabled, and UBSan can
+  arrive via injected `-fsanitize=undefined` flags on any build type (e.g.
+  `-DCMAKE_BUILD_TYPE=Debug` sanitizer sweeps), not just `CBTU=ASAN` — which
+  is why the exemption no longer follows the build type. Only the
+  `qa_strict_misaligned_canary` ctest *registration* remains ASAN-gated; it
+  runs the strict misaligned mode and goes red if the exemption is ever lost.
 - **Default qa:** `volk_test_all` and the per-kernel `qa_volk_*` ctests are
   byte-for-byte unaffected by every capability here; all harness behavior is
   opt-in via the env toggles.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -939,15 +939,27 @@ if(ENABLE_TESTING)
     # continues). NOTE: setting PASS_REGULAR_EXPRESSION makes ctest IGNORE the
     # process exit code -- the NC blocks run before the sweep row is printed,
     # so an NC loss is still caught by the fail regex; that ordering is
-    # load-bearing. Registration is gated to x86_64 POSIX hosts: this is a
-    # HARD covered-and-clean contract, and x86_64 (plain/ASan/UBSan) is the
-    # validated set. The misaligned mode has never run in CI on the QEMU
-    # arches (armv7/ppc64le/s390x/riscv64) or aarch64 -- enabling it there
-    # blind risks lane-redding on alignment behavior nobody has probed
-    # (degenerate volk_get_alignment(), QEMU fork semantics, arch-specific
-    # divergence). Broadening after a cross-arch probe is a filed follow-up;
-    # other hosts can opt in with -DVOLK_MISALIGNED_PUPPET_CTEST=ON.
-    if(NOT WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+    # load-bearing. The fail regex also reds on "setup-failed impl-runs": a
+    # partially-exercised kernel (some fork/pipe setups lost) must not pass as
+    # covered. Registration is gated to Linux x86_64 hosts by default: the
+    # contract is HARD covered-and-clean, and the validated evidence is one
+    # Linux x86-64 box across plain / ASAN-build-type / Debug+UBSan-flag
+    # configs plus local static and static-dispatch(generic) probes. The
+    # misaligned mode has never run in CI on the QEMU arches
+    # (armv7/ppc64le/s390x/riscv64), aarch64, or macOS -- enabling it there
+    # blind risks lane-redding on behavior nobody has probed (degenerate
+    # volk_get_alignment(), QEMU fork semantics, arch-specific divergence,
+    # platform libc). Static-dispatch builds are excluded outright: with a
+    # single statically dispatched machine (CI pins "generic") the misaligned
+    # mode's degenerate-alignment guard fails closed NC-LOST -- probed live:
+    # volk_get_alignment()==1 cannot misalign anything, the mode is
+    # inapplicable by design, and the hard ctest would red the lane.
+    # Broadening after a cross-platform probe is a filed follow-up; other
+    # hosts can opt in with -DVOLK_MISALIGNED_PUPPET_CTEST=ON.
+    if(NOT WIN32
+       AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
+       AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$"
+       AND NOT VOLK_STATIC_DISPATCH)
         set(VOLK_MISALIGNED_PUPPET_CTEST_DEFAULT ON)
     else()
         set(VOLK_MISALIGNED_PUPPET_CTEST_DEFAULT OFF)
@@ -966,7 +978,7 @@ if(ENABLE_TESTING)
                 PASS_REGULAR_EXPRESSION
                 "ok    \\[misaligned\\] volk_32fc_s32fc_rotator2puppet_32fc \\(fork-isolated\\)"
                 FAIL_REGULAR_EXPRESSION
-                "NEGATIVE CONTROL LOST;FAIL  \\[misaligned\\]"
+                "NEGATIVE CONTROL LOST;FAIL  \\[misaligned\\];setup-failed impl-runs"
                 ENVIRONMENT
                 "HARNESS_MISALIGNED=1;UBSAN_OPTIONS=halt_on_error=1;ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1"
         )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -895,17 +895,22 @@ if(ENABLE_TESTING)
     # The planted misaligned-fault control must keep its raw movaps, but
     # UBSan's alignment check reports it BEFORE the deliberate fault, so a
     # strict lane (halt_on_error=1) dies pre-sweep. Exempt this one test-only
-    # TU under the sanitizer build type (#221; details: harness README,
-    # Platform notes). A function-level no_sanitize attribute does NOT work
-    # here -- GCC generates the check inside the always-inlined _mm_load_ps.
-    # The qa_strict_misaligned_canary ctest is the regression detector: it
-    # goes red if the exemption is dropped, stops reaching the compile line,
-    # or the canary stops faulting (NC-LOST exit 2).
-    if(NOT WIN32 AND CBTU STREQUAL "ASAN")
+    # TU (#221; details: harness README, Platform notes). A function-level
+    # no_sanitize attribute does NOT work here -- GCC generates the check
+    # inside the always-inlined _mm_load_ps. Unconditional on POSIX (#162,
+    # widening #221's ASAN-build-type gate): UBSan can arrive via injected
+    # -fsanitize flags on ANY build type (e.g. sanitizer sweeps over Debug),
+    # not just CBTU=ASAN, and -fno-sanitize=alignment is an accepted no-op
+    # when no sanitizer is enabled. The qa_strict_misaligned_canary ctest is
+    # the regression detector: it goes red if the exemption is dropped, stops
+    # reaching the compile line, or the canary stops faulting (NC-LOST exit 2).
+    if(NOT WIN32)
         set_property(
             SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
             APPEND
             PROPERTY COMPILE_OPTIONS "-fno-sanitize=alignment")
+    endif()
+    if(NOT WIN32 AND CBTU STREQUAL "ASAN")
         add_test(NAME qa_strict_misaligned_canary
                  COMMAND volk_test_correctness volk_32f_x3_sum_of_poly_32f)
         set_tests_properties(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -915,6 +915,31 @@ if(ENABLE_TESTING)
                 "HARNESS_MISALIGNED=1;UBSAN_OPTIONS=halt_on_error=1;ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1"
         )
     endif()
+    # #162: puppet kernels are covered in misaligned mode via fork isolation.
+    # The pass regex pins the whole contract observably: the rotator2 puppet
+    # must produce a real, fork-routed ok row (not the pre-#162 skip, and not
+    # a silent loss of the fork routing -- the "(fork-isolated)" tag is printed
+    # only on the puppet path). The fail regex reds the lane on any recorded
+    # FAIL row or a lost negative control (either pair; the fork-path pair is
+    # the #101-class regression proof: a planted unaligned fault in a forked
+    # child must be recorded while the run continues). POSIX-only: the mode is
+    # signal/fork-based and compiles to a fail-closed skip on WIN32.
+    if(NOT WIN32)
+        add_test(NAME qa_misaligned_puppet_control
+                 COMMAND volk_test_correctness volk_32fc_s32fc_rotator2puppet_32fc)
+        set_tests_properties(
+            qa_misaligned_puppet_control
+            PROPERTIES
+                TIMEOUT
+                600
+                PASS_REGULAR_EXPRESSION
+                "ok    \\[misaligned\\] volk_32fc_s32fc_rotator2puppet_32fc \\(fork-isolated\\)"
+                FAIL_REGULAR_EXPRESSION
+                "NEGATIVE CONTROL LOST;FAIL  \\[misaligned\\]"
+                ENVIRONMENT
+                "HARNESS_MISALIGNED=1;UBSAN_OPTIONS=halt_on_error=1;ASAN_OPTIONS=handle_segv=0:handle_sigbus=0:handle_sigill=0:allow_user_segv_handler=1"
+        )
+    endif()
     target_link_libraries(volk_test_all fmt::fmt)
     target_link_libraries(volk_test_correctness fmt::fmt)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -897,18 +897,26 @@ if(ENABLE_TESTING)
     # strict lane (halt_on_error=1) dies pre-sweep. Exempt this one test-only
     # TU (#221; details: harness README, Platform notes). A function-level
     # no_sanitize attribute does NOT work here -- GCC generates the check
-    # inside the always-inlined _mm_load_ps. Unconditional on POSIX (#162,
-    # widening #221's ASAN-build-type gate): UBSan can arrive via injected
-    # -fsanitize flags on ANY build type (e.g. sanitizer sweeps over Debug),
-    # not just CBTU=ASAN, and -fno-sanitize=alignment is an accepted no-op
-    # when no sanitizer is enabled. The qa_strict_misaligned_canary ctest is
-    # the regression detector: it goes red if the exemption is dropped, stops
-    # reaching the compile line, or the canary stops faulting (NC-LOST exit 2).
+    # inside the always-inlined _mm_load_ps. Applied on every POSIX build
+    # whose compiler accepts the flag (#162, widening #221's ASAN-build-type
+    # gate): UBSan can arrive via injected -fsanitize flags on ANY build type
+    # (e.g. sanitizer sweeps over Debug), not just CBTU=ASAN, and
+    # -fno-sanitize=alignment is a no-op when no sanitizer is enabled. The
+    # flag-support probe follows this file's check_cxx_compiler_flag idiom
+    # rather than asserting compiler behavior. The qa_strict_misaligned_canary
+    # ctest is the regression detector: it goes red if the exemption is
+    # dropped, stops reaching the compile line, or the canary stops faulting
+    # (NC-LOST exit 2).
     if(NOT WIN32)
-        set_property(
-            SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
-            APPEND
-            PROPERTY COMPILE_OPTIONS "-fno-sanitize=alignment")
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("-fno-sanitize=alignment"
+                                HAVE_NO_SANITIZE_ALIGNMENT)
+        if(HAVE_NO_SANITIZE_ALIGNMENT)
+            set_property(
+                SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
+                APPEND
+                PROPERTY COMPILE_OPTIONS "-fno-sanitize=alignment")
+        endif()
     endif()
     if(NOT WIN32 AND CBTU STREQUAL "ASAN")
         add_test(NAME qa_strict_misaligned_canary
@@ -925,11 +933,29 @@ if(ENABLE_TESTING)
     # must produce a real, fork-routed ok row (not the pre-#162 skip, and not
     # a silent loss of the fork routing -- the "(fork-isolated)" tag is printed
     # only on the puppet path). The fail regex reds the lane on any recorded
-    # FAIL row or a lost negative control (either pair; the fork-path pair is
-    # the #101-class regression proof: a planted unaligned fault in a forked
-    # child must be recorded while the run continues). POSIX-only: the mode is
-    # signal/fork-based and compiles to a fail-closed skip on WIN32.
-    if(NOT WIN32)
+    # FAIL row or a lost negative control (any of the three pairs; the
+    # fork-path fault twin is the #101-class regression proof: a planted
+    # unaligned fault in a forked child must be recorded while the run
+    # continues). NOTE: setting PASS_REGULAR_EXPRESSION makes ctest IGNORE the
+    # process exit code -- the NC blocks run before the sweep row is printed,
+    # so an NC loss is still caught by the fail regex; that ordering is
+    # load-bearing. Registration is gated to x86_64 POSIX hosts: this is a
+    # HARD covered-and-clean contract, and x86_64 (plain/ASan/UBSan) is the
+    # validated set. The misaligned mode has never run in CI on the QEMU
+    # arches (armv7/ppc64le/s390x/riscv64) or aarch64 -- enabling it there
+    # blind risks lane-redding on alignment behavior nobody has probed
+    # (degenerate volk_get_alignment(), QEMU fork semantics, arch-specific
+    # divergence). Broadening after a cross-arch probe is a filed follow-up;
+    # other hosts can opt in with -DVOLK_MISALIGNED_PUPPET_CTEST=ON.
+    if(NOT WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+        set(VOLK_MISALIGNED_PUPPET_CTEST_DEFAULT ON)
+    else()
+        set(VOLK_MISALIGNED_PUPPET_CTEST_DEFAULT OFF)
+    endif()
+    option(VOLK_MISALIGNED_PUPPET_CTEST
+           "Register the qa_misaligned_puppet_control ctest (#162)"
+           ${VOLK_MISALIGNED_PUPPET_CTEST_DEFAULT})
+    if(NOT WIN32 AND VOLK_MISALIGNED_PUPPET_CTEST)
         add_test(NAME qa_misaligned_puppet_control
                  COMMAND volk_test_correctness volk_32fc_s32fc_rotator2puppet_32fc)
         set_tests_properties(

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -19,12 +19,15 @@
 // function names of the pattern kernel_name_*
 
 // for puppets we need to get all the func_variants for the puppet and just
-// keep track of the actual function name to write to results
+// keep track of the actual function name to write to results. #162: the
+// master's func_desc is captured too, so the harness can check the puppet's
+// wrapper list against the master's impl list (mapping-completeness note).
 #define VOLK_INIT_PUPP(func, puppet_master_func, test_params) \
     volk_test_case_t(func##_get_func_desc(),                  \
                      (void (*)())func##_manual,               \
                      std::string(#func),                      \
                      std::string(#puppet_master_func),        \
+                     puppet_master_func##_get_func_desc(),    \
                      test_params)
 
 #define VOLK_INIT_TEST(func, test_params)       \

--- a/lib/qa_canary_kernel.cc
+++ b/lib/qa_canary_kernel.cc
@@ -7,13 +7,16 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-// Under the ASAN build type this TU is compiled with -fno-sanitize=alignment
-// (see lib/CMakeLists.txt, #221): UBSan will NOT report misaligned access from
-// anything added to this file — the planted faults must stay real faults.
+// On every non-Windows build this TU is compiled with -fno-sanitize=alignment
+// (see lib/CMakeLists.txt; #221, gate widened by #162 because UBSan can arrive
+// via injected -fsanitize flags on any build type): UBSan will NOT report
+// misaligned access from anything added to this file — the planted faults must
+// stay real faults.
 
 #include "qa_canary_kernel.h"
 
 #include "volk/volk_complex.h" // lv_32fc_t/lv_cmake (planted power pair, #92)
+#include <volk/volk.h>         // volk_get_alignment (misaligned-diverge control, #162)
 #include <cmath>               // atan2f/powf/cosf/sinf/tanhf (planted defect pairs, #92)
 #include <csignal>             // for raise (misaligned-fault portable fallback, #91)
 #include <cstdint>             // for uint32_t (input-immutability scribble, #90)
@@ -121,6 +124,28 @@ void volk_32f_misalignedfault_32f(void* out,
 #endif
     for (unsigned int n = 0; n < num_points; ++n) {
         o[n] = i[n];
+    }
+}
+
+void volk_32f_misaligneddiverge_32f(void* out,
+                                    void* in,
+                                    unsigned int num_points,
+                                    const char*)
+{
+    float* o = static_cast<float*>(out);
+    const float* i = static_cast<const float*>(in);
+    for (unsigned int n = 0; n < num_points; ++n) {
+        o[n] = i[n];
+    }
+    // The planted defect (#162): the result depends on the INPUT pointer's
+    // alignment. The harness's aligned pool buffers sit ON a
+    // volk_get_alignment() boundary; its misaligned copies sit one element past
+    // one -- so the perturbation fires on exactly the misaligned run, far
+    // beyond any kernel tol, and the aligned-vs-misaligned compare MUST report
+    // divergence (never a crash). This is the failure class the
+    // misalignedfault control cannot exercise: a wrong-answer, not a fault.
+    if (num_points > 0 && reinterpret_cast<uintptr_t>(in) % volk_get_alignment() != 0) {
+        o[0] += 1000.0f;
     }
 }
 

--- a/lib/qa_canary_kernel.h
+++ b/lib/qa_canary_kernel.h
@@ -98,6 +98,13 @@ void volk_32f_misalignedfault_32f(void* out,
                                   void* in,
                                   unsigned int num_points,
                                   const char* arch);
+// #162 misaligned negative control: output depends on the INPUT pointer's
+// alignment (the alignment-sensitive-result class) -- proves the DIVERGED
+// verdict transport, the failure class the fault control cannot exercise.
+void volk_32f_misaligneddiverge_32f(void* out,
+                                    void* in,
+                                    unsigned int num_points,
+                                    const char* arch);
 
 // #92 combined negative control: test-only copies of the two escaped defects
 // that motivated epic #85, paired with corrected twins. The defect copies are

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -2942,6 +2942,54 @@ run_volk_misaligned_test(volk_func_desc_t desc,
     // write only a fixed-size scalar into out[0..k), and output cardinality
     // cannot be derived from the signature (#89 lesson). With a common prefill,
     // never-written regions are 0 == 0 and only kernel-written elements compare.
+
+    // Buffer-cycle helpers shared by the signal path and the #162 fork path so
+    // the two cannot drift (both run OUTSIDE any sigsetjmp window; only the
+    // run_impl_direct calls sit inside one, so the setjmp-clobber discipline is
+    // untouched by this sharing).
+    // Aligned reference side: this impl's pool buffers, outputs zero-prefilled.
+    auto gather_aligned_buffs = [&](size_t impl_idx) {
+        std::vector<void*> abuffs;
+        for (size_t j = 0; j < d.both_sigs.size(); j++) {
+            abuffs.push_back(d.test_data[impl_idx][j]);
+        }
+        for (size_t j = 0; j < d.outputsig.size(); j++) {
+            const size_t out_bytes = static_cast<size_t>(vlen) * d.outputsig[j].size *
+                                     (d.outputsig[j].is_complex ? 2 : 1);
+            memset(abuffs[j], 0, out_bytes);
+        }
+        return abuffs;
+    };
+    // Misaligned test side: own-malloc misaligned copies, identical inputs.
+    // vlen_twiddle padding: the misaligned copy must span the same seeded
+    // region as the aligned pool buffer so a fixed-element over-read reads
+    // identical bytes on both sides (#98; a mere zero-fill would make the
+    // vlen < 5 comparison vacuous).
+    auto build_misaligned_buffs =
+        [&](std::vector<std::unique_ptr<misaligned_buffer>>& mbufs) {
+            std::vector<void*> buffs;
+            for (size_t j = 0; j < d.both_sigs.size(); j++) {
+                const size_t elem =
+                    d.both_sigs[j].size * (d.both_sigs[j].is_complex ? 2 : 1);
+                const size_t bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
+                mbufs.push_back(
+                    std::make_unique<misaligned_buffer>(bytes, alignment, elem));
+                buffs.push_back(mbufs.back()->data());
+            }
+            for (size_t j = 0; j < d.outputsig.size(); j++) {
+                const size_t out_bytes = static_cast<size_t>(vlen) * d.outputsig[j].size *
+                                         (d.outputsig[j].is_complex ? 2 : 1);
+                memset(buffs[j], 0, out_bytes);
+            }
+            for (size_t k = 0; k < d.inputsig.size(); k++) {
+                const size_t elem =
+                    d.inputsig[k].size * (d.inputsig[k].is_complex ? 2 : 1);
+                const size_t in_bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
+                memcpy(buffs[d.outputsig.size() + k], d.inbuffs[k], in_bytes);
+            }
+            return buffs;
+        };
+
     scoped_fault_isolation guard_signals;
 
     for (size_t i = 0; i < d.arch_list.size(); i++) {
@@ -2975,6 +3023,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
             if (pipe(pfd) != 0) {
                 std::cerr << name << ": pipe() failed for arch " << arch
                           << " -- impl not exercised (not counted)\n";
+                summary.setup_failed++; // surfaced on the driver's row (#162)
                 continue; // fail closed: neither applied nor checked
             }
             const pid_t pid = fork();
@@ -2983,50 +3032,18 @@ run_volk_misaligned_test(volk_func_desc_t desc,
                 close(pfd[1]);
                 std::cerr << name << ": fork() failed for arch " << arch
                           << " -- impl not exercised (not counted)\n";
+                summary.setup_failed++; // surfaced on the driver's row (#162)
                 continue; // fail closed
             }
             if (pid == 0) {
                 close(pfd[0]);
-                // Child cycle mirrors the signal path's buffer discipline below
-                // (same #98 vlen_twiddle seeding rationale, same zero-prefill
-                // contract) minus the sigsetjmp windows -- keep both in sync.
                 // ---- child: aligned reference run (no sigsetjmp window) ----
-                std::vector<void*> abuffs;
-                for (size_t j = 0; j < d.both_sigs.size(); j++) {
-                    abuffs.push_back(d.test_data[i][j]);
-                }
-                for (size_t j = 0; j < d.outputsig.size(); j++) {
-                    const size_t out_bytes = static_cast<size_t>(vlen) *
-                                             d.outputsig[j].size *
-                                             (d.outputsig[j].is_complex ? 2 : 1);
-                    memset(abuffs[j], 0, out_bytes);
-                }
+                std::vector<void*> abuffs = gather_aligned_buffs(i);
                 run_impl_direct(abuffs, arch_cstr);
                 send_phase(pfd[1], 'A');
                 // ---- child: misaligned run, identical inputs ----
                 std::vector<std::unique_ptr<misaligned_buffer>> mbufs;
-                std::vector<void*> buffs;
-                for (size_t j = 0; j < d.both_sigs.size(); j++) {
-                    const size_t elem =
-                        d.both_sigs[j].size * (d.both_sigs[j].is_complex ? 2 : 1);
-                    const size_t bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
-                    mbufs.push_back(
-                        std::make_unique<misaligned_buffer>(bytes, alignment, elem));
-                    buffs.push_back(mbufs.back()->data());
-                }
-                for (size_t j = 0; j < d.outputsig.size(); j++) {
-                    const size_t out_bytes = static_cast<size_t>(vlen) *
-                                             d.outputsig[j].size *
-                                             (d.outputsig[j].is_complex ? 2 : 1);
-                    memset(buffs[j], 0, out_bytes);
-                }
-                for (size_t k = 0; k < d.inputsig.size(); k++) {
-                    const size_t elem =
-                        d.inputsig[k].size * (d.inputsig[k].is_complex ? 2 : 1);
-                    const size_t in_bytes =
-                        static_cast<size_t>(vlen + vlen_twiddle) * elem;
-                    memcpy(buffs[d.outputsig.size() + k], d.inbuffs[k], in_bytes);
-                }
+                std::vector<void*> buffs = build_misaligned_buffs(mbufs);
                 run_impl_direct(buffs, arch_cstr);
                 send_phase(pfd[1], 'M');
                 // ---- child: compare (same helper as the signal path) ----
@@ -3085,15 +3102,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
         summary.checked_impls.push_back(arch); // #92 triage detail
 
         // ---- Reference run: this impl on its ALIGNED pool buffers ----
-        std::vector<void*> abuffs;
-        for (size_t j = 0; j < d.both_sigs.size(); j++) {
-            abuffs.push_back(d.test_data[i][j]);
-        }
-        for (size_t j = 0; j < d.outputsig.size(); j++) {
-            const size_t out_bytes = static_cast<size_t>(vlen) * d.outputsig[j].size *
-                                     (d.outputsig[j].is_complex ? 2 : 1);
-            memset(abuffs[j], 0, out_bytes);
-        }
+        std::vector<void*> abuffs = gather_aligned_buffs(i);
         const char* arch_cstr = arch.c_str(); // materialized BEFORE sigsetjmp
         g_misaligned_sig = 0;
         // setjmp-clobber discipline: NOTHING may be modified between a sigsetjmp
@@ -3116,28 +3125,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
 
         // ---- Test run: the SAME impl on misaligned buffers, identical inputs ----
         std::vector<std::unique_ptr<misaligned_buffer>> mbufs;
-        std::vector<void*> buffs;
-        for (size_t j = 0; j < d.both_sigs.size(); j++) {
-            const size_t elem = d.both_sigs[j].size * (d.both_sigs[j].is_complex ? 2 : 1);
-            // vlen_twiddle padding here too: the misaligned copy must span the same
-            // seeded region as the aligned pool buffer so a fixed-element over-read
-            // reads identical bytes on both sides (#98).
-            const size_t bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
-            mbufs.push_back(std::make_unique<misaligned_buffer>(bytes, alignment, elem));
-            buffs.push_back(mbufs.back()->data());
-        }
-        for (size_t j = 0; j < d.outputsig.size(); j++) {
-            const size_t out_bytes = static_cast<size_t>(vlen) * d.outputsig[j].size *
-                                     (d.outputsig[j].is_complex ? 2 : 1);
-            memset(buffs[j], 0, out_bytes);
-        }
-        for (size_t k = 0; k < d.inputsig.size(); k++) {
-            // Copy the full seeded region (vlen + vlen_twiddle), matching the aligned
-            // pool pre-image, so fixed-element over-reads see identical bytes (#98).
-            const size_t elem = d.inputsig[k].size * (d.inputsig[k].is_complex ? 2 : 1);
-            const size_t in_bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
-            memcpy(buffs[d.outputsig.size() + k], d.inbuffs[k], in_bytes);
-        }
+        std::vector<void*> buffs = build_misaligned_buffs(mbufs);
 
         g_misaligned_sig = 0;
         if (sigsetjmp(g_misaligned_jmp, 1) == 0) {

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -3032,7 +3032,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
                 std::cerr << name << ": pipe() failed for arch " << arch
                           << " -- impl not exercised (not counted)\n";
                 summary.setup_failed++; // surfaced on the driver's row (#162)
-                continue; // fail closed: neither applied nor checked
+                continue;               // fail closed: neither applied nor checked
             }
             const pid_t pid = fork();
             if (pid < 0) {
@@ -3041,7 +3041,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
                 std::cerr << name << ": fork() failed for arch " << arch
                           << " -- impl not exercised (not counted)\n";
                 summary.setup_failed++; // surfaced on the driver's row (#162)
-                continue; // fail closed
+                continue;               // fail closed
             }
             if (pid == 0) {
                 close(pfd[0]);
@@ -3079,7 +3079,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
             close(pfd[0]);
             if (nread < 0)
                 nread = 0;
-            summary.applied = true;                // a child ran: this impl was exercised
+            summary.applied = true;       // a child ran: this impl was exercised
             summary.fork_isolated = true; // routing OBSERVED, not inferred (#162)
             summary.checked_impls.push_back(arch); // #92 triage detail
             const bool completed = (WIFEXITED(status) && WEXITSTATUS(status) == 0 &&

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -41,6 +41,11 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
+#ifndef _WIN32
+#include <sys/wait.h> // waitpid/WIFSIGNALED (fork-isolation parent, #162)
+#include <unistd.h>   // fork/pipe/read/write/_exit (fork isolation, #162)
+#endif
+
 // Warmup time for CPU frequency scaling (ms)
 static double g_warmup_ms = 2000.0;
 static bool g_warmup_done = false;
@@ -2565,9 +2570,6 @@ run_volk_misaligned_test(volk_func_desc_t /*desc*/,
 }
 #else
 
-#include <sys/wait.h>
-#include <unistd.h>
-
 namespace {
 // #91: SIGSEGV/SIGBUS/SIGILL isolation for misaligned-impl runs. An aligned SIMD
 // load on a misaligned address raises a hardware signal, not a C++ exception, so
@@ -3013,7 +3015,13 @@ run_volk_misaligned_test(volk_func_desc_t desc,
             // checked_impls are set HERE, only after a child actually ran -- a
             // pipe()/fork() failure leaves this impl uncounted so an all-failed
             // kernel reports skip, never a green ok over never-run code (#162
-            // fail-closed).
+            // fail-closed). Fork-safety invariant: the process-wide fault
+            // handlers are installed, but g_misaligned_window_open is ALWAYS 0
+            // at this fork point (fork_isolation is a whole-call flag, so no
+            // sigsetjmp window can be open here) -- a fault in the child
+            // therefore re-raises with default disposition instead of
+            // longjmp-ing through the child's copy of a stale jmp_buf. Any
+            // future per-impl routing change must preserve this.
             const char* arch_cstr = arch.c_str();
             // Flush ALL C output streams pre-fork (iostreams are tied to them
             // in this binary) so the child cannot double-emit buffered output
@@ -3072,6 +3080,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
             if (nread < 0)
                 nread = 0;
             summary.applied = true;                // a child ran: this impl was exercised
+            summary.fork_isolated = true; // routing OBSERVED, not inferred (#162)
             summary.checked_impls.push_back(arch); // #92 triage detail
             const bool completed = (WIFEXITED(status) && WEXITSTATUS(status) == 0 &&
                                     nread == 3 && phases[0] == 'A' && phases[1] == 'M');

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -2659,6 +2659,11 @@ private:
     uint8_t* raw_;
     void* ptr_;
 };
+
+// #162: one byte of the fork-path phase protocol ('A' aligned-run done,
+// 'M' misaligned-run done, then verdict 'O'/'D'). write(2) is fork-safe;
+// the parent classifies a short read as a crash in the unreached phase.
+void send_phase(int fd, char c) { (void)!write(fd, &c, 1); }
 } // namespace
 
 volk_misaligned_summary
@@ -2962,10 +2967,10 @@ run_volk_misaligned_test(volk_func_desc_t desc,
             // kernel reports skip, never a green ok over never-run code (#162
             // fail-closed).
             const char* arch_cstr = arch.c_str();
-            std::fflush(stdout);
-            std::fflush(stderr);
-            std::cout.flush();
-            std::cerr.flush();
+            // Flush ALL C output streams pre-fork (iostreams are tied to them
+            // in this binary) so the child cannot double-emit buffered output
+            // through the driver's muting fds.
+            std::fflush(nullptr);
             int pfd[2];
             if (pipe(pfd) != 0) {
                 std::cerr << name << ": pipe() failed for arch " << arch
@@ -2982,6 +2987,9 @@ run_volk_misaligned_test(volk_func_desc_t desc,
             }
             if (pid == 0) {
                 close(pfd[0]);
+                // Child cycle mirrors the signal path's buffer discipline below
+                // (same #98 vlen_twiddle seeding rationale, same zero-prefill
+                // contract) minus the sigsetjmp windows -- keep both in sync.
                 // ---- child: aligned reference run (no sigsetjmp window) ----
                 std::vector<void*> abuffs;
                 for (size_t j = 0; j < d.both_sigs.size(); j++) {
@@ -2994,10 +3002,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
                     memset(abuffs[j], 0, out_bytes);
                 }
                 run_impl_direct(abuffs, arch_cstr);
-                {
-                    const char ph = 'A';
-                    (void)!write(pfd[1], &ph, 1);
-                }
+                send_phase(pfd[1], 'A');
                 // ---- child: misaligned run, identical inputs ----
                 std::vector<std::unique_ptr<misaligned_buffer>> mbufs;
                 std::vector<void*> buffs;
@@ -3023,10 +3028,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
                     memcpy(buffs[d.outputsig.size() + k], d.inbuffs[k], in_bytes);
                 }
                 run_impl_direct(buffs, arch_cstr);
-                {
-                    const char ph = 'M';
-                    (void)!write(pfd[1], &ph, 1);
-                }
+                send_phase(pfd[1], 'M');
                 // ---- child: compare (same helper as the signal path) ----
                 bool child_diverged = false;
                 for (size_t j = 0; j < d.both_sigs.size(); j++) {
@@ -3039,10 +3041,7 @@ run_volk_misaligned_test(volk_func_desc_t desc,
                                   << ") [forked child]\n";
                     }
                 }
-                {
-                    const char verdict = child_diverged ? 'D' : 'O';
-                    (void)!write(pfd[1], &verdict, 1);
-                }
+                send_phase(pfd[1], child_diverged ? 'D' : 'O');
                 std::fflush(stderr);
                 _exit(0); // NEVER exit(): no double stdio flush, no atexit
             }

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -2573,10 +2573,11 @@ namespace {
 // load on a misaligned address raises a hardware signal, not a C++ exception, so
 // catch(...) cannot trap it. sigsetjmp/siglongjmp is sound HERE because every
 // exercised impl is a pure computational loop over harness-owned buffers (the
-// driver skips puppets): no locks, allocations, or unwind-relevant state can be
-// in flight at the faulting instruction, and the dispatch deliberately uses
-// direct casted calls so no C++ frame with a non-trivial destructor sits between
-// the sigsetjmp and the fault.
+// driver routes puppets to the fork-isolation path -- see fork_isolation, #162 --
+// so no impl with internal allocation runs under the signal guard): no locks,
+// allocations, or unwind-relevant state can be in flight at the faulting
+// instruction, and the dispatch deliberately uses direct casted calls so no C++
+// frame with a non-trivial destructor sits between the sigsetjmp and the fault.
 // Single-threaded qa binary by design: process-wide handlers + globals are safe
 // (the faults are synchronous; there is no second thread to race).
 sigjmp_buf g_misaligned_jmp;

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -2555,7 +2555,8 @@ run_volk_misaligned_test(volk_func_desc_t /*desc*/,
                          unsigned int /*vlen*/,
                          std::vector<volk_test_results_t>* /*results*/,
                          const std::vector<float>& /*float_edge_cases*/,
-                         const std::vector<lv_32fc_t>& /*complex_edge_cases*/)
+                         const std::vector<lv_32fc_t>& /*complex_edge_cases*/,
+                         bool /*fork_isolation*/)
 {
     std::cerr << "misaligned mode: unsupported on this platform (POSIX signal "
                  "isolation required): "
@@ -2563,6 +2564,9 @@ run_volk_misaligned_test(volk_func_desc_t /*desc*/,
     return volk_misaligned_summary();
 }
 #else
+
+#include <sys/wait.h>
+#include <unistd.h>
 
 namespace {
 // #91: SIGSEGV/SIGBUS/SIGILL isolation for misaligned-impl runs. An aligned SIMD
@@ -2666,7 +2670,8 @@ run_volk_misaligned_test(volk_func_desc_t desc,
                          unsigned int vlen,
                          std::vector<volk_test_results_t>* results,
                          const std::vector<float>& float_edge_cases,
-                         const std::vector<lv_32fc_t>& complex_edge_cases)
+                         const std::vector<lv_32fc_t>& complex_edge_cases,
+                         bool fork_isolation)
 {
     volk_misaligned_summary summary;
 
@@ -2939,6 +2944,143 @@ run_volk_misaligned_test(volk_func_desc_t desc,
         if (desc.impl_alignment[orig_idx]) {
             continue; // aligned-only impl: allowed to assume alignment, not under test
         }
+
+        if (fork_isolation) {
+            // #162: process-level isolation for impls that may allocate internally
+            // (puppets) -- the longjmp-under-signal-guard soundness argument does
+            // not hold for them (see the block comment above
+            // scoped_fault_isolation), so recovery is waitpid, not siglongjmp. The
+            // whole aligned/misaligned/compare cycle runs in a forked child; a
+            // fault reaches misaligned_fault_handler with NO window open,
+            // re-raises with default disposition, and kills only the child. Phase
+            // pipe: 'A' aligned-run done, 'M' misaligned-run done, then verdict
+            // 'O' (ok) / 'D' (diverged); a short read + wait status attributes a
+            // crash to the phase that died. Bookkeeping note: applied /
+            // checked_impls are set HERE, only after a child actually ran -- a
+            // pipe()/fork() failure leaves this impl uncounted so an all-failed
+            // kernel reports skip, never a green ok over never-run code (#162
+            // fail-closed).
+            const char* arch_cstr = arch.c_str();
+            std::fflush(stdout);
+            std::fflush(stderr);
+            std::cout.flush();
+            std::cerr.flush();
+            int pfd[2];
+            if (pipe(pfd) != 0) {
+                std::cerr << name << ": pipe() failed for arch " << arch
+                          << " -- impl not exercised (not counted)\n";
+                continue; // fail closed: neither applied nor checked
+            }
+            const pid_t pid = fork();
+            if (pid < 0) {
+                close(pfd[0]);
+                close(pfd[1]);
+                std::cerr << name << ": fork() failed for arch " << arch
+                          << " -- impl not exercised (not counted)\n";
+                continue; // fail closed
+            }
+            if (pid == 0) {
+                close(pfd[0]);
+                // ---- child: aligned reference run (no sigsetjmp window) ----
+                std::vector<void*> abuffs;
+                for (size_t j = 0; j < d.both_sigs.size(); j++) {
+                    abuffs.push_back(d.test_data[i][j]);
+                }
+                for (size_t j = 0; j < d.outputsig.size(); j++) {
+                    const size_t out_bytes = static_cast<size_t>(vlen) *
+                                             d.outputsig[j].size *
+                                             (d.outputsig[j].is_complex ? 2 : 1);
+                    memset(abuffs[j], 0, out_bytes);
+                }
+                run_impl_direct(abuffs, arch_cstr);
+                {
+                    const char ph = 'A';
+                    (void)!write(pfd[1], &ph, 1);
+                }
+                // ---- child: misaligned run, identical inputs ----
+                std::vector<std::unique_ptr<misaligned_buffer>> mbufs;
+                std::vector<void*> buffs;
+                for (size_t j = 0; j < d.both_sigs.size(); j++) {
+                    const size_t elem =
+                        d.both_sigs[j].size * (d.both_sigs[j].is_complex ? 2 : 1);
+                    const size_t bytes = static_cast<size_t>(vlen + vlen_twiddle) * elem;
+                    mbufs.push_back(
+                        std::make_unique<misaligned_buffer>(bytes, alignment, elem));
+                    buffs.push_back(mbufs.back()->data());
+                }
+                for (size_t j = 0; j < d.outputsig.size(); j++) {
+                    const size_t out_bytes = static_cast<size_t>(vlen) *
+                                             d.outputsig[j].size *
+                                             (d.outputsig[j].is_complex ? 2 : 1);
+                    memset(buffs[j], 0, out_bytes);
+                }
+                for (size_t k = 0; k < d.inputsig.size(); k++) {
+                    const size_t elem =
+                        d.inputsig[k].size * (d.inputsig[k].is_complex ? 2 : 1);
+                    const size_t in_bytes =
+                        static_cast<size_t>(vlen + vlen_twiddle) * elem;
+                    memcpy(buffs[d.outputsig.size() + k], d.inbuffs[k], in_bytes);
+                }
+                run_impl_direct(buffs, arch_cstr);
+                {
+                    const char ph = 'M';
+                    (void)!write(pfd[1], &ph, 1);
+                }
+                // ---- child: compare (same helper as the signal path) ----
+                bool child_diverged = false;
+                for (size_t j = 0; j < d.both_sigs.size(); j++) {
+                    double max_err = 0.0;
+                    if (compare_buffer(j, abuffs[j], buffs[j], max_err)) {
+                        child_diverged = true;
+                        std::cerr << name << ": output diverged between aligned and "
+                                  << "misaligned runs on arch " << arch << " (buffer "
+                                  << j << ", vlen " << vlen << ", max_err " << max_err
+                                  << ") [forked child]\n";
+                    }
+                }
+                {
+                    const char verdict = child_diverged ? 'D' : 'O';
+                    (void)!write(pfd[1], &verdict, 1);
+                }
+                std::fflush(stderr);
+                _exit(0); // NEVER exit(): no double stdio flush, no atexit
+            }
+            // ---- parent: classify, then do the bookkeeping ----
+            close(pfd[1]);
+            int status = 0;
+            (void)waitpid(pid, &status, 0);
+            char phases[3] = { 0, 0, 0 };
+            ssize_t nread = read(pfd[0], phases, sizeof(phases));
+            close(pfd[0]);
+            if (nread < 0)
+                nread = 0;
+            summary.applied = true;                // a child ran: this impl was exercised
+            summary.checked_impls.push_back(arch); // #92 triage detail
+            const bool completed = (WIFEXITED(status) && WEXITSTATUS(status) == 0 &&
+                                    nread == 3 && phases[0] == 'A' && phases[1] == 'M');
+            if (!completed) {
+                summary.crashed = true;
+                summary.crashed_impls.push_back(arch); // #92: once per arch
+                const char* phase = (nread < 1)   ? "ALIGNED buffers"
+                                    : (nread < 2) ? "misaligned buffers"
+                                                  : "compare/exit";
+                if (WIFSIGNALED(status))
+                    std::cerr << name << ": impl crashed on " << phase << " on arch "
+                              << arch << " (signal " << WTERMSIG(status) << ", vlen "
+                              << vlen << ") [forked child]\n";
+                else
+                    std::cerr << name << ": impl child exited abnormally on " << phase
+                              << " on arch " << arch << " (status " << status << ", vlen "
+                              << vlen << ") [forked child]\n";
+                continue;
+            }
+            if (phases[2] == 'D') {
+                summary.diverged = true;
+                summary.diverged_impls.push_back(arch); // #92: once per arch
+            }
+            continue; // fork path complete for this arch; skip the signal path
+        }
+
         summary.applied = true;
         summary.checked_impls.push_back(arch); // #92 triage detail
 

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -160,6 +160,12 @@ private:
     std::string _name;
     volk_test_params_t _test_parameters;
     std::string _puppet_master_name;
+    // #162: the puppet MASTER's own dispatch metadata, captured by
+    // VOLK_INIT_PUPP so the harness can compare the master's impl list against
+    // the puppet's wrappers (mapping-completeness). Points at the kernel's
+    // static tables; by-value copy is safe.
+    volk_func_desc_t _master_desc;
+    bool _has_master_desc = false;
 
 public:
     volk_func_desc_t desc() { return _desc; };
@@ -167,6 +173,8 @@ public:
     std::string name() { return _name; };
     std::string puppet_master_name() { return _puppet_master_name; };
     volk_test_params_t test_parameters() { return _test_parameters; };
+    volk_func_desc_t master_desc() { return _master_desc; };
+    bool has_master_desc() { return _has_master_desc; };
     // normal ctor
     volk_test_case_t(volk_func_desc_t desc,
                      void (*t_kernel_ptr)(),
@@ -182,12 +190,15 @@ public:
                      void (*t_kernel_ptr)(),
                      std::string name,
                      std::string puppet_master_name,
+                     volk_func_desc_t master_desc,
                      volk_test_params_t test_parameters)
         : _desc(desc),
           _kernel_ptr(t_kernel_ptr),
           _name(name),
           _test_parameters(test_parameters),
-          _puppet_master_name(puppet_master_name){};
+          _puppet_master_name(puppet_master_name),
+          _master_desc(master_desc),
+          _has_master_desc(true){};
 };
 
 class volk_qa_aligned_mem_pool

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -380,6 +380,11 @@ struct volk_misaligned_summary {
     // counted in checked_impls/applied (fail-closed), but the count is
     // surfaced so a partially-exercised kernel cannot print a bare ok row.
     int setup_failed = 0;
+    // #162: true iff at least one impl actually ran under FORK isolation --
+    // reported from inside the fork branch itself, so the driver's
+    // "(fork-isolated)" row tag observes the routing that happened, not the
+    // predicate that was supposed to select it.
+    bool fork_isolated = false;
     // #92 triage detail (same convention as volk_canary_summary).
     std::vector<std::string> checked_impls;
     std::vector<std::string> crashed_impls;

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -376,6 +376,10 @@ struct volk_misaligned_summary {
     bool crashed = false;
     bool diverged = false;
     bool applied = false;
+    // #162: impls whose fork/pipe setup failed (fork path only). They are NOT
+    // counted in checked_impls/applied (fail-closed), but the count is
+    // surfaced so a partially-exercised kernel cannot print a bare ok row.
+    int setup_failed = 0;
     // #92 triage detail (same convention as volk_canary_summary).
     std::vector<std::string> checked_impls;
     std::vector<std::string> crashed_impls;

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -378,6 +378,11 @@ struct volk_misaligned_summary {
 // volk_test_params_t) -- approximate kernels (log2, expfast, tan, ...) carry
 // looser tolerances than the harness default, and using anything else
 // false-positives them.
+// fork_isolation (#162): run each impl's whole aligned/misaligned/compare
+// cycle in a forked child instead of under the sigsetjmp signal guard --
+// required for impls that may allocate internally (puppets), where the
+// longjmp soundness argument does not hold. Fail-closed: an impl whose
+// fork/pipe setup fails is not counted as checked.
 volk_misaligned_summary run_volk_misaligned_test(
     volk_func_desc_t,
     void (*)(),
@@ -388,7 +393,8 @@ volk_misaligned_summary run_volk_misaligned_test(
     unsigned int,
     std::vector<volk_test_results_t>* results = NULL,
     const std::vector<float>& float_edge_cases = std::vector<float>(),
-    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>());
+    const std::vector<lv_32fc_t>& complex_edge_cases = std::vector<lv_32fc_t>(),
+    bool fork_isolation = false);
 
 #define VOLK_PROFILE(func, test_params, results) \
     run_volk_tests(func##_get_func_desc(),       \

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -163,18 +163,20 @@ private:
     // #162: the puppet MASTER's own dispatch metadata, captured by
     // VOLK_INIT_PUPP so the harness can compare the master's impl list against
     // the puppet's wrappers (mapping-completeness). Points at the kernel's
-    // static tables; by-value copy is safe.
-    volk_func_desc_t _master_desc;
-    bool _has_master_desc = false;
+    // static tables; by-value copy is safe. Value-initialized (all null/zero)
+    // for non-puppets -- is_puppet() is the validity discriminator.
+    volk_func_desc_t _master_desc{};
 
 public:
     volk_func_desc_t desc() { return _desc; };
     void (*kernel_ptr())() { return _kernel_ptr; };
     std::string name() { return _name; };
     std::string puppet_master_name() { return _puppet_master_name; };
+    // #162: the one puppet discriminator (the puppet ctor is the only path
+    // that sets a master name, and it always supplies the master desc).
+    bool is_puppet() { return _puppet_master_name != "NULL"; };
     volk_test_params_t test_parameters() { return _test_parameters; };
     volk_func_desc_t master_desc() { return _master_desc; };
-    bool has_master_desc() { return _has_master_desc; };
     // normal ctor
     volk_test_case_t(volk_func_desc_t desc,
                      void (*t_kernel_ptr)(),
@@ -197,8 +199,7 @@ public:
           _name(name),
           _test_parameters(test_parameters),
           _puppet_master_name(puppet_master_name),
-          _master_desc(master_desc),
-          _has_master_desc(true){};
+          _master_desc(master_desc){};
 };
 
 class volk_qa_aligned_mem_pool

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -1027,6 +1027,34 @@ int main(int argc, char* argv[])
                 std::cout.flush();
                 continue;
             }
+            // #162 mapping-completeness note (stderr, advisory): a master impl
+            // with no same-named puppet wrapper is invisible to EVERY qa mode --
+            // the puppet's impl list is the coverage ceiling for a puppet-only
+            // kernel class. Name-set check only: a wrapper that exists but calls
+            // the WRONG master impl is out of reach here (source-level property).
+            if (tc.puppet_master_name() != "NULL" && tc.has_master_desc()) {
+                std::vector<std::string> unmapped;
+                for (size_t mi = 0; mi < tc.master_desc().n_impls; ++mi) {
+                    const std::string m = tc.master_desc().impl_names[mi];
+                    bool found = false;
+                    for (size_t pi = 0; pi < tc.desc().n_impls; ++pi) {
+                        if (m == tc.desc().impl_names[pi]) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found)
+                        unmapped.push_back(m);
+                }
+                if (!unmapped.empty()) {
+                    std::cerr << "note  [misaligned] " << tc.name() << ": master "
+                              << tc.puppet_master_name()
+                              << " impls with no puppet wrapper:";
+                    for (const std::string& m : unmapped)
+                        std::cerr << " " << m;
+                    std::cerr << "\n";
+                }
+            }
             std::vector<unsigned int> crash_vlens;
             std::vector<unsigned int> diverge_vlens;
             bool any_applied = false;

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -36,8 +36,9 @@
 #include "volk_reference.h" // for the independent double-precision oracle registry (#88)
 #include <volk/volk.h>
 
-#include <cstdio>  // fflush
-#include <cstdlib> // getenv
+#include <algorithm> // std::find (mapping-completeness note, #162)
+#include <cstdio>    // fflush
+#include <cstdlib>   // getenv
 #include <iostream>
 #include <map> // per-impl failed-vlen accumulation (#92 triage report)
 #include <set> // per-impl seen-set (#92 triage report)
@@ -372,8 +373,7 @@ static volk_misaligned_summary quiet_misaligned_run(volk_test_case_t& tc, unsign
                                            &results,
                                            kFloatEdges,
                                            kComplexEdges,
-                                           /*fork_isolation=*/tc.puppet_master_name() !=
-                                               "NULL");
+                                           /*fork_isolation=*/tc.is_puppet());
     } catch (...) {
         threw = true;
         summary = volk_misaligned_summary(); // applied=false -> skip
@@ -951,33 +951,25 @@ int main(int argc, char* argv[])
         // class in a puppet-only worker now surfaces. Any deviation = broken fork
         // path, exit 2. Runs in every misaligned invocation (incl. the
         // qa_strict_misaligned_canary lane).
-        nc.clear();
-        const volk_misaligned_summary pok_sum =
-            run_volk_misaligned_test(volk_canary_desc(),
-                                     (void (*)())(&volk_32f_canaryok_32f),
-                                     "volk_32f_canaryokpuppet_32f",
-                                     scalar,
-                                     tol,
-                                     false /*absolute_mode*/,
-                                     nc_vlen,
-                                     &nc,
-                                     kFloatEdges,
-                                     kComplexEdges,
-                                     /*fork_isolation=*/true);
-        nc.clear();
+        auto run_fork_nc = [&](void (*kernel)(), const char* nc_name) {
+            nc.clear();
+            return run_volk_misaligned_test(volk_canary_desc(),
+                                            kernel,
+                                            nc_name,
+                                            scalar,
+                                            tol,
+                                            false /*absolute_mode*/,
+                                            nc_vlen,
+                                            &nc,
+                                            kFloatEdges,
+                                            kComplexEdges,
+                                            /*fork_isolation=*/true);
+        };
+        const volk_misaligned_summary pok_sum = run_fork_nc(
+            (void (*)())(&volk_32f_canaryok_32f), "volk_32f_canaryokpuppet_32f");
         const volk_misaligned_summary pfault_sum =
-            run_volk_misaligned_test(volk_canary_desc(),
-                                     (void (*)())(&volk_32f_misalignedfault_32f),
-                                     "volk_32f_misalignedfaultpuppet_32f",
-                                     scalar,
-                                     tol,
-                                     false /*absolute_mode*/,
-                                     nc_vlen,
-                                     &nc,
-                                     kFloatEdges,
-                                     kComplexEdges,
-                                     /*fork_isolation=*/true);
-        nc.clear();
+            run_fork_nc((void (*)())(&volk_32f_misalignedfault_32f),
+                        "volk_32f_misalignedfaultpuppet_32f");
         const char* pnc_err = nullptr;
         if (pok_sum.crashed || pok_sum.diverged) {
             pnc_err = "the correct planted kernel was flagged through the fork-"
@@ -1032,18 +1024,14 @@ int main(int argc, char* argv[])
             // the puppet's impl list is the coverage ceiling for a puppet-only
             // kernel class. Name-set check only: a wrapper that exists but calls
             // the WRONG master impl is out of reach here (source-level property).
-            if (tc.puppet_master_name() != "NULL" && tc.has_master_desc()) {
+            if (tc.is_puppet()) {
+                const std::vector<std::string> master_impls =
+                    get_arch_list(tc.master_desc());
+                const std::vector<std::string> puppet_impls = get_arch_list(tc.desc());
                 std::vector<std::string> unmapped;
-                for (size_t mi = 0; mi < tc.master_desc().n_impls; ++mi) {
-                    const std::string m = tc.master_desc().impl_names[mi];
-                    bool found = false;
-                    for (size_t pi = 0; pi < tc.desc().n_impls; ++pi) {
-                        if (m == tc.desc().impl_names[pi]) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found)
+                for (const std::string& m : master_impls) {
+                    if (std::find(puppet_impls.begin(), puppet_impls.end(), m) ==
+                        puppet_impls.end())
                         unmapped.push_back(m);
                 }
                 if (!unmapped.empty()) {
@@ -1088,8 +1076,7 @@ int main(int argc, char* argv[])
             // #162: puppet rows carry the isolation tag so the fork routing is
             // OBSERVABLE (a lost fork_isolation argument would drop the tag and
             // red the qa_misaligned_puppet_control ctest, not pass silently).
-            const char* iso_tag =
-                (tc.puppet_master_name() != "NULL") ? " (fork-isolated)" : "";
+            const char* iso_tag = tc.is_puppet() ? " (fork-isolated)" : "";
             if (!crash_vlens.empty() || !diverge_vlens.empty()) {
                 ++a_failed;
                 if (!crash_vlens.empty())

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -1097,7 +1097,8 @@ int main(int argc, char* argv[])
             std::vector<unsigned int> crash_vlens;
             std::vector<unsigned int> diverge_vlens;
             bool any_applied = false;
-            int setup_failed_total = 0; // #162: fork/pipe setup losses
+            bool any_fork_isolated = false; // #162: routing OBSERVED via summary
+            int setup_failed_total = 0;     // #162: fork/pipe setup losses
             std::set<std::string> impls_seen;
             std::map<std::string, std::vector<unsigned int>> crash_fails;
             std::map<std::string, std::vector<unsigned int>> diverge_fails;
@@ -1105,6 +1106,8 @@ int main(int argc, char* argv[])
                 const volk_misaligned_summary s = quiet_misaligned_run(tc, v);
                 if (s.applied)
                     any_applied = true;
+                if (s.fork_isolated)
+                    any_fork_isolated = true;
                 setup_failed_total += s.setup_failed;
                 if (s.crashed)
                     crash_vlens.push_back(v);
@@ -1118,8 +1121,15 @@ int main(int argc, char* argv[])
                     diverge_fails[impl].push_back(v);
             }
             if (!any_applied && crash_vlens.empty() && diverge_vlens.empty()) {
-                std::cout << "skip  [misaligned] " << tc.name()
-                          << " (no checkable unaligned impl)\n";
+                // #162: attribute a total fork-setup loss to the harness, not
+                // the kernel -- "(no checkable unaligned impl)" would misdirect
+                // triage when the impls were checkable and fork()/pipe() failed.
+                std::cout << "skip  [misaligned] " << tc.name();
+                if (setup_failed_total > 0)
+                    std::cout << " (fork setup failed: " << setup_failed_total
+                              << " impl-runs)\n";
+                else
+                    std::cout << " (no checkable unaligned impl)\n";
                 if (report)
                     std::fprintf(report, "%s,-,misaligned,skip,,\n", tc.name().c_str());
                 std::cout.flush();
@@ -1127,9 +1137,11 @@ int main(int argc, char* argv[])
             }
             ++a_tested;
             // #162: puppet rows carry the isolation tag so the fork routing is
-            // OBSERVABLE (a lost fork_isolation argument would drop the tag and
-            // red the qa_misaligned_puppet_control ctest, not pass silently).
-            const char* iso_tag = tc.is_puppet() ? " (fork-isolated)" : "";
+            // OBSERVABLE -- derived from summary.fork_isolated, which is set
+            // INSIDE the fork branch, never from the routing predicate itself.
+            // A lost fork_isolation argument drops the tag and reds the
+            // qa_misaligned_puppet_control ctest (mutation-proven).
+            const char* iso_tag = any_fork_isolated ? " (fork-isolated)" : "";
             if (!crash_vlens.empty() || !diverge_vlens.empty()) {
                 ++a_failed;
                 if (!crash_vlens.empty())

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -942,6 +942,63 @@ int main(int argc, char* argv[])
         std::cerr << "misaligned negative control OK: ok-kernel clean, aligned-load "
                      "kernel crash recorded and the run continued.\n";
 
+        // #162: same negative-control pair through the FORK-isolation path that
+        // puppet test cases use. Asserts (a) the ok-kernel is clean through a
+        // forked child (no over-report), (b) a planted unaligned fault in a child
+        // is RECORDED as a crash while THIS process continues -- the #101 defect
+        // class in a puppet-only worker now surfaces. Any deviation = broken fork
+        // path, exit 2. Runs in every misaligned invocation (incl. the
+        // qa_strict_misaligned_canary lane).
+        nc.clear();
+        const volk_misaligned_summary pok_sum =
+            run_volk_misaligned_test(volk_canary_desc(),
+                                     (void (*)())(&volk_32f_canaryok_32f),
+                                     "volk_32f_canaryokpuppet_32f",
+                                     scalar,
+                                     tol,
+                                     false /*absolute_mode*/,
+                                     nc_vlen,
+                                     &nc,
+                                     kFloatEdges,
+                                     kComplexEdges,
+                                     /*fork_isolation=*/true);
+        nc.clear();
+        const volk_misaligned_summary pfault_sum =
+            run_volk_misaligned_test(volk_canary_desc(),
+                                     (void (*)())(&volk_32f_misalignedfault_32f),
+                                     "volk_32f_misalignedfaultpuppet_32f",
+                                     scalar,
+                                     tol,
+                                     false /*absolute_mode*/,
+                                     nc_vlen,
+                                     &nc,
+                                     kFloatEdges,
+                                     kComplexEdges,
+                                     /*fork_isolation=*/true);
+        nc.clear();
+        const char* pnc_err = nullptr;
+        if (pok_sum.crashed || pok_sum.diverged) {
+            pnc_err = "the correct planted kernel was flagged through the fork-"
+                      "isolation (puppet) path -- the forked detector over-reports";
+        } else if (!pok_sum.applied || !pfault_sum.applied) {
+            pnc_err = "the fork-isolation (puppet) path could not run at all -- "
+                      "puppet kernels would silently lose misaligned coverage";
+        } else if (!pfault_sum.crashed) {
+            pnc_err = "the planted aligned-load kernel did not produce a recorded "
+                      "crash through the fork-isolation (puppet) path -- child "
+                      "fault classification is broken";
+        }
+        if (pnc_err) {
+            std::cerr << "NEGATIVE CONTROL LOST (fork path): " << pnc_err
+                      << ". Aborting.\n";
+            if (report)
+                std::fclose(report);
+            return 2;
+        }
+        std::cerr << "misaligned fork-path negative control OK: ok-kernel clean "
+                     "through fork isolation, child crash recorded and the run "
+                     "continued.\n";
+
         // Per-kernel misaligned sweep over the real kernels (unaligned impls only).
         //   FAIL -> an impl crashed on misaligned buffers or diverged from the
         //           the SAME impl's aligned run (both always defects).

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -344,7 +344,8 @@ static volk_immutability_summary quiet_immutability_run(volk_test_case_t& tc,
 
 // #91: run the misaligned check for one (kernel, vlen) with stdout muted (mirrors
 // quiet_immutability_run). Hardware faults are handled INSIDE
-// run_volk_misaligned_test by the signal path (-> summary.crashed); a C++
+// run_volk_misaligned_test -- by the signal path for non-puppets, by fork
+// isolation (#162) for puppets (-> summary.crashed either way); a C++
 // exception here is non-signal harness plumbing, out of #91 scope -- report it
 // skipped (applied stays false) with a note rather than mislabeling it.
 static volk_misaligned_summary quiet_misaligned_run(volk_test_case_t& tc, unsigned int v)

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -342,6 +342,25 @@ static volk_immutability_summary quiet_immutability_run(volk_test_case_t& tc,
     return summary;
 }
 
+// #162: master impls with no same-named puppet wrapper -- the puppet's impl
+// list is the coverage ceiling for a puppet-only kernel class, so an unmapped
+// master impl is invisible to EVERY qa mode. Name-set check only: a wrapper
+// that exists but calls the WRONG master impl is out of reach here
+// (source-level property). Self-checked by the misaligned mode's mapping-note
+// negative control against hand-built descs.
+static std::vector<std::string> unmapped_master_impls(volk_func_desc_t master,
+                                                      volk_func_desc_t puppet)
+{
+    const std::vector<std::string> master_impls = get_arch_list(master);
+    const std::vector<std::string> puppet_impls = get_arch_list(puppet);
+    std::vector<std::string> unmapped;
+    for (const std::string& m : master_impls) {
+        if (std::find(puppet_impls.begin(), puppet_impls.end(), m) == puppet_impls.end())
+            unmapped.push_back(m);
+    }
+    return unmapped;
+}
+
 // #91: run the misaligned check for one (kernel, vlen) with stdout muted (mirrors
 // quiet_immutability_run). Hardware faults are handled INSIDE
 // run_volk_misaligned_test -- by the signal path for non-puppets, by fork
@@ -971,17 +990,27 @@ int main(int argc, char* argv[])
         const volk_misaligned_summary pfault_sum =
             run_fork_nc((void (*)())(&volk_32f_misalignedfault_32f),
                         "volk_32f_misalignedfaultpuppet_32f");
+        // #162: the DIVERGED verdict rides its own transport (the child's
+        // third phase byte), which the fault twin cannot exercise -- a planted
+        // alignment-sensitive kernel proves the 'D' path end to end.
+        const volk_misaligned_summary pdiv_sum =
+            run_fork_nc((void (*)())(&volk_32f_misaligneddiverge_32f),
+                        "volk_32f_misaligneddivergepuppet_32f");
         const char* pnc_err = nullptr;
         if (pok_sum.crashed || pok_sum.diverged) {
             pnc_err = "the correct planted kernel was flagged through the fork-"
                       "isolation (puppet) path -- the forked detector over-reports";
-        } else if (!pok_sum.applied || !pfault_sum.applied) {
+        } else if (!pok_sum.applied || !pfault_sum.applied || !pdiv_sum.applied) {
             pnc_err = "the fork-isolation (puppet) path could not run at all -- "
                       "puppet kernels would silently lose misaligned coverage";
         } else if (!pfault_sum.crashed) {
             pnc_err = "the planted aligned-load kernel did not produce a recorded "
                       "crash through the fork-isolation (puppet) path -- child "
                       "fault classification is broken";
+        } else if (pdiv_sum.crashed || !pdiv_sum.diverged) {
+            pnc_err = "the planted alignment-sensitive kernel did not produce a "
+                      "recorded DIVERGENCE through the fork-isolation (puppet) "
+                      "path -- the child's diverged-verdict transport is broken";
         }
         if (pnc_err) {
             std::cerr << "NEGATIVE CONTROL LOST (fork path): " << pnc_err
@@ -991,8 +1020,37 @@ int main(int argc, char* argv[])
             return 2;
         }
         std::cerr << "misaligned fork-path negative control OK: ok-kernel clean "
-                     "through fork isolation, child crash recorded and the run "
-                     "continued.\n";
+                     "through fork isolation, child crash recorded, child "
+                     "divergence recorded, and the run continued.\n";
+
+        // #162: mapping-note self-check. The unmapped-impl computation below
+        // (unmapped_master_impls) is advisory output with no failing consumer,
+        // so a broken comparison would be invisible -- prove it can both fire
+        // and stay quiet against two hand-built descs before trusting its
+        // silence over the real catalog.
+        {
+            static const char* mc_master_names[] = { "generic", "u_planted" };
+            static const int mc_master_deps[] = { 0, 0 };
+            static const bool mc_master_align[] = { false, false };
+            volk_func_desc_t mc_master;
+            mc_master.impl_names = mc_master_names;
+            mc_master.impl_deps = mc_master_deps;
+            mc_master.impl_alignment = mc_master_align;
+            mc_master.n_impls = 2;
+            const std::vector<std::string> um_fire =
+                unmapped_master_impls(mc_master, volk_canary_desc());
+            const std::vector<std::string> um_quiet =
+                unmapped_master_impls(volk_canary_desc(), mc_master);
+            if (um_fire.size() != 1 || um_fire[0] != "u_planted" || !um_quiet.empty()) {
+                std::cerr << "NEGATIVE CONTROL LOST (mapping note): the "
+                             "unmapped-master-impl computation misclassified a "
+                             "hand-built desc pair -- its silence over the real "
+                             "catalog cannot be trusted. Aborting.\n";
+                if (report)
+                    std::fclose(report);
+                return 2;
+            }
+        }
 
         // Per-kernel misaligned sweep over the real kernels (unaligned impls only).
         //   FAIL -> an impl crashed on misaligned buffers or diverged from the
@@ -1005,6 +1063,22 @@ int main(int argc, char* argv[])
         for (auto& tc : test_cases) {
             if (!filter.empty() && tc.name() != filter)
                 continue;
+            // #162 mapping-completeness note (stderr, advisory; BEFORE the
+            // conv_k7 exclusion so every puppet -- excluded ones included --
+            // gets a completeness check, as the harness README states).
+            // Self-checked by the mapping-note negative control above.
+            if (tc.is_puppet()) {
+                const std::vector<std::string> unmapped =
+                    unmapped_master_impls(tc.master_desc(), tc.desc());
+                if (!unmapped.empty()) {
+                    std::cerr << "note  [misaligned] " << tc.name() << ": master "
+                              << tc.puppet_master_name()
+                              << " impls with no puppet wrapper:";
+                    for (const std::string& m : unmapped)
+                        std::cerr << " " << m;
+                    std::cerr << "\n";
+                }
+            }
             // #162: puppets now run under FORK isolation (routed by
             // quiet_misaligned_run via fork_isolation), so the longjmp safety
             // argument is untouched: no impl with internal allocation ever runs
@@ -1020,33 +1094,10 @@ int main(int argc, char* argv[])
                 std::cout.flush();
                 continue;
             }
-            // #162 mapping-completeness note (stderr, advisory): a master impl
-            // with no same-named puppet wrapper is invisible to EVERY qa mode --
-            // the puppet's impl list is the coverage ceiling for a puppet-only
-            // kernel class. Name-set check only: a wrapper that exists but calls
-            // the WRONG master impl is out of reach here (source-level property).
-            if (tc.is_puppet()) {
-                const std::vector<std::string> master_impls =
-                    get_arch_list(tc.master_desc());
-                const std::vector<std::string> puppet_impls = get_arch_list(tc.desc());
-                std::vector<std::string> unmapped;
-                for (const std::string& m : master_impls) {
-                    if (std::find(puppet_impls.begin(), puppet_impls.end(), m) ==
-                        puppet_impls.end())
-                        unmapped.push_back(m);
-                }
-                if (!unmapped.empty()) {
-                    std::cerr << "note  [misaligned] " << tc.name() << ": master "
-                              << tc.puppet_master_name()
-                              << " impls with no puppet wrapper:";
-                    for (const std::string& m : unmapped)
-                        std::cerr << " " << m;
-                    std::cerr << "\n";
-                }
-            }
             std::vector<unsigned int> crash_vlens;
             std::vector<unsigned int> diverge_vlens;
             bool any_applied = false;
+            int setup_failed_total = 0; // #162: fork/pipe setup losses
             std::set<std::string> impls_seen;
             std::map<std::string, std::vector<unsigned int>> crash_fails;
             std::map<std::string, std::vector<unsigned int>> diverge_fails;
@@ -1054,6 +1105,7 @@ int main(int argc, char* argv[])
                 const volk_misaligned_summary s = quiet_misaligned_run(tc, v);
                 if (s.applied)
                     any_applied = true;
+                setup_failed_total += s.setup_failed;
                 if (s.crashed)
                     crash_vlens.push_back(v);
                 if (s.diverged)
@@ -1098,6 +1150,11 @@ int main(int argc, char* argv[])
             } else {
                 std::cout << "ok    [misaligned] " << tc.name() << iso_tag;
             }
+            // #162: a partially-exercised kernel must not print a bare ok row
+            // -- fork/pipe setup losses are uncounted (fail-closed) but their
+            // count is surfaced right where the coverage claim is made.
+            if (setup_failed_total > 0)
+                std::cout << "  setup-failed impl-runs: " << setup_failed_total;
             std::cout << "\n";
             if (report) {
                 // Crash and diverge rows are both FAIL; an impl hit by both

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -371,7 +371,9 @@ static volk_misaligned_summary quiet_misaligned_run(volk_test_case_t& tc, unsign
                                            v /*vlen*/,
                                            &results,
                                            kFloatEdges,
-                                           kComplexEdges);
+                                           kComplexEdges,
+                                           /*fork_isolation=*/tc.puppet_master_name() !=
+                                               "NULL");
     } catch (...) {
         threw = true;
         summary = volk_misaligned_summary(); // applied=false -> skip
@@ -1002,18 +1004,24 @@ int main(int argc, char* argv[])
         // Per-kernel misaligned sweep over the real kernels (unaligned impls only).
         //   FAIL -> an impl crashed on misaligned buffers or diverged from the
         //           the SAME impl's aligned run (both always defects).
-        //   skip -> puppet / unsupported signature / nothing observed (fail closed).
-        // Puppets are skipped -- load-bearing here: it is what keeps the longjmp
-        // safety argument airtight (no impl with internal allocation runs under the
-        // signal guard) and keeps #96's conv_k7 out of this mode.
+        //   skip -> excluded / unsupported signature / nothing observed (fail
+        //           closed).
         std::cout << "# misaligned sweep: vlens 1..40, 131071, 1000003\n";
         std::cout.flush();
         int a_tested = 0, a_failed = 0, a_crashed = 0, a_diverged = 0;
         for (auto& tc : test_cases) {
             if (!filter.empty() && tc.name() != filter)
                 continue;
-            if (tc.puppet_master_name() != "NULL") {
-                std::cout << "skip  [misaligned] " << tc.name() << " (puppet)\n";
+            // #162: puppets now run under FORK isolation (routed by
+            // quiet_misaligned_run via fork_isolation), so the longjmp safety
+            // argument is untouched: no impl with internal allocation ever runs
+            // under the signal guard. The only remaining puppet skip is policy:
+            // conv_k7's decision-buffer overflow (#96, OPEN) corrupts the child
+            // heap at multi-vlen and would hard-red every ASan lane for a known,
+            // separately-tracked defect.
+            if (tc.name() == "volk_8u_conv_k7_r2puppet_8u") {
+                std::cout << "skip  [misaligned] " << tc.name()
+                          << " (excluded: #96 conv_k7)\n";
                 if (report)
                     std::fprintf(report, "%s,-,misaligned,skip,,\n", tc.name().c_str());
                 std::cout.flush();
@@ -1049,13 +1057,18 @@ int main(int argc, char* argv[])
                 continue;
             }
             ++a_tested;
+            // #162: puppet rows carry the isolation tag so the fork routing is
+            // OBSERVABLE (a lost fork_isolation argument would drop the tag and
+            // red the qa_misaligned_puppet_control ctest, not pass silently).
+            const char* iso_tag =
+                (tc.puppet_master_name() != "NULL") ? " (fork-isolated)" : "";
             if (!crash_vlens.empty() || !diverge_vlens.empty()) {
                 ++a_failed;
                 if (!crash_vlens.empty())
                     ++a_crashed;
                 if (!diverge_vlens.empty())
                     ++a_diverged;
-                std::cout << "FAIL  [misaligned] " << tc.name();
+                std::cout << "FAIL  [misaligned] " << tc.name() << iso_tag;
                 if (!crash_vlens.empty()) {
                     std::cout << "  crash vlens:";
                     for (unsigned int v : crash_vlens)
@@ -1067,7 +1080,7 @@ int main(int argc, char* argv[])
                         std::cout << " " << v;
                 }
             } else {
-                std::cout << "ok    [misaligned] " << tc.name();
+                std::cout << "ok    [misaligned] " << tc.name() << iso_tag;
             }
             std::cout << "\n";
             if (report) {


### PR DESCRIPTION
## Summary

The `HARNESS_MISALIGNED` sweep (#91) hard-skipped every puppet test case — load-bearing for its `longjmp`-under-signal-guard safety argument, but it left puppet-only kernel classes (all 15 of them: the only entry points to their workers) with zero misaligned coverage. That is the exact hole the #101 rotator2 unaligned fault lived in. This PR closes the hole with a second isolation mechanism instead of weakening the first: `run_volk_misaligned_test` gains a `fork_isolation` mode that runs each unaligned impl's whole aligned/misaligned/compare cycle in a forked child (recovery is `waitpid` + a phase pipe, so internal allocation in puppets — 3 of 15 allocate, incl. encodepolar's 7 `volk_malloc` sites — is safe by construction), and the driver routes puppets through it. Puppet rows now print real `ok`/`FAIL` results tagged `(fork-isolated)` so the routing itself is observable; the signal-guard path and all existing callers are unchanged. A fork-path negative-control TRIO (planted ok, fault, and alignment-sensitive-diverging kernels routed through a forked child) gates every misaligned run with the same NC-LOST exit-2 semantics — all three verdict transports (ok / crash / diverged) are negative-controlled, with mutation proofs on the crash classifier, the verdict-byte transport, and the routing tag — and the fault twin doubles as the #101-class regression proof: a planted unaligned fault in a puppet-routed worker is recorded while the run continues. The sweep also emits an advisory stderr note when a master impl has no same-named puppet wrapper — a stale puppet silently caps its whole class's coverage in every qa mode (the gnuradio/volk#570 popcnt lesson); the check is name-set only (limitation documented) and its computation is self-checked against hand-built descs with NC-LOST exit-2 semantics, mutation-proven. One puppet stays excluded by policy: conv_k7 (`#96`, OPEN — its decision-buffer overflow would hard-red ASan lanes for a known, tracked defect). Landing the first misaligned-mode ctest outside the ASAN build type also surfaced that the #221 canary-TU alignment exemption was gated to `CBTU=ASAN`; the exemption is now unconditional on POSIX (the flag is a no-op without sanitizers), which is the previously-unfiled #221 follow-up.

Result: 14 of 14 non-excluded puppet classes report `ok … (fork-isolated)` on the dev box (previously 15 skips), non-puppet rows are byte-for-byte unchanged, and the new `qa_misaligned_puppet_control` ctest pins the contract ("covered AND clean") with pass/fail regexes rather than a vacuous exit code. The ctest registers by default on Linux x86_64 non-static-dispatch builds only (option `VOLK_MISALIGNED_PUPPET_CTEST`, opt-in elsewhere): the validated evidence is one Linux x86-64 box across plain/ASAN/UBSan-flag/static configs, the static-dispatch(generic) shape was probed and is inapplicable by design (`volk_get_alignment()==1` fails the mode closed), and the misaligned mode has never run on the QEMU arches, aarch64, or macOS — broadening after a cross-platform probe is a filed follow-up. The `(fork-isolated)` row tag is derived from a summary flag set inside the fork branch itself (routing observed, not inferred — mutation-proven: flipping the routing argument reds the ctest), and fork-setup losses red the ctest via the FAIL regex (`setup-failed impl-runs`) or fail the PASS regex outright (a total loss prints a `skip (fork setup failed: …)` row).

## Related issues

Closes #162
Related: #91 (misaligned mode), #96 (conv_k7 exclusion), #101 (the escaped defect class this covers), #221 (canary-TU exemption gate widened)

## Testing

- Baseline gap evidence: `skip [misaligned] volk_32fc_s32fc_rotator2puppet_32fc (puppet)` at `dev/all-prs` e2f11132; after: `ok [misaligned] … (fork-isolated)` (issue artifacts `baseline-rotator2-misaligned.txt` / `after-rotator2-misaligned.txt`).
- Full sweep at final SHA: exit 0, 9.4 s wall; 113 non-puppet kernels tested, 0 crashed/diverged; CSV report multiset diff vs baseline empty for non-puppet rows (AC-3); all 14 non-excluded puppets `ok (fork-isolated)`.
- Fork-path negative controls: ok-twin clean, fault-twin crash recorded, diverge-twin divergence recorded (never a crash), run continues — on plain, ASAN (`handle_segv=0` env), and Debug+`-fsanitize=undefined` builds. Three mutations proven live (artifact `fork-nc-mutation-proof.txt`): neutered crash classifier → NC-LOST exit 2; inverted diverge verdict byte → NC-LOST exit 2; neutered mapping computation → NC-LOST exit 2; each restored → OK.
- New ctest `qa_misaligned_puppet_control` (x86_64 POSIX; opt-in elsewhere): PASS regex pins the fork-routed rotator2 `ok` row, FAIL regex reds on any `FAIL` row or NC loss, `TIMEOUT 600`; green on plain + ASAN + UBSan-flag builds. Note: `PASS_REGULAR_EXPRESSION` shadows the exit code — documented, with the load-bearing NC-before-sweep ordering. `qa_strict_misaligned_canary` (which now also executes the fork twins) re-verified green.
- ctest: 257/257 plain; analyzer sanitizer legs asan/ubsan/tsan all exit 0 (ubsan initially red → root-caused to the #221 exemption gate, fixed in-branch).
- clang-format clean; cpplint/cmake-lint residue is in-tree-style noise (90-col clang-format limit, existing `};` accessor style).

## Evidence

suite: none @ 8ddcbb4206866cb1fed7ba35aca6a68dc7ebdf39
files: 8 changed

## Checklist
- [x] Builds cleanly (`cmake --build`) — plain, ASAN, Debug+UBSan; all four `kernel_tests.h` consumers (`volk_test_correctness`, `volk_test_all`, `volk_profile`, `volk_ulp_profile`)
- [x] Tests pass (`ctest`) — 257/257 plain; sanitizer legs green
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — misaligned-mode puppet coverage, plus two named riders it carries deliberately: (1) the operator-requested mapping-completeness note (self-checked, advisory), and (2) the #221 canary-TU exemption gate widening, which is load-bearing for the new ctest on injected-UBSan builds. The rotator2 `rvvseg` wrapper miswire found during research is deliberately NOT fixed here (separate follow-up)
