### PR TITLE
avx2 index tie break

### DIFF
--- a/docs/kernel_correctness_harness/README.md
+++ b/docs/kernel_correctness_harness/README.md
@@ -10,6 +10,15 @@ suite byte-for-byte unchanged, plus a CI-enforced combined negative control
 that proves the assembled harness still catches the defect classes that
 motivated it.
 
+A sixth blind spot is positional: fixed-position tie edges (qa's
+`test_params_index_fc`, this harness's edge-value injection) place the first
+tied element in an early-scanned lane, so an impl whose horizontal reduce
+scans lanes out of memory order can violate the first-index-wins tie-break and
+still pass every fixed edge (#195 — all four avx2 complex index variants did).
+The standalone ctest `qa_index_tie_sweep` closes it by planting an
+equal-magnitude extremum pair at every position pair (i, j) for vlens
+8/32/37 and requiring every available impl to return the first tied index.
+
 ## How to run
 
 Build with testing enabled, then run the harness binary directly:
@@ -31,6 +40,7 @@ environment variable:
 | `HARNESS_IMMUTABLE=1` | input-immutability canary: byte-exact post-run compare of every input against its pristine pre-image | #90 |
 | `HARNESS_MISALIGNED=1` | misaligned `_u_`-variant runs: every unaligned impl on deliberately misaligned buffers, with scoped signal trapping (POSIX only); puppet kernels run under fork isolation with `(fork-isolated)`-tagged rows (ctest `qa_misaligned_puppet_control`); strict-UBSan regression detector is the ctest `qa_strict_misaligned_canary` (ASAN build type only) | #91 / #221 / #162 |
 | `HARNESS_COMBINED_NC=1` | combined negative control (the ctest `qa_harness_negative_control`) | #92 |
+| (none — standalone ctest `qa_index_tie_sweep`, binary `volk_test_index_tie_sweep`) | tie-position sweep for the complex index kernels: equal-magnitude extremum pair at every position pair (vlens 8/32/37), every available impl must return the FIRST tied index; avx2 coverage floor keyed to the hardware capability | #195 |
 | `HARNESS_REPORT=path` | write the per-kernel × per-impl CSV (format below) in any mode | #87 / #92 |
 | `HARNESS_VERBOSE=1` | unmute the per-impl stdout of the underlying qa runs | — |
 
@@ -271,7 +281,9 @@ Retention: latest snapshot only — a new snapshot replaces the old files
   runs the strict misaligned mode and goes red if the exemption is ever lost.
 - **Default qa:** `volk_test_all` and the per-kernel `qa_volk_*` ctests are
   byte-for-byte unaffected by every capability here; all harness behavior is
-  opt-in via the env toggles.
+  opt-in via the env toggles. The `qa_index_tie_sweep` ctest (#195) is
+  standalone and unconditional: plain ctest, every platform, no env toggle,
+  no special build type.
 
 ## Reproducibility (`HARNESS_SEED`)
 

--- a/kernels/volk/volk_32fc_index_max_16u.h
+++ b/kernels/volk/volk_32fc_index_max_16u.h
@@ -108,9 +108,16 @@ static inline void volk_32fc_index_max_16u_a_avx2_variant_0(uint16_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break: the buffers are in lane-scan order
+    // [0,1,4,5,2,3,6,7], not memory order, so a strict > over the scan
+    // keeps the wrong element of a cross-lane tie. On an equal magnitude,
+    // take the smaller index (#195; same convention as a_sse3/#127 and
+    // avx512f).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }
@@ -168,9 +175,13 @@ static inline void volk_32fc_index_max_16u_a_avx2_variant_1(uint16_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }
@@ -623,9 +634,13 @@ static inline void volk_32fc_index_max_16u_u_avx2_variant_0(uint16_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }
@@ -683,9 +698,13 @@ static inline void volk_32fc_index_max_16u_u_avx2_variant_1(uint16_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -103,9 +103,16 @@ static inline void volk_32fc_index_max_32u_a_avx2_variant_0(uint32_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break: the buffers are in lane-scan order
+    // [0,1,4,5,2,3,6,7], not memory order, so a strict > over the scan
+    // keeps the wrong element of a cross-lane tie. On an equal magnitude,
+    // take the smaller index (#195; same convention as a_sse3/#127 and
+    // avx512f).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }
@@ -161,9 +168,13 @@ static inline void volk_32fc_index_max_32u_a_avx2_variant_1(uint32_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }
@@ -462,9 +473,13 @@ static inline void volk_32fc_index_max_32u_u_avx2_variant_0(uint32_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }
@@ -520,9 +535,13 @@ static inline void volk_32fc_index_max_32u_u_avx2_variant_1(uint32_t* target,
 
     float max = 0.f;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (max_values_buffer[i] > max) {
             max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        } else if (max_values_buffer[i] == max && max_indices_buffer[i] < index) {
             index = max_indices_buffer[i];
         }
     }

--- a/kernels/volk/volk_32fc_index_min_16u.h
+++ b/kernels/volk/volk_32fc_index_min_16u.h
@@ -110,9 +110,14 @@ static inline void volk_32fc_index_min_16u_a_avx2_variant_0(uint16_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break: the buffers are in lane-scan order
+    // [0,1,4,5,2,3,6,7], not memory order -- equal magnitude takes the
+    // smaller index (#195; same convention as a_sse3/#127 and avx512f).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }
@@ -170,9 +175,13 @@ static inline void volk_32fc_index_min_16u_a_avx2_variant_1(uint16_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }
@@ -621,9 +630,13 @@ static inline void volk_32fc_index_min_16u_u_avx2_variant_0(uint16_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }
@@ -681,9 +694,13 @@ static inline void volk_32fc_index_min_16u_u_avx2_variant_1(uint16_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }

--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -105,9 +105,14 @@ static inline void volk_32fc_index_min_32u_a_avx2_variant_0(uint32_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break: the buffers are in lane-scan order
+    // [0,1,4,5,2,3,6,7], not memory order -- equal magnitude takes the
+    // smaller index (#195; same convention as a_sse3/#127 and avx512f).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }
@@ -163,9 +168,13 @@ static inline void volk_32fc_index_min_32u_a_avx2_variant_1(uint32_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }
@@ -459,9 +468,13 @@ static inline void volk_32fc_index_min_32u_u_avx2_variant_0(uint32_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }
@@ -517,9 +530,13 @@ static inline void volk_32fc_index_min_32u_u_avx2_variant_1(uint32_t* target,
 
     float min = FLT_MAX;
     uint32_t index = 0;
+    // First-index tie-break on the lane-scan-order buffers -- see the first
+    // avx2 variant (#195).
     for (unsigned i = 0; i < 8; i++) {
         if (min_values_buffer[i] < min) {
             min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        } else if (min_values_buffer[i] == min && min_indices_buffer[i] < index) {
             index = min_indices_buffer[i];
         }
     }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -899,6 +899,17 @@ if(ENABLE_TESTING)
             volk_test_index_tie_sweep SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_index_tie_sweep.cc TARGET_DEPS volk)
     endif()
+    # Arm the tie sweep's avx2 coverage floor only when this BUILD's machine
+    # table carries an avx2 machine. The floor's other key is the runtime CPU
+    # capability; hardware alone must not red a build whose arch list
+    # legitimately has no avx2 impls (VOLK_STATIC_DISPATCH=generic runs ctest
+    # on avx2 CI runners; an old-compiler dynamic build is the same shape).
+    # available_machines is already collapsed to the pinned machine under
+    # static dispatch, so it is the build's truth in both modes.
+    if(available_machines MATCHES "avx2")
+        target_compile_definitions(volk_test_index_tie_sweep
+                                   PRIVATE VOLK_TIE_SWEEP_EXPECT_AVX2=1)
+    endif()
     # The planted misaligned-fault control must keep its raw movaps, but
     # UBSan's alignment check reports it BEFORE the deliberate fault, so a
     # strict lane (halt_on_error=1) dies pre-sweep. Exempt this one test-only

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -881,6 +881,10 @@ if(ENABLE_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_buffer_roles.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk_static)
+        volk_gen_test(
+            volk_test_index_tie_sweep SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/qa_index_tie_sweep.cc TARGET_DEPS
+            volk_static)
     else()
         volk_gen_test(volk_test_all SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc
                       ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk)
@@ -891,6 +895,9 @@ if(ENABLE_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_canary_kernel.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/volk_buffer_roles.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc TARGET_DEPS volk)
+        volk_gen_test(
+            volk_test_index_tie_sweep SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/qa_index_tie_sweep.cc TARGET_DEPS volk)
     endif()
     # The planted misaligned-fault control must keep its raw movaps, but
     # UBSan's alignment check reports it BEFORE the deliberate fault, so a
@@ -1000,5 +1007,11 @@ if(ENABLE_TESTING)
     # breaks here.
     volk_add_test(harness_negative_control volk_test_correctness ENVIRONS
                   "HARNESS_COMBINED_NC=1")
+
+    # Tie-position-sweeping regression test for the complex index kernels
+    # (#195): plants an equal-magnitude extremum pair at every position pair
+    # and requires every available impl to return the FIRST tied index.
+    # Fixed-position tie edges cannot see a scan-order reduce bug.
+    volk_add_test(index_tie_sweep volk_test_index_tie_sweep)
 
 endif(ENABLE_TESTING)

--- a/lib/qa_index_tie_sweep.cc
+++ b/lib/qa_index_tie_sweep.cc
@@ -1,0 +1,148 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2026 Free Software Foundation, Inc.
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/*
+ * Tie-position-sweeping regression test for the complex index kernels (#195).
+ *
+ * The first-index-wins tie-break is only observable when the FIRST tied
+ * element sits in a lane the implementation's horizontal reduce scans LATE.
+ * Fixed-position tie edges (test_params_index_fc, the correctness sweep's
+ * complex edge vector) place the first tied index in an early-scanned lane,
+ * so a scan-order reduce passes them by accident. This test plants an
+ * equal-magnitude extremum pair at every position pair (i, j), i < j, for
+ * several vlens, and requires every available implementation to return i.
+ */
+
+#include <volk/volk.h>
+#include <volk/volk_alloc.hh>
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+// 8: the issue's repro width (one avx2 block). 32: two avx512 blocks, four
+// avx2 blocks, no tail. 37: forces a scalar tail on every SIMD width, so
+// vector-region-vs-tail ties are swept too.
+const unsigned kVlens[] = { 8, 32, 37 };
+
+unsigned pairs_per_arch()
+{
+    unsigned pairs = 0;
+    for (unsigned vlen : kVlens)
+        pairs += vlen * (vlen - 1) / 2;
+    return pairs;
+}
+
+template <typename TargetT, typename ManualF>
+int sweep_kernel(const char* kernel_name,
+                 volk_func_desc_t desc,
+                 ManualF manual,
+                 lv_32fc_t baseline,
+                 lv_32fc_t extremum)
+{
+    // impl_names from the runtime-selected machine are runnable by
+    // construction.
+    bool have_generic = false;
+    for (size_t i = 0; i < desc.n_impls && !have_generic; ++i)
+        have_generic = (std::strcmp(desc.impl_names[i], "generic") == 0);
+    if (!have_generic) {
+        std::printf("%s: FAIL (generic missing from arch list, %zu archs)\n",
+                    kernel_name,
+                    desc.n_impls);
+        return 1;
+    }
+
+    int total_failures = 0;
+    unsigned total_pairs = 0;
+    for (size_t ai = 0; ai < desc.n_impls; ++ai) {
+        const char* arch = desc.impl_names[ai];
+        unsigned arch_pairs = 0;
+        int arch_failures = 0;
+        for (unsigned vlen : kVlens) {
+            volk::vector<lv_32fc_t> buf(vlen);
+            for (unsigned i = 0; i + 1 < vlen; ++i) {
+                for (unsigned j = i + 1; j < vlen; ++j) {
+                    for (unsigned k = 0; k < vlen; ++k)
+                        buf[k] = baseline;
+                    buf[i] = extremum;
+                    buf[j] = extremum;
+                    TargetT target = static_cast<TargetT>(vlen); // impossible
+                    manual(&target, buf.data(), vlen, arch);
+                    ++arch_pairs;
+                    if (static_cast<unsigned>(target) != i) {
+                        ++arch_failures;
+                        // Cap printed rows PER ARCH so one broken impl
+                        // cannot suppress its siblings' evidence; count all.
+                        if (arch_failures <= 20)
+                            std::printf("%s %s vlen=%u tie(%u,%u): got %u want %u\n",
+                                        kernel_name,
+                                        arch,
+                                        vlen,
+                                        i,
+                                        j,
+                                        static_cast<unsigned>(target),
+                                        i);
+                    }
+                }
+            }
+        }
+        // One summary line per (kernel, arch): the per-impl failure count
+        // the born-red evidence keys on.
+        std::printf("%s %s: %s (%d failing of %u tie pairs)\n",
+                    kernel_name,
+                    arch,
+                    arch_failures ? "FAIL" : "ok",
+                    arch_failures,
+                    arch_pairs);
+        total_failures += arch_failures;
+        total_pairs += arch_pairs;
+    }
+    if (total_pairs != desc.n_impls * pairs_per_arch()) {
+        std::printf("%s: FAIL (coverage: swept %u pairs, expected %zu)\n",
+                    kernel_name,
+                    total_pairs,
+                    desc.n_impls * pairs_per_arch());
+        return total_failures + 1;
+    }
+    return total_failures;
+}
+
+} // namespace
+
+int main(int, char**)
+{
+    int failures = 0;
+
+    // Magnitudes chosen exactly representable: baseline |z|^2 = 2 or 9,
+    // extremum |z|^2 = 9 or 1 -- no float-compare tolerance in play.
+    failures += sweep_kernel<uint16_t>("volk_32fc_index_max_16u",
+                                       volk_32fc_index_max_16u_get_func_desc(),
+                                       volk_32fc_index_max_16u_manual,
+                                       lv_cmake(1.0f, 1.0f),
+                                       lv_cmake(3.0f, 0.0f));
+    failures += sweep_kernel<uint32_t>("volk_32fc_index_max_32u",
+                                       volk_32fc_index_max_32u_get_func_desc(),
+                                       volk_32fc_index_max_32u_manual,
+                                       lv_cmake(1.0f, 1.0f),
+                                       lv_cmake(3.0f, 0.0f));
+    failures += sweep_kernel<uint16_t>("volk_32fc_index_min_16u",
+                                       volk_32fc_index_min_16u_get_func_desc(),
+                                       volk_32fc_index_min_16u_manual,
+                                       lv_cmake(3.0f, 0.0f),
+                                       lv_cmake(1.0f, 0.0f));
+    failures += sweep_kernel<uint32_t>("volk_32fc_index_min_32u",
+                                       volk_32fc_index_min_32u_get_func_desc(),
+                                       volk_32fc_index_min_32u_manual,
+                                       lv_cmake(3.0f, 0.0f),
+                                       lv_cmake(1.0f, 0.0f));
+
+    std::printf("qa_index_tie_sweep: %d failing checks\n", failures);
+    return failures ? 1 : 0;
+}

--- a/lib/qa_index_tie_sweep.cc
+++ b/lib/qa_index_tie_sweep.cc
@@ -23,8 +23,27 @@
 #include <volk/volk_alloc.hh>
 
 #include <cstdio>
+#include <cstring>
 
 namespace {
+
+// Coverage floor: on avx2-capable hardware the avx2 impls must actually be in
+// the swept list — otherwise a dispatch/machine-table regression could
+// silently drop the 16 reduce sites this test exists to protect while the
+// sweep stays green on the remaining impls. Keyed to the HARDWARE capability
+// (the runtime machine name is not usable: an avx512 box selects e.g.
+// avx512f_64_mmx_orc, which does not contain "avx2" yet carries the avx2
+// impls). Armed only where the probe exists (GCC/Clang x86); elsewhere the
+// per-arch summary lines keep coverage visible.
+bool hw_has_avx2()
+{
+#if (defined(__GNUC__) || defined(__clang__)) && \
+    (defined(__x86_64__) || defined(__i386__))
+    return __builtin_cpu_supports("avx2");
+#else
+    return false;
+#endif
+}
 
 // 8: the issue's repro width (one avx2 block). 32: two avx512 blocks, four
 // avx2 blocks, no tail. 37: forces a scalar tail on every SIMD width, so
@@ -51,6 +70,15 @@ int sweep_kernel(const char* kernel_name,
     // fail-closed condition here.
     if (desc.n_impls == 0) {
         std::printf("%s: FAIL (empty arch list)\n", kernel_name);
+        return 1;
+    }
+    bool list_has_avx2 = false;
+    for (size_t i = 0; i < desc.n_impls && !list_has_avx2; ++i)
+        list_has_avx2 = (std::strstr(desc.impl_names[i], "avx2") != NULL);
+    if (hw_has_avx2() && !list_has_avx2) {
+        std::printf("%s: FAIL (avx2-capable host but no avx2 impl in the arch "
+                    "list — the sites #195 protects are not being swept)\n",
+                    kernel_name);
         return 1;
     }
 

--- a/lib/qa_index_tie_sweep.cc
+++ b/lib/qa_index_tie_sweep.cc
@@ -23,7 +23,6 @@
 #include <volk/volk_alloc.hh>
 
 #include <cstdio>
-#include <cstring>
 
 namespace {
 
@@ -31,14 +30,11 @@ namespace {
 // avx2 blocks, no tail. 37: forces a scalar tail on every SIMD width, so
 // vector-region-vs-tail ties are swept too.
 const unsigned kVlens[] = { 8, 32, 37 };
-
-unsigned pairs_per_arch()
-{
-    unsigned pairs = 0;
-    for (unsigned vlen : kVlens)
-        pairs += vlen * (vlen - 1) / 2;
-    return pairs;
-}
+// Independent expected count: C(8,2) + C(32,2) + C(37,2). Deliberately NOT
+// derived from kVlens — the coverage check below compares the swept total
+// against this constant, so an edit that silently shrinks the sweep (or a
+// pair-enumeration bug) fails loudly instead of re-deriving itself green.
+const unsigned kExpectedPairsPerArch = 1190;
 
 template <typename TargetT, typename ManualF>
 int sweep_kernel(const char* kernel_name,
@@ -48,14 +44,13 @@ int sweep_kernel(const char* kernel_name,
                  lv_32fc_t extremum)
 {
     // impl_names from the runtime-selected machine are runnable by
-    // construction.
-    bool have_generic = false;
-    for (size_t i = 0; i < desc.n_impls && !have_generic; ++i)
-        have_generic = (std::strcmp(desc.impl_names[i], "generic") == 0);
-    if (!have_generic) {
-        std::printf("%s: FAIL (generic missing from arch list, %zu archs)\n",
-                    kernel_name,
-                    desc.n_impls);
+    // construction. The assertion below is analytic (== first tied index), so
+    // no reference impl is required — but an empty list would pass vacuously,
+    // and under VOLK_STATIC_DISPATCH the list legitimately shrinks to the
+    // pinned machine's impls (no "generic" entry), so emptiness is the only
+    // fail-closed condition here.
+    if (desc.n_impls == 0) {
+        std::printf("%s: FAIL (empty arch list)\n", kernel_name);
         return 1;
     }
 
@@ -104,11 +99,11 @@ int sweep_kernel(const char* kernel_name,
         total_failures += arch_failures;
         total_pairs += arch_pairs;
     }
-    if (total_pairs != desc.n_impls * pairs_per_arch()) {
+    if (total_pairs != desc.n_impls * kExpectedPairsPerArch) {
         std::printf("%s: FAIL (coverage: swept %u pairs, expected %zu)\n",
                     kernel_name,
                     total_pairs,
-                    desc.n_impls * pairs_per_arch());
+                    desc.n_impls * kExpectedPairsPerArch);
         return total_failures + 1;
     }
     return total_failures;

--- a/lib/qa_index_tie_sweep.cc
+++ b/lib/qa_index_tie_sweep.cc
@@ -27,19 +27,33 @@
 
 namespace {
 
-// Coverage floor: on avx2-capable hardware the avx2 impls must actually be in
-// the swept list — otherwise a dispatch/machine-table regression could
-// silently drop the 16 reduce sites this test exists to protect while the
-// sweep stays green on the remaining impls. Keyed to the HARDWARE capability
-// (the runtime machine name is not usable: an avx512 box selects e.g.
-// avx512f_64_mmx_orc, which does not contain "avx2" yet carries the avx2
-// impls). Armed only where the probe exists (GCC/Clang x86); elsewhere the
-// per-arch summary lines keep coverage visible.
+// Coverage floor: on avx2-capable hardware, in a build whose machine table
+// carries avx2, the avx2 impls must actually be in the swept list — otherwise
+// a runtime dispatch/machine-selection regression could silently drop the 16
+// reduce sites this test exists to protect while the sweep stays green on the
+// remaining impls. BOTH keys are load-bearing:
+//  - hardware capability, not the runtime machine NAME (an avx512 box selects
+//    e.g. avx512f_64_mmx_orc — no "avx2" substring — yet carries avx2 impls);
+//  - the build's expectation (VOLK_TIE_SWEEP_EXPECT_AVX2, set by CMake from
+//    available_machines), because the arch list is a property of the BUILD:
+//    hardware alone would false-red VOLK_STATIC_DISPATCH=generic on avx2 CI
+//    runners. Build-level LOSS of avx2 machines disarms the floor by design —
+//    that shape is visible in the configure log's "Available machines:" line.
+// The hardware probe is armed only where it exists (GCC/Clang x86).
 bool hw_has_avx2()
 {
 #if (defined(__GNUC__) || defined(__clang__)) && \
     (defined(__x86_64__) || defined(__i386__))
     return __builtin_cpu_supports("avx2");
+#else
+    return false;
+#endif
+}
+
+bool build_expects_avx2()
+{
+#ifdef VOLK_TIE_SWEEP_EXPECT_AVX2
+    return true;
 #else
     return false;
 #endif
@@ -75,7 +89,7 @@ int sweep_kernel(const char* kernel_name,
     bool list_has_avx2 = false;
     for (size_t i = 0; i < desc.n_impls && !list_has_avx2; ++i)
         list_has_avx2 = (std::strstr(desc.impl_names[i], "avx2") != NULL);
-    if (hw_has_avx2() && !list_has_avx2) {
+    if (hw_has_avx2() && build_expects_avx2() && !list_has_avx2) {
         std::printf("%s: FAIL (avx2-capable host but no avx2 impl in the arch "
                     "list — the sites #195 protects are not being swept)\n",
                     kernel_name);


### PR DESCRIPTION
## Summary

All four avx2 variants (`u_/a_` × `variant_0/1`) of `volk_32fc_index_max_16u`,
`volk_32fc_index_max_32u`, `volk_32fc_index_min_16u`, and
`volk_32fc_index_min_32u` violated the documented first-index-wins tie-break:
on an equal-|z|² tie spanning SIMD lanes they returned a LATER index (repro:
vlen 8, tie at {2,4} → avx2 returns 4; generic/a_sse3/a_avx512f return 2). The
per-lane vector updates were already strict-compare-correct; the defect was
confined to the final 8-slot horizontal reduce, which scans a buffer holding
interleaved memory indices `[0,1,4,5,2,3,6,7]` with a bare strict `>`/`<`.
This PR applies the same reduce shape upstream `0478a465` used for avx512f and
#127 used for a_sse3 — replace on strictly-better, and on equal magnitude take
the smaller index — at all 16 sites (4 files × 4 avx2 variants), and closes
the harness gap that hid the bug: a new tie-position-sweeping ctest
(`qa_index_tie_sweep`) plants an equal-magnitude extremum pair at every
position pair (i, j) for vlens {8, 32, 37} and requires every available impl
to return i. Fixed-position tie edges (upstream's tie test, the correctness
sweep's complex edges) structurally cannot catch scan-order tie bugs — the
sweep can. Why now: found by the Fable verification gate during #127; the
avx2 variants were the last known tie-break violators in this kernel family.

Behavior change is observable ONLY on exact-tie inputs: the avx2 variants now
return the FIRST tied index, matching generic/sse3/avx512f/neon/rvv and the
documented convention. No perf claim is made and no benchmark plot is attached:
the delta is one extra compare per slot in the once-per-call 8-slot reduce —
the same shape #127 already landed in a_sse3 with no measurable cost.

## Related issues

Related: #195 (fork posture: issue stays open; evidence lands in issue
comments — deliberately NOT `Closes`)

## Testing

- Born-red proof (five rounds recorded; round 5 = the SHIPPING TU at
  a4ac3eb1): the sweep FAILS on the unfixed tree with exactly the 16
  (kernel × avx2-impl) pairs red, 372/1190 tie pairs each, and every other
  arch `ok` — proven in an ephemeral worktree at the baseline. Post-fix:
  32/32 (kernel, arch) lines `ok (0 failing of 1190 tie pairs)`. Both test
  guards are mutation-proven live: a dropped vlen trips the pair-count check,
  and a broken impl-name probe trips the avx2 coverage floor. The floor is
  keyed to BOTH the hardware capability and the build's machine table
  (VOLK_TIE_SWEEP_EXPECT_AVX2 from available_machines): a runtime dispatch
  regression cannot green the test vacuously, while a build whose arch list
  legitimately has no avx2 (the VOLK_STATIC_DISPATCH=generic CI lane on x86
  runners) stays green — proven on both halves at the shipping SHA.
- Brute-force parity vs generic (the #127 method): vlens 1..200 × 800 trials,
  integer re/im in {-2..2} (tie-heavy), seeds pinned per (vlen, trial).
  Pre-fix: 105862/160000 (max) and 81764/160000 (min) mismatches per avx2
  impl, 1,501,008 total. Post-fix: 0/160000 for all 16.
- Audit of all 48 reduce sites (12 impls × 4 kernels): only the 16 avx2 sites
  were scan-order-broken; sse3 (#127), avx512f (0478a465), neon, neonv8,
  rvv/rvvseg verified first-index-correct by read — and rvv/rvvseg also by
  EXECUTION under qemu (VLEN 128 and 256, CI's exact cpu string): all green.
- Full suites AT THE SHIPPING SHA a4ac3eb1: Release 258/258 and the in-tree
  ASAN build type (`-DCMAKE_BUILD_TYPE=ASAN`, ASan+UBSan) 259/259 including
  `qa_index_tie_sweep` and `qa_strict_misaligned_canary`. The step-13 analyze
  family (Debug+injected-flag ASan/TSan/UBSan legs each 258/258, scan-build,
  compiler warnings — all clean) ran at 0d21d81a; the delta from there to the
  tip is confined to the test TU, its CMake registration lines, and the
  harness README (kernel headers are byte-identical), and the tip-level runs
  above cover that TU. (cpplint's 22
  novel findings are 80-col/brace-style rules that conflict with the
  project's clang-format authority; clang-format is clean.)
- Sweep coverage boundaries (deliberate): `u_` variants are swept on aligned
  buffers only (misaligned execution coverage is the #91/#162 machinery);
  vlens {8,32,37} do not express the num_points 0/1 edges; sentinel edges
  (all-zero max input, |z|² at FLT_MAX, NaN) were hand-verified inert rather
  than swept. The 16-site duplication of the fix shape is deliberate
  precedent-matching (#127/0478a465 use the same in-file shape) to keep the
  diff revertable against upstream — a shared reduce helper is a possible
  upstream refactor, not this surgical PR.
- CI-watch notes: (a) Windows lane test count increases by 1 (new ctest);
  (b) native ARM lanes (`ubuntu-*-arm`) will execute the sweep on neon/neonv8
  on hardware — the audit predicts green; (c) the rvv workflow lane runs zero
  ctests (ENABLE_TESTING is force-off for cross builds — `CMakeLists.txt:111`),
  so rvv enforcement is the qemu evidence above, not CI; noted as a follow-up
  candidate.

## Evidence

suite: none @ a4ac3eb196c7f27962713a94354bb6d67c66c227
files: 7 changed

## Checklist
- [x] Builds cleanly (`cmake --build`)
- [x] Tests pass (`ctest`)
- [x] Commits are signed off (`git commit -s`)
- [x] PR does one thing — no unrelated changes mixed in
