### PR TITLE
batch-register fixed-output kernels

### DIFF
--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -103,9 +103,9 @@ the kernel's numbers and cite this section.
 - **How:** each output buffer is its own malloc with leading/trailing sentinel
   guards; two runs with distinct sentinels flag guard writes (always a defect)
   and never-written in-bounds elements (`partial` for kernels not in the #161
-  buffer-role registry). Kernels registered in the buffer-role registry — the
-  fixed-output reduction/index class, as of #191 — instead get a hard
-  `ok`/`FAIL` against their declared cardinality. ASan redzones bracket the
+  buffer-role registry). Kernels registered in the buffer-role registry — every
+  fixed-output reduction/index kernel in the QA roster, as of #191 — instead get
+  a hard `ok`/`FAIL` against their declared cardinality. ASan redzones bracket the
   guarded buffers for far-past coverage (demo gated to ASan builds).
 
 ### 4. Input-immutability canary (#90)

--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -102,8 +102,10 @@ the kernel's numbers and cite this section.
 - **Escaped defect:** tail one-past over/under-run class (`30ab2b0`).
 - **How:** each output buffer is its own malloc with leading/trailing sentinel
   guards; two runs with distinct sentinels flag guard writes (always a defect)
-  and never-written in-bounds elements (`partial` — expected for
-  reduction/index kernels with fixed-size outputs). ASan redzones bracket the
+  and never-written in-bounds elements (`partial` for kernels not in the #161
+  buffer-role registry). Kernels registered in the buffer-role registry — the
+  fixed-output reduction/index class, as of #191 — instead get a hard
+  `ok`/`FAIL` against their declared cardinality. ASan redzones bracket the
   guarded buffers for far-past coverage (demo gated to ASan builds).
 
 ### 4. Input-immutability canary (#90)

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -664,9 +664,12 @@ int main(int argc, char* argv[])
         //              on a kernel NOT in the buffer-role registry — the signature
         //              alone cannot distinguish a fixed-output kernel's unwritten
         //              tail from a real map under-write; surfaced for triage, not
-        //              counted as a failure. The fixed-output class is registered
-        //              as of #191, so a fresh `partial` means an unregistered new
-        //              kernel or a real under-write.
+        //              counted as a failure. Every fixed-output kernel in the QA
+        //              roster is registered as of #191 (kernels absent from
+        //              kernel_tests.h — the deprecated max-star family — are
+        //              outside the sweep's reach and stay unregistered), so a
+        //              fresh `partial` means an unregistered new kernel or a
+        //              real under-write.
         // Puppets are skipped: their output-buffer semantics differ from a plain map.
         std::cout << "# output-canary sweep: vlens 1..40, 131071, 1000003\n";
         std::cout.flush();
@@ -780,8 +783,10 @@ int main(int argc, char* argv[])
         if (report)
             std::fclose(report);
         std::cerr << "\noutput-canary sweep: " << c_failed << " / " << c_tested
-                  << " kernels over-ran the output buffer; " << c_partial
-                  << " left in-bounds elements unwritten (reduction/index kernels — "
+                  << " kernels FAILed (guard over-run, or an under-written "
+                     "contracted region on a registered kernel); "
+                  << c_partial
+                  << " left in-bounds elements unwritten (unregistered kernels — "
                      "triage)\n";
         return c_failed > 0 ? 1 : 0;
     }

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -657,12 +657,16 @@ int main(int argc, char* argv[])
 
         // Best-effort per-kernel canary sweep over the real kernels.
         //   FAIL    -> a GUARD violation (write past the end / before index 0): a
-        //              real buffer over/under-run, the issue's core blind spot.
-        //   partial -> an in-bounds element left unwritten with NO guard violation:
-        //              expected for reduction/index/accumulator kernels (fixed-size
-        //              scalar output, not num_points elements), which the signature
-        //              cannot distinguish from a real map under-write — surfaced for
-        //              triage, not counted as a failure.
+        //              real buffer over/under-run, the issue's core blind spot —
+        //              or, for a registered kernel, an under-written contracted
+        //              region (#161/#191).
+        //   partial -> an in-bounds element left unwritten with NO guard violation,
+        //              on a kernel NOT in the buffer-role registry — the signature
+        //              alone cannot distinguish a fixed-output kernel's unwritten
+        //              tail from a real map under-write; surfaced for triage, not
+        //              counted as a failure. The fixed-output class is registered
+        //              as of #191, so a fresh `partial` means an unregistered new
+        //              kernel or a real under-write.
         // Puppets are skipped: their output-buffer semantics differ from a plain map.
         std::cout << "# output-canary sweep: vlens 1..40, 131071, 1000003\n";
         std::cout.flush();

