### PR TITLE
qa harness fd-mute RAII dedup

### DIFF
--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -311,39 +311,23 @@ static volk_immutability_summary quiet_immutability_run(volk_test_case_t& tc,
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
-    std::fflush(stdout);
-    std::cout.flush();
-    int saved = -1, devnull = -1;
-    if (!verbose) {
-        saved = dup(STDOUT_FILENO);
-        devnull = open(VOLK_DEVNULL, O_WRONLY);
-        if (saved >= 0 && devnull >= 0)
-            dup2(devnull, STDOUT_FILENO);
-    }
     volk_immutability_summary summary;
     bool threw = false;
-    try {
-        summary = run_volk_immutability_test(tc.desc(),
-                                             tc.kernel_ptr(),
-                                             tc.name(),
-                                             tc.test_parameters().scalar(),
-                                             v /*vlen*/,
-                                             &results,
-                                             kFloatEdges,
-                                             kComplexEdges);
-    } catch (...) {
-        threw = true;
-        summary = volk_immutability_summary(); // applied=false, mutated=false -> skip
-    }
-    std::fflush(stdout);
-    std::cout.flush();
-    if (!verbose) {
-        if (saved >= 0) {
-            dup2(saved, STDOUT_FILENO);
-            close(saved);
+    {
+        FdMuteGuard stdout_mute(!verbose);
+        try {
+            summary = run_volk_immutability_test(tc.desc(),
+                                                 tc.kernel_ptr(),
+                                                 tc.name(),
+                                                 tc.test_parameters().scalar(),
+                                                 v /*vlen*/,
+                                                 &results,
+                                                 kFloatEdges,
+                                                 kComplexEdges);
+        } catch (...) {
+            threw = true;
+            summary = volk_immutability_summary(); // applied=false, mutated=false -> skip
         }
-        if (devnull >= 0)
-            close(devnull);
     }
     if (threw)
         std::cerr << "note  [immutable] " << tc.name() << " threw at vlen " << v
@@ -380,42 +364,26 @@ static volk_misaligned_summary quiet_misaligned_run(volk_test_case_t& tc, unsign
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
-    std::fflush(stdout);
-    std::cout.flush();
-    int saved = -1, devnull = -1;
-    if (!verbose) {
-        saved = dup(STDOUT_FILENO);
-        devnull = open(VOLK_DEVNULL, O_WRONLY);
-        if (saved >= 0 && devnull >= 0)
-            dup2(devnull, STDOUT_FILENO);
-    }
     volk_misaligned_summary summary;
     bool threw = false;
-    try {
-        summary = run_volk_misaligned_test(tc.desc(),
-                                           tc.kernel_ptr(),
-                                           tc.name(),
-                                           tc.test_parameters().scalar(),
-                                           tc.test_parameters().tol(),
-                                           tc.test_parameters().absolute_mode(),
-                                           v /*vlen*/,
-                                           &results,
-                                           kFloatEdges,
-                                           kComplexEdges,
-                                           /*fork_isolation=*/tc.is_puppet());
-    } catch (...) {
-        threw = true;
-        summary = volk_misaligned_summary(); // applied=false -> skip
-    }
-    std::fflush(stdout);
-    std::cout.flush();
-    if (!verbose) {
-        if (saved >= 0) {
-            dup2(saved, STDOUT_FILENO);
-            close(saved);
+    {
+        FdMuteGuard stdout_mute(!verbose);
+        try {
+            summary = run_volk_misaligned_test(tc.desc(),
+                                               tc.kernel_ptr(),
+                                               tc.name(),
+                                               tc.test_parameters().scalar(),
+                                               tc.test_parameters().tol(),
+                                               tc.test_parameters().absolute_mode(),
+                                               v /*vlen*/,
+                                               &results,
+                                               kFloatEdges,
+                                               kComplexEdges,
+                                               /*fork_isolation=*/tc.is_puppet());
+        } catch (...) {
+            threw = true;
+            summary = volk_misaligned_summary(); // applied=false -> skip
         }
-        if (devnull >= 0)
-            close(devnull);
     }
     if (threw)
         std::cerr << "note  [misaligned] " << tc.name() << " threw at vlen " << v

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -81,7 +81,10 @@ namespace {
 // (puppet fork-isolation) while the mute is engaged; the child exits via
 // _exit() only, so this destructor never runs in the child — a future child
 // path that unwound or called exit() would restore/close the PARENT's saved
-// fds from inside the child.
+// fds from inside the child. Longjmp-safety: the #91 fault recovery opens its
+// sigsetjmp windows INSIDE run_volk_misaligned_test and recovers there, so no
+// siglongjmp ever crosses this guard's frame; hoisting a sigsetjmp window
+// above the guard would be UB (longjmp across a non-trivial destructor).
 class FdMuteGuard
 {
 public:
@@ -99,8 +102,10 @@ public:
                 dup2(devnull_, STDOUT_FILENO);
         }
     }
-    // Implicitly noexcept: cout's exception mask is the default goodbit here
-    // (nothing in this TU widens it), so flush() cannot throw during unwind.
+    // Implicitly noexcept: no TU linked into this binary calls
+    // std::cout.exceptions() (grep-verified), so the mask stays goodbit and
+    // flush() cannot throw during unwind. A TU that widens the mask would
+    // turn a throwing flush here into std::terminate.
     ~FdMuteGuard()
     {
         std::fflush(stdout);

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -71,6 +71,54 @@
 #define VOLK_DEVNULL "/dev/null"
 #endif
 
+namespace {
+// #163: single home for the stdout fd-mute dance the four quiet_* helpers
+// previously open-coded. The constructor flushes (stdio + iostream) and, when
+// `mute` is set, redirects STDOUT_FILENO to VOLK_DEVNULL; the destructor
+// flushes and restores. Uses the POSIX names mapped by the macro block above,
+// so it must stay in this TU below that block. Fork-safety: the misaligned
+// mode forks (puppet fork-isolation) while the mute is engaged; the child
+// exits via _exit() only, so this destructor never runs in the child — a
+// future child path that unwound or called exit() would restore/close the
+// PARENT's saved fds from inside the child.
+class FdMuteGuard
+{
+public:
+    explicit FdMuteGuard(bool mute)
+    {
+        std::fflush(stdout);
+        std::cout.flush();
+        if (mute) {
+            saved_ = dup(STDOUT_FILENO);
+            devnull_ = open(VOLK_DEVNULL, O_WRONLY);
+            // Only redirect if BOTH fds are valid; otherwise we could mute
+            // stdout with no way to restore it (a failed dup leaves
+            // saved_ == -1).
+            if (saved_ >= 0 && devnull_ >= 0)
+                dup2(devnull_, STDOUT_FILENO);
+        }
+    }
+    ~FdMuteGuard()
+    {
+        std::fflush(stdout);
+        std::cout.flush();
+        // Restore only if we actually have the saved fd; never dup2/close(-1).
+        if (saved_ >= 0) {
+            dup2(saved_, STDOUT_FILENO);
+            close(saved_);
+        }
+        if (devnull_ >= 0)
+            close(devnull_);
+    }
+    FdMuteGuard(const FdMuteGuard&) = delete;
+    FdMuteGuard& operator=(const FdMuteGuard&) = delete;
+
+private:
+    int saved_ = -1;
+    int devnull_ = -1;
+};
+} // namespace
+
 // Compile-time AddressSanitizer detection: the far-past ASan demo deliberately
 // writes past the guarded allocation, which is undefined behaviour unless ASan
 // is bracketing it, so it must only run in an ASan build.

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -73,22 +73,23 @@
 
 namespace {
 // #163: single home for the stdout fd-mute dance the four quiet_* helpers
-// previously open-coded. The constructor flushes (stdio + iostream) and, when
-// `mute` is set, redirects STDOUT_FILENO to VOLK_DEVNULL; the destructor
-// flushes and restores. Uses the POSIX names mapped by the macro block above,
-// so it must stay in this TU below that block. Fork-safety: the misaligned
-// mode forks (puppet fork-isolation) while the mute is engaged; the child
-// exits via _exit() only, so this destructor never runs in the child — a
-// future child path that unwound or called exit() would restore/close the
-// PARENT's saved fds from inside the child.
+// previously open-coded, policy included: the constructor flushes (stdio +
+// iostream) and, unless HARNESS_VERBOSE is set (the operator's unmute knob),
+// redirects STDOUT_FILENO to VOLK_DEVNULL; the destructor flushes and
+// restores. Uses the POSIX names mapped by the macro block above, so it must
+// stay in this TU below that block. Fork-safety: the misaligned mode forks
+// (puppet fork-isolation) while the mute is engaged; the child exits via
+// _exit() only, so this destructor never runs in the child — a future child
+// path that unwound or called exit() would restore/close the PARENT's saved
+// fds from inside the child.
 class FdMuteGuard
 {
 public:
-    explicit FdMuteGuard(bool mute)
+    FdMuteGuard()
     {
         std::fflush(stdout);
         std::cout.flush();
-        if (mute) {
+        if (std::getenv("HARNESS_VERBOSE") == nullptr) {
             saved_ = dup(STDOUT_FILENO);
             devnull_ = open(VOLK_DEVNULL, O_WRONLY);
             // Only redirect if BOTH fds are valid; otherwise we could mute
@@ -175,8 +176,7 @@ quiet_run(volk_test_case_t& tc,
           std::map<std::string, double>* impl_max_err = nullptr)
 {
     std::vector<volk_test_results_t> results;
-    const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
-    FdMuteGuard stdout_mute(!verbose);
+    FdMuteGuard stdout_mute;
     bool fail = false;
     try {
         if (ref) {
@@ -283,8 +283,7 @@ static volk_canary_summary
 quiet_canary_run(volk_test_case_t& tc, unsigned int v, unsigned int contracted_elems = 0)
 {
     std::vector<volk_test_results_t> results;
-    const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
-    FdMuteGuard stdout_mute(!verbose);
+    FdMuteGuard stdout_mute;
     volk_canary_summary summary;
     try {
         summary = run_volk_canary_test(tc.desc(),
@@ -310,11 +309,10 @@ static volk_immutability_summary quiet_immutability_run(volk_test_case_t& tc,
                                                         unsigned int v)
 {
     std::vector<volk_test_results_t> results;
-    const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
     volk_immutability_summary summary;
     bool threw = false;
     {
-        FdMuteGuard stdout_mute(!verbose);
+        FdMuteGuard stdout_mute;
         try {
             summary = run_volk_immutability_test(tc.desc(),
                                                  tc.kernel_ptr(),
@@ -363,11 +361,10 @@ static std::vector<std::string> unmapped_master_impls(volk_func_desc_t master,
 static volk_misaligned_summary quiet_misaligned_run(volk_test_case_t& tc, unsigned int v)
 {
     std::vector<volk_test_results_t> results;
-    const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
     volk_misaligned_summary summary;
     bool threw = false;
     {
-        FdMuteGuard stdout_mute(!verbose);
+        FdMuteGuard stdout_mute;
         try {
             summary = run_volk_misaligned_test(tc.desc(),
                                                tc.kernel_ptr(),

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -99,6 +99,8 @@ public:
                 dup2(devnull_, STDOUT_FILENO);
         }
     }
+    // Implicitly noexcept: cout's exception mask is the default goodbit here
+    // (nothing in this TU widens it), so flush() cannot throw during unwind.
     ~FdMuteGuard()
     {
         std::fflush(stdout);
@@ -176,6 +178,8 @@ quiet_run(volk_test_case_t& tc,
           std::map<std::string, double>* impl_max_err = nullptr)
 {
     std::vector<volk_test_results_t> results;
+    // Function-scoped: stdout stays muted until return; a stdout write added
+    // below would be swallowed where the pre-#163 code would have printed it.
     FdMuteGuard stdout_mute;
     bool fail = false;
     try {
@@ -283,6 +287,7 @@ static volk_canary_summary
 quiet_canary_run(volk_test_case_t& tc, unsigned int v, unsigned int contracted_elems = 0)
 {
     std::vector<volk_test_results_t> results;
+    // Function-scoped: stdout stays muted until return (see quiet_run).
     FdMuteGuard stdout_mute;
     volk_canary_summary summary;
     try {
@@ -311,6 +316,7 @@ static volk_immutability_summary quiet_immutability_run(volk_test_case_t& tc,
     std::vector<volk_test_results_t> results;
     volk_immutability_summary summary;
     bool threw = false;
+    // Scoped: the cerr note below must print AFTER stdout is restored.
     {
         FdMuteGuard stdout_mute;
         try {
@@ -363,6 +369,7 @@ static volk_misaligned_summary quiet_misaligned_run(volk_test_case_t& tc, unsign
     std::vector<volk_test_results_t> results;
     volk_misaligned_summary summary;
     bool threw = false;
+    // Scoped: the cerr note below must print AFTER stdout is restored.
     {
         FdMuteGuard stdout_mute;
         try {

--- a/lib/test_correctness.cc
+++ b/lib/test_correctness.cc
@@ -176,17 +176,7 @@ quiet_run(volk_test_case_t& tc,
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
-    std::fflush(stdout);
-    std::cout.flush();
-    int saved = -1, devnull = -1;
-    if (!verbose) {
-        saved = dup(STDOUT_FILENO);
-        devnull = open(VOLK_DEVNULL, O_WRONLY);
-        // Only redirect if BOTH fds are valid; otherwise we could mute stdout
-        // with no way to restore it (a failed dup leaves saved == -1).
-        if (saved >= 0 && devnull >= 0)
-            dup2(devnull, STDOUT_FILENO);
-    }
+    FdMuteGuard stdout_mute(!verbose);
     bool fail = false;
     try {
         if (ref) {
@@ -246,17 +236,6 @@ quiet_run(volk_test_case_t& tc,
         if (ref_skip_reason)
             *ref_skip_reason = results.back().skip_reason;
     }
-    std::fflush(stdout);
-    std::cout.flush();
-    if (!verbose) {
-        // Restore only if we actually have the saved fd; never dup2/close(-1).
-        if (saved >= 0) {
-            dup2(saved, STDOUT_FILENO);
-            close(saved);
-        }
-        if (devnull >= 0)
-            close(devnull);
-    }
     return fail;
 }
 
@@ -305,15 +284,7 @@ quiet_canary_run(volk_test_case_t& tc, unsigned int v, unsigned int contracted_e
 {
     std::vector<volk_test_results_t> results;
     const bool verbose = (std::getenv("HARNESS_VERBOSE") != nullptr);
-    std::fflush(stdout);
-    std::cout.flush();
-    int saved = -1, devnull = -1;
-    if (!verbose) {
-        saved = dup(STDOUT_FILENO);
-        devnull = open(VOLK_DEVNULL, O_WRONLY);
-        if (saved >= 0 && devnull >= 0)
-            dup2(devnull, STDOUT_FILENO);
-    }
+    FdMuteGuard stdout_mute(!verbose);
     volk_canary_summary summary;
     try {
         summary = run_volk_canary_test(tc.desc(),
@@ -327,16 +298,6 @@ quiet_canary_run(volk_test_case_t& tc, unsigned int v, unsigned int contracted_e
                                        contracted_elems);
     } catch (...) {
         summary.guard_violation = true;
-    }
-    std::fflush(stdout);
-    std::cout.flush();
-    if (!verbose) {
-        if (saved >= 0) {
-            dup2(saved, STDOUT_FILENO);
-            close(saved);
-        }
-        if (devnull >= 0)
-            close(devnull);
     }
     return summary;
 }


### PR DESCRIPTION
## Summary

Deduplicate the four open-coded stdout fd-mute blocks in
`lib/test_correctness.cc` into one anonymous-namespace RAII guard,
`FdMuteGuard` — a pure refactor with byte-identical harness output, proven by
a seed-pinned before/after capture matrix. Why now: every hardening change to
the mute dance had to be made four times, and the copies had already diverged
(only the `quiet_run` copy carried the hand-written invariant comments — the
issue's "each carries the same guard comment" premise was falsified at 3 of 4
sites, which is the divergence risk demonstrating itself). The guard owns the
whole contract in one home: the unconditional stdio+iostream flushes, the
`HARNESS_VERBOSE` unmute knob, the "redirect only if BOTH fds are valid"
guard, and the "never dup2/close(-1)" restore guard. The two call sites that
print a `std::cerr` note after the old restore point close the guard in an
explicit inner scope, so every restore happens at exactly the old program
point. Fork-safety of the misaligned mode's puppet fork-isolation (child
exits via `_exit()` only, so the destructor never runs in the child) is
recorded on the class.

One disclosed deviation from the issue's suggested shape: the issue sketched
`constructed only when !verbose`; the landed guard instead always constructs
and owns the `HARNESS_VERBOSE` read itself (default constructor). The change
originated in the quality pass, where two independent reviewers converged on
the same argument the issue makes about the fd dance — four copies of one
policy (a per-site `getenv` plus a `!verbose` polarity flip) belong in the
single home too. The trade-off (call sites no longer show the env knob; no
unconditional-mute spelling) is carried by the class comment.

Two disclosed qualifications to "no behavior change", neither reachable in
any capture: (1) an exception escaping the post-run bookkeeping in
`quiet_run` now restores stdout during unwinding where it previously stayed
muted — a strict improvement; (2) MSVC shims and `VOLK_DEVNULL` are untouched
per the issue.

## Related issues

Closes #163

## Testing

- **Byte-identity (AC2)**: 5 modes (default sweep, canary, immutable,
  misaligned, combined-NC) captured full-roster at the baseline
  (`9d755aa8`) and re-captured after — all 15 cells (mode × stdout/stderr/
  exit-status) byte-IDENTICAL, `HARNESS_SEED=163` pinned both sides
  (`Issue-Fork-163/analysis/capture-provenance.txt`). The default-mode
  baseline legitimately exits rc=1 (pre-existing
  `FAIL volk_16ic_x2_dot_prod_16ic` at vlen 1000003) and the refactored
  binary reproduces it exactly. Verbose (unmuted) mode is timing-
  nondeterministic, so its comparators are rc equality and line-count
  equality (632/632); as a sanity check only, the before/after diff (924 raw
  lines) falls inside the same-binary run-to-run noise band of the new
  binary, measured over 5 consecutive pairs ([916..924]). (AC2's wording
  mentions `volk_test_all`; the capture matrix deliberately covers
  `volk_test_correctness` only — `volk_test_all` does not compile this TU and
  cannot exercise the mute; ctest covers it on the after side.)
- **Failed-dup edge (AC4)**: A/B probe of the preserved baseline binary vs
  the new one under `ulimit -n {24..4}`: mute engages and output is
  byte-identical at n ≥ 5; at n = 4 `dup`/`open` fail, the guard's
  `saved_ < 0` branch fires in both binaries, and both run unmuted to
  completion with identical structure (diff confined to nondeterministic
  timing columns). The guarded branch is exercised, not just present.
- **Dedup complete (AC1)**: `int saved = -1, devnull = -1;` → 0 hits;
  `dup(STDOUT_FILENO)` → 1; `dup2(` → 2 (ctor+dtor); `FdMuteGuard
  stdout_mute;` → 4. Token-level boundary probe (`dup2|VOLK_DEVNULL|_dup\b`
  across `lib apps python cmake tmpl`) hits only this TU.
- **ctest (AC3)**: 257/257 pass (run at `0c85dee8`; the two later commits
  are comment-only and provably codegen-inert — the built binary's sha256 is
  identical across them, recorded in the provenance sidecar)
  (presence-asserted:
  `harness_negative_control` and `qa_misaligned_puppet_control` registered;
  `qa_strict_misaligned_canary` is ASAN-only by its CMake gate and is owned
  by the CI ASAN lane, not claimable locally in a Release build).
- **Analyzers**: cppcheck/clang-tidy/iwyu/scan-build/compiler-warnings/
  codespell clean; ASan+UBSan and TSan builds each ran the full 257-test
  suite, 0 failures. cpplint reports 11 novel whitespace/brace-style nits on
  the changed lines that contradict the in-tree `.clang-format`
  (`git clang-format --diff` is empty) — the project formatter is the
  arbiter, per existing practice in this TU.
- 6 signed-off commits; net −14 LOC in one file (the last two commits are
  review/red-team touch-ups commenting the load-bearing scopes and widening
  two safety claims to program scope — both verified codegen-identical: the
  binary sha256 is unchanged across them).
- The `suite:` line below is the workflow's machine-checked form and means
  "no bats/pytest exist in this repo" — the C++ coverage is the ctest suite
  (257/257) plus the capture matrix above, not zero tests.

## Evidence

suite: none @ 4a600e7abcbeb773c32cca8aa0aef52f2928ca1d
files: 1 changed

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