--- a/lib/volk_buffer_roles.cc
+++ b/lib/volk_buffer_roles.cc
@@ -10,12 +10,14 @@
 #include "volk_buffer_roles.h"
 
 // Sparse, opt-in buffer-role registry (#161). See volk_buffer_roles.h for the
-// schema and "how to add a kernel". Covers the fixed-output class (#191): every
-// kernel whose single-element-per-output-buffer contract the canary otherwise
-// reports as `part` (the rest of the num_points-sized buffer is legitimately
-// unwritten). Declaring output_elems=1 lets the canary confirm the contracted
-// element was written and emit a hard ok/FAIL. Contracts are scoped to
-// num_points >= 1, the canary's vlen range.
+// schema and "how to add a kernel". Covers the QA-roster fixed-output class
+// (#191): every kernel_tests.h kernel whose single-element-per-output-buffer
+// contract the canary otherwise reports as `part` (the rest of the
+// num_points-sized buffer is legitimately unwritten). Kernels outside the QA
+// roster (the deprecated max-star family) are outside the sweep's reach and
+// stay unregistered. Declaring output_elems=1 lets the canary confirm the
+// contracted element was written and emit a hard ok/FAIL. Contracts are scoped
+// to num_points >= 1, the canary's vlen range.
 static const std::vector<volk_buffer_roles_entry> g_registry{
     // result = sum_i a[i] * b[i] -- single-element dot-product outputs.
     { "volk_32f_x2_dot_prod_32f", 1 },

--- a/lib/volk_buffer_roles.cc
+++ b/lib/volk_buffer_roles.cc
@@ -10,16 +10,41 @@
 #include "volk_buffer_roles.h"
 
 // Sparse, opt-in buffer-role registry (#161). See volk_buffer_roles.h for the
-// schema and "how to add a kernel". Proof-of-concept entries: reduction kernels
-// whose single-element output the canary otherwise reports as `part` (the rest of
-// the num_points-sized buffer is legitimately unwritten). Declaring output_elems=1
-// lets the canary confirm the one contracted element was written and emit a clean
-// pass. Grows over time -- comprehensive characterization is incremental follow-up.
+// schema and "how to add a kernel". Covers the fixed-output class (#191): every
+// kernel whose single-element-per-output-buffer contract the canary otherwise
+// reports as `part` (the rest of the num_points-sized buffer is legitimately
+// unwritten). Declaring output_elems=1 lets the canary confirm the contracted
+// element was written and emit a hard ok/FAIL. Contracts are scoped to
+// num_points >= 1, the canary's vlen range.
 static const std::vector<volk_buffer_roles_entry> g_registry{
-    // result = sum_i input[i] * taps[i] -- writes a single float.
+    // result = sum_i a[i] * b[i] -- single-element dot-product outputs.
     { "volk_32f_x2_dot_prod_32f", 1 },
-    // result = sum_i inputBuffer[i] -- writes a single float.
+    { "volk_32fc_x2_dot_prod_32fc", 1 },
+    { "volk_32fc_x2_conjugate_dot_prod_32fc", 1 },
+    { "volk_32fc_32f_dot_prod_32fc", 1 },
+    { "volk_16i_32fc_dot_prod_32fc", 1 },
+    { "volk_16ic_x2_dot_prod_16ic", 1 },
+    { "volk_32f_x2_dot_prod_16i", 1 },
+    { "volk_64f_x2_dot_prod_64f", 1 },
+    // result = sum_i inputBuffer[i] -- a single accumulated element.
     { "volk_32f_accumulator_s32f", 1 },
+    { "volk_32fc_accumulator_s32fc", 1 },
+    // single index written to target[0].
+    { "volk_32f_index_max_16u", 1 },
+    { "volk_32f_index_max_32u", 1 },
+    { "volk_32f_index_min_16u", 1 },
+    { "volk_32f_index_min_32u", 1 },
+    { "volk_32fc_index_max_16u", 1 },
+    { "volk_32fc_index_max_32u", 1 },
+    { "volk_32fc_index_min_16u", 1 },
+    { "volk_32fc_index_min_32u", 1 },
+    // single-element statistic outputs (stddev_and_mean writes 1 elem in EACH
+    // of its two output buffers).
+    { "volk_32f_s32f_stddev_32f", 1 },
+    { "volk_32f_s32f_calc_spectral_noise_floor_32f", 1 },
+    { "volk_32f_stddev_and_mean_32f_x2", 1 },
+    // polynomial evaluation reduced to a single float in target[0].
+    { "volk_32f_x3_sum_of_poly_32f", 1 },
 };
 
 const std::vector<volk_buffer_roles_entry>& volk_buffer_roles_registry()

--- a/lib/volk_buffer_roles.h
+++ b/lib/volk_buffer_roles.h
@@ -33,14 +33,16 @@
  * count for a reduction (e.g. 1 for a dot product / accumulator / single-index).
  * Before registering, verify the cardinality against the kernel header's doc
  * contract AND every impl's stores (a wrong count turns the canary's hard
- * verdict against the wrong contract). Unregistered kernels keep today's
- * verdict exactly.
+ * verdict against the wrong contract). New fixed-output kernels are expected
+ * to be registered here -- an unregistered one reverts its canary verdict to
+ * the `part` hedge. Unregistered kernels keep today's verdict exactly.
  *
  * NOTE: output_elems is a single value applied to EVERY output buffer of the
- * kernel; it assumes all outputs share one cardinality (true for the single-output
- * reductions registered today). A kernel with multiple outputs of differing
- * cardinalities would need a per-output vector -- a planned extension, not yet
- * needed.
+ * kernel; it assumes all outputs share one cardinality (true for every kernel
+ * registered today, including the two-output volk_32f_stddev_and_mean_32f_x2,
+ * whose stddev and mean buffers each hold 1 element). A kernel with multiple
+ * outputs of differing cardinalities would need a per-output vector -- a
+ * planned extension, not yet needed.
  */
 
 #ifndef INCLUDED_VOLK_BUFFER_ROLES_H

--- a/lib/volk_buffer_roles.h
+++ b/lib/volk_buffer_roles.h
@@ -42,7 +42,9 @@
  * registered today, including the two-output volk_32f_stddev_and_mean_32f_x2,
  * whose stddev and mean buffers each hold 1 element). A kernel with multiple
  * outputs of differing cardinalities would need a per-output vector -- a
- * planned extension, not yet needed.
+ * planned extension, not yet needed. Declared contracts are scoped to
+ * num_points >= 1 (the canary's vlen range); behavior at num_points == 0 is
+ * not part of any registered claim.
  */
 
 #ifndef INCLUDED_VOLK_BUFFER_ROLES_H

--- a/lib/volk_buffer_roles.h
+++ b/lib/volk_buffer_roles.h
@@ -31,7 +31,10 @@
  * volk_buffer_roles.cc, keyed by the exact kernel name. Set output_elems to 0
  * for a map kernel (writes `vlen` elements per output) or to the fixed element
  * count for a reduction (e.g. 1 for a dot product / accumulator / single-index).
- * Unregistered kernels keep today's verdict exactly.
+ * Before registering, verify the cardinality against the kernel header's doc
+ * contract AND every impl's stores (a wrong count turns the canary's hard
+ * verdict against the wrong contract). Unregistered kernels keep today's
+ * verdict exactly.
  *
  * NOTE: output_elems is a single value applied to EVERY output buffer of the
  * kernel; it assumes all outputs share one cardinality (true for the single-output

--- a/lib/volk_reference.h
+++ b/lib/volk_reference.h
@@ -32,8 +32,10 @@
 //             outputs[0][0]); the harness zero-fills both sides so untouched
 //             tails compare equal. A wrong-prefix oracle IS caught (fcompare
 //             runs the full vlen, so it diverges from the impl's zero tail);
-//             keep the count consistent with volk_buffer_roles.cc, which the
-//             canary side consults.
+//             for kernels present in BOTH registries, keep the prefix count
+//             consistent with the volk_buffer_roles.cc entry the canary side
+//             consults. Membership itself diverges by design (#191): buffer
+//             roles cover the whole fixed-output class, oracles stay opt-in.
 //   scalar  : test_params.scalar() — real part carries an s32f scalar
 //             (e.g. power exponent, atan2 normalizeFactor); full value for s32fc.
 //   vlen    : the USER vlen (number of elements), not the twiddled buffer size.


### PR DESCRIPTION
## Summary

Batch-registers the 20 remaining fixed-output kernels (dot products, accumulator, index max/min, single-element stats, sum-of-poly) in the #161 buffer-role registry, so the #89 output canary now issues a hard `ok`/`FAIL` verdict for the whole fixed-output class instead of the `part` hedge every reduction-tolerance PR (#119–#123) had to document as "expected, out of scope". Registry rows only — no kernel or harness-logic changes. Two doc surfaces the flip falsifies are updated in the same change: the harness README's "`partial` — expected for reduction/index kernels" sentence, and `volk_reference.h`'s cross-registry consistency comment (membership now diverges by design: buffer roles cover the whole fixed-output class, oracles stay opt-in). The registration-discipline note ("verify cardinality against the header contract and every impl's stores before registering") moved into `volk_buffer_roles.h`'s HOW-TO block.

Candidate set was derived from a fresh seeded sweep at the branch HEAD, not the issue's prose list — the fresh set (20) matches the issue's own definition ("canary `part` rows minus the two registered") and includes `volk_64f_x2_dot_prod_64f` and `volk_32f_x3_sum_of_poly_32f`, which the issue body's list omitted. Every kernel's cardinality was verified against its header contract and every impl's stores (all 20 KEEP; per-impl citations in the issue's `analysis/2026-08-07-contract-verification.md`).

Review + red-team follow-ups (second and third commits, comment/banner-string only): the `volk_buffer_roles.h` multi-output NOTE was falsified by registering the two-output `stddev_and_mean` kernel, and the `test_correctness.cc` sweep comment still described pre-#191 `partial` semantics — both aligned. The class-closure claims are scoped to the **QA roster**: the deprecated max-star family (`volk_16i_max_star_16i` and friends; QA rows commented out in `kernel_tests.h`) is fixed-output but outside the sweep's reach, and stays unregistered. The sweep's summary banner no longer attributes a registered kernel's under-written contracted region to "over-ran the output buffer" (both FAIL causes are now named), and the `num_points >= 1` contract scoping is mirrored into the `.h` schema NOTE.

Guard status, stated plainly: nothing in the repo runs the canary sweep automatically (no ctest or CI workflow sets `HARNESS_CANARY`; the two misaligned ctests and the combined negative control never consult the registry for real kernels — enumerated below). The flip is proven by this PR's seeded sweep pair; CI/ctest enrollment of the canary sweep is a follow-up to be filed at reap, per the validated-set-plus-broadening-follow-up disposition. That follow-up is load-bearing, not optional: the HOW-TO now states an expectation that new fixed-output kernels register, and until a gate runs the sweep, nothing enforces either that expectation or the 20 contracts landed here.

## Related issues

Closes #191. Related: #161 (registry + promotion path), #89 (output canary), #119–#123 (the campaign whose `part` hedges this retires).

## Testing

- Seeded sweep pair (`HARNESS_SEED=191`) at the branch baseline `ff056439` and after the edit: all 147 `partial` canary rows across exactly the 20 registered kernels flip to `ok`; 0 `FAIL`; verified in BOTH channels (CSV rows and the kernel-level stdout verdicts, which come from different code paths). Diff at identical seed confined to the 20 kernels' rows — no behavior change for unregistered kernels. Runtime proof covers the impls this box dispatches (x86: generic/SSE/AVX/AVX-512); NEON/RVV impl cardinality is verified by header/store inspection only (per-impl citations in the issue's contract-verification artifact) — no automated runner exists yet to execute them under this contract.
- Teeth check: `volk_32fc_x2_dot_prod_32fc` deliberately mis-declared `output_elems=2` → hard `FAIL  [canary] … under-wrote contracted region` at every vlen ≥ 2, harness exit 1; restored to `1` → `ok`, exit 0; restoration proven by `git diff --exit-code` against the staged index.
- Canary negative control OK in every run (planted ok/one-past/unwritten kernels + the #161 registered-map-FAIL / unregistered-part promotion controls).
- `ctest`: 257/257 pass (incl. `qa_harness_negative_control`).
- Consumer enumeration (registration blast radius): `qa_strict_misaligned_canary` and `qa_misaligned_puppet_control` run `HARNESS_MISALIGNED=1` and never consult the buffer-role registry; `qa_harness_negative_control` builds its own synthetic entry — all unaffected.
- Analyzers (changed-line scope): cppcheck 0, cpplint 0 novel (13 pre-existing), clang-tidy 0, scan-build pass, iwyu 0, clang-format 0, codespell 0, compiler warnings 0; ASan+UBSan pass; TSan pass.

## Evidence

suite: none @ 6f3c362efaa607baa2ad49b6d37ba0e55217a04b
files: 5 changed

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
